### PR TITLE
OGM-144: Make where to store associations in MongoDB configurable

### DIFF
--- a/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/Environment.java
+++ b/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/Environment.java
@@ -54,4 +54,13 @@ public interface Environment {
 	*/
 	public static final int MONGODB_DEFAULT_PORT = 27017;
 
+	/**
+	 * Where to store associations.
+	 */
+
+	public static final String MONGODB_ASSOCIATIONS_STORE = "hibernate.ogm.mongodb.associations.store";
+	public static final String ASSOC_STORE_GLOBAL = "global";
+	public static final String ASSOC_STORE_ENTITY = "entity";
+	public static final String ASSOC_STORE_PREFIXED = "prefixed";
+	public static final String MONGODB_DEFAULT_ASSOCIATION_STORE = "Associations";
 }

--- a/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBDatastoreProvider.java
+++ b/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBDatastoreProvider.java
@@ -49,10 +49,30 @@ public class MongoDBDatastoreProvider implements DatastoreProvider, Startable, S
 	private boolean isCacheStarted;
 	private Mongo mongo;
 	private DB mongoDb;
+	private AssociationStorage assocStorage;
+
+	public enum AssociationStorage {
+		GLOBAL, ENTITY, PREFIXED
+	}
 
 	@Override
 	public void configure(Map configurationValues) {
 		cfg = configurationValues;
+		
+		String assocStoreString = (String) cfg.get( Environment.MONGODB_ASSOCIATIONS_STORE );
+		if ( assocStoreString != null && assocStoreString.equalsIgnoreCase( Environment.ASSOC_STORE_GLOBAL ) ) {
+			assocStorage = AssociationStorage.GLOBAL;
+		}
+		else if ( assocStoreString != null && assocStoreString.equalsIgnoreCase( Environment.ASSOC_STORE_ENTITY ) ) {
+			assocStorage = AssociationStorage.ENTITY;
+		}
+		else {
+			assocStorage = AssociationStorage.PREFIXED;
+		}
+	}
+
+	public AssociationStorage getAssociationStorage() {
+		return assocStorage;
 	}
 
 	@Override

--- a/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/dialect/mongodb/MongoHelpers.java
+++ b/hibernate-ogm-mongodb/src/main/java/org/hibernate/ogm/dialect/mongodb/MongoHelpers.java
@@ -20,6 +20,7 @@
  */
 package org.hibernate.ogm.dialect.mongodb;
 
+import org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider.AssociationStorage;
 import org.hibernate.ogm.grid.AssociationKey;
 
 import com.mongodb.BasicDBObject;
@@ -30,7 +31,8 @@ import com.mongodb.DBObject;
  */
 public class MongoHelpers {
 
-	public static DBObject associationKeyToObject(AssociationKey key) {
+	public static DBObject associationKeyToObject(AssociationStorage storage,
+			AssociationKey key) {
 		Object[] columnValues = key.getColumnValues();
 		DBObject columns = new BasicDBObject( columnValues.length );
 
@@ -41,6 +43,9 @@ public class MongoHelpers {
 
 		DBObject obj = new BasicDBObject( 1 );
 		obj.put( MongoDBDialect.COLUMNS_FIELDNAME, columns );
+		
+		if (storage == AssociationStorage.GLOBAL)
+			obj.put( MongoDBDialect.TABLE_FIELDNAME, key.getTable() );
 
 		return obj;
 	}

--- a/hibernate-ogm-mongodb/src/test/resources/hibernate.properties
+++ b/hibernate-ogm-mongodb/src/test/resources/hibernate.properties
@@ -24,3 +24,6 @@
 
 hibernate.ogm.datastore.provider = org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider
 hibernate.ogm.mongodb.database = ogm_test_database
+hibernate.ogm.mongodb.associations.store = prefixed
+#hibernate.ogm.mongodb.associations.store = global
+#hibernate.ogm.mongodb.associations.store = entity


### PR DESCRIPTION
OGM-144

This allows configuration of the different modes for storing associations as a property.

1) prefixed - associatons_Entity
2) global - one global associations collection
3) entity - inside the entity collection, at the same level as the entities.

Prefixed remains the default. I need to add unit tests for the other two modes (actually probably the same test, but different properties).
