### PR TITLE
Instantiate dialect from the hibernate.dialect property

### DIFF
--- a/hibernate-ogm-core/src/main/java/org/hibernate/ogm/dialect/OgmDialectFactoryInitiator.java
+++ b/hibernate-ogm-core/src/main/java/org/hibernate/ogm/dialect/OgmDialectFactoryInitiator.java
@@ -45,8 +45,23 @@ public class OgmDialectFactoryInitiator implements BasicServiceInitiator<Dialect
 	}
 
 	private static class NoopDialectFactory implements DialectFactory {
+
+		@SuppressWarnings("unchecked")
 		@Override
 		public Dialect buildDialect(Map configValues, Connection connection) throws HibernateException {
+			if (configValues.containsKey("hibernate.dialect")) {
+				Class<? extends Dialect> cl;
+				try {
+					cl = (Class<? extends Dialect>) Class.forName(configValues.get("hibernate.dialect").toString());
+					return cl.newInstance();
+				} catch (ClassNotFoundException e) {
+					e.printStackTrace();
+				} catch (InstantiationException e) {
+					e.printStackTrace();
+				} catch (IllegalAccessException e) {
+					e.printStackTrace();
+				}
+			}
 			return new NoopDialect();
 		}
 	}


### PR DESCRIPTION
Previously dialect used wwas only NoopDialect now it tries to instantiate the dialect from the hibernate.dialect property.
If something goes wrong a NoopDialect instance is returned.
