### PR TITLE
Removed Infinispan

### DIFF
--- a/hibernate-ogm-documentation/examples/gettingstarted/pom.xml
+++ b/hibernate-ogm-documentation/examples/gettingstarted/pom.xml
@@ -24,11 +24,6 @@
 			<version>3.12.1.GA</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-core</artifactId>
-			<version>5.0.0.CR1</version>
-		</dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/hibernate-ogm-documentation/manual/src/main/docbook/en-US/modules/getting-started.xml
+++ b/hibernate-ogm-documentation/manual/src/main/docbook/en-US/modules/getting-started.xml
@@ -127,11 +127,6 @@ public class Breed {
         &lt;scope&gt;compile&lt;/scope&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
-        &lt;groupId&gt;org.infinispan&lt;/groupId&gt;
-        &lt;artifactId&gt;infinispan-core&lt;/artifactId&gt;
-        &lt;version&gt;5.0.0.CR1&lt;/version&gt;
-    &lt;/dependency&gt;
-    &lt;dependency&gt;
         &lt;groupId&gt;org.slf4j&lt;/groupId&gt;
         &lt;artifactId&gt;slf4j-log4j12&lt;/artifactId&gt;
         &lt;version&gt;1.6.1&lt;/version&gt;


### PR DESCRIPTION
As Emmanuel pointed out in pull request #7, Infinispan doesn't need to be explicitly listed in maven dependencies when OGM is there. For some reason, I left it there while trying to get the correct setup. 
