### PR TITLE
OGM-181 Rework EntityKeyBuilder (Remove a method called 'getColumnMap')

### DIFF
--- a/hibernate-ogm-voldemort/pom.xml
+++ b/hibernate-ogm-voldemort/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ Copyright (c) 2010-2011, Red Hat, Inc. and/or its affiliates or third-party contributors as
+  ~ indicated by the @author tags or express copyright attribution
+  ~ statements applied by the authors.  All third-party contributions are
+  ~ distributed under license by Red Hat, Inc.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use, modify,
+  ~ copy, or redistribute it subject to the terms and conditions of the GNU
+  ~ Lesser General Public License, as published by the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.ogm</groupId>
+        <artifactId>hibernate-ogm-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-ogm-voldemort</artifactId>
+    <packaging>jar</packaging>
+
+    <name>OGM-181 Rework EntityKeyBuilder (Remove a method called "getColumnMap")</name>
+    <description>OGM-181 Rework EntityKeyBuilder (Remove a method called "getColumnMap")</description>
+    
+      <dependencies>
+        <!-- AnnotationFinder dependency -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <!-- AnnotationFinder dependency end -->
+
+        <dependency>
+            <groupId>org.hibernate.ogm</groupId>
+            <artifactId>hibernate-ogm-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.ogm</groupId>
+            <artifactId>hibernate-ogm-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- this is optional on core :( and needed for testing -->
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.jbossts</groupId>
+            <artifactId>jbossjta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/AbstractFinder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/AbstractFinder.java
@@ -1,0 +1,79 @@
+package org.hibernate.ogm.helper.annotation;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class AbstractFinder implements Finder {
+	/**
+	 * Extracts column name from @Column(name='xxx').
+	 * 
+	 * @param annotationStr
+	 *            @Column representation as String.
+	 * @param pattern
+	 *            Pattern for the name property in @Column annotation.
+	 * @return Column name.
+	 */
+	protected String extractColumnNameFrom(String annotationStr, Pattern pattern) {
+
+		Matcher matcher = pattern.matcher( annotationStr );
+		String columnName = "";
+		while ( matcher.find() ) {
+			columnName = matcher.group().split( "=" )[1];
+		}
+
+		return columnName;
+	}
+	
+	protected String findFieldNameFor(String methodName, Field[] fields) {
+		
+		Pattern pattern = null;
+		if(methodName.startsWith( "get" )){
+			pattern = Pattern.compile( "^" + methodName.substring( 3 ) + "$", Pattern.CASE_INSENSITIVE );
+		}else if(methodName.startsWith( "is" )){
+			pattern = Pattern.compile( "^" + methodName.substring( 2 ) + "$", Pattern.CASE_INSENSITIVE );
+		}
+		//Pattern pattern = Pattern.compile( "^" + methodName.substring( 3 ) + "$", Pattern.CASE_INSENSITIVE );
+		for ( Field field : fields ) {
+			Matcher matcher = pattern.matcher( field.getName() );
+			while ( matcher.find() ) {
+				return matcher.group();
+			}
+		}
+
+		return "";
+	}
+	
+	/**
+	 * Copied from AnnotationFinder. Gets inherited method.
+	 * 
+	 * @param obj
+	 *            Object to be examined.
+	 * @param methodName
+	 *            Method name to be used to narrow.
+	 * @return Method whose name equals to the parameter, methodName.
+	 */
+	protected Method getInheritedMethod(Object obj, String methodName) {
+
+		Class cl = obj.getClass();
+		Method[] methods = cl.getDeclaredMethods();
+		Method method = null;
+		int i = 0;
+		for ( ; i < methods.length; i++ ) {
+			if ( methods[i].getName().equals( methodName ) ) {
+				method = methods[i];
+				break;
+			}
+			else {
+				if ( i == ( methods.length - 1 ) && method == null ) {
+					cl = cl.getSuperclass();
+					methods = cl.getDeclaredMethods();
+					i = -1;
+				}
+			}
+		}
+
+		return method;
+	}
+}

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/AnnotationFinder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/AnnotationFinder.java
@@ -1,0 +1,453 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.ogm.helper.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hibernate.ogm.helper.annotation.impl.ColumnFinder;
+import org.hibernate.ogm.helper.annotation.impl.IdFinder;
+import org.hibernate.ogm.helper.annotation.impl.JoinColumnFinder;
+
+/**
+ * @author Seiya Kawashima <skawashima@uchicago.edu>
+ */
+public class AnnotationFinder {
+
+	private static final String JPA_ANNOTATION_PREFIX = "^@javax.persistence.";
+	private static final String EMBEDDABLE = "Embeddable";
+	private static final String ENTITY = "Entity";
+	private static final String PUNCT = "\\p{Punct}";
+	private final Pattern embeddableAnnotationPattern = Pattern.compile( JPA_ANNOTATION_PREFIX + EMBEDDABLE + PUNCT );
+	private final Pattern entityAnnotationPattern = Pattern.compile( JPA_ANNOTATION_PREFIX + ENTITY +  PUNCT);
+	private final String GET_DECLARED_ANNOTATIONS = "getDeclaredAnnotations";
+	private final String GET_TYPE = "getType";
+	private final String GET_DECLARED_FIELDS = "getDeclaredFields";
+	private final String GET_RETURN_TYPE = "getReturnType";
+	private final String GET_DECLARED_METHODS = "getDeclaredMethods";
+	private final String GET_NAME = "getName";
+	private final Finder columnFinder = new ColumnFinder();
+	private final Finder joinColumnFinder = new JoinColumnFinder();
+	private final Finder idFinder = new IdFinder();
+	
+	/**
+	 * Checks if a Class is annotated by @Embeddable or not.
+	 * @param cls Class to be examined.
+	 * @return True if the Class is annotated by @Embeddable, otherwise false.
+	 */
+	public boolean isEmbeddableAnnotated(Class cls) {
+
+		return cls == null ? false : isAnnotatedBy( cls.getDeclaredAnnotations() , embeddableAnnotationPattern);
+	}
+
+	/**
+	 * Checks if a Class is annotated by @Entity or not.
+	 * @param cls Class to be examined.
+	 * @return True if the Class is annotated by @Entity, otherwise false.
+	 */
+	public boolean isEntityAnnotated(Class cls) {
+
+		return cls == null ? false : isAnnotatedBy( cls.getDeclaredAnnotations(), entityAnnotationPattern );
+	}
+	
+	/**
+	 * Checks if Annotation array has a pattern.
+	 * @param annotations Annotation array to be examined.
+	 * @param pattern Pattern to be checked against Annotation array.
+	 * @return True if one of the elements in Annotation array has the pattern, otherwise false.
+	 */
+	private boolean isAnnotatedBy(Annotation[] annotations, Pattern pattern) {
+
+		for ( Annotation annotation : annotations ) {
+			Matcher matcher = pattern.matcher( annotation.toString() );
+			while(matcher.find()){
+				return true;
+			}
+		}
+
+		return false;
+	}
+	
+	/**
+	 * Finds all @Column annotations on fields and methods from the parameter, cls. The method searches for the
+	 * annotation on every field and method. If the parameter, fieldName is specified, then the method only searches @Column
+	 * annotation on the corresponding field and method to the name.
+	 * 
+	 * @param cls
+	 *            Where the search starts.
+	 * @param fieldName
+	 *            Constraint for the search.
+	 * @return Mapping information for @Column annotation having column name and the class.
+	 */
+	public Map<String, Class> findAllColumnNamesFrom(Class cls, String fieldName, boolean fast) {
+
+		if ( isNull( cls ) ) {
+			return Collections.EMPTY_MAP;
+		}
+
+		Map<String, Class> columnMap = new HashMap<String, Class>();
+		findFieldColumns( cls, fieldName, columnMap ,fast);
+		findMethodColumns( cls, fieldName, columnMap , fast );
+		return columnMap;
+	}
+	
+	public Map<String, Class> findAllJoinColumnNamesFrom(Class cls, String fieldName, boolean fast) {
+
+		if ( isNull( cls ) ) {
+			return Collections.EMPTY_MAP;
+		}
+
+		Map<String, Class> columnMap = new HashMap<String, Class>();
+		findFieldJoinColumns( cls, fieldName, columnMap, fast );
+		findMethodJoinColumns( cls, fieldName, columnMap, fast );
+		return columnMap;
+	}
+	
+	public Map<String,Class> findAllIdsFrom(Class cls,String fieldName,boolean fast){
+		if ( isNull( cls ) ) {
+			return Collections.EMPTY_MAP;
+		}
+		Map<String, Class> columnMap = new HashMap<String, Class>();
+		findFieldIds( cls, fieldName, columnMap, fast );
+		findMethodIds( cls, fieldName, columnMap, fast );
+		return columnMap;
+		
+	}
+	
+	/**
+	 * 
+	 * @param cls
+	 * @param fieldName
+	 * @param columnMap
+	 * @param fast
+	 * @return
+	 */
+	public Map<String,Class> findFieldColumns(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast){
+		
+		return findFieldAnnotations(cls,fieldName,columnMap,
+				fast,columnFinder);
+	}
+	
+	/**
+	 * 
+	 * @param cls
+	 * @param fieldName
+	 * @param columnMap
+	 * @param fast
+	 * @return
+	 */
+	public Map<String, Class> findFieldJoinColumns(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast) {
+		return findFieldAnnotations( cls, fieldName, columnMap, fast, joinColumnFinder );
+	}
+	
+	public Map<String, Class> findFieldIds(Class cls, String fieldName, Map<String, Class> columnMap, boolean fast) {
+		return findFieldAnnotations( cls, fieldName, columnMap, fast, idFinder );
+	}
+	
+	/**
+	 * Finds fields equal to the parameter, fieldName, annotated by @Column
+	 * 
+	 * @param cls
+	 *            Class to be examined.
+	 * @param fieldName
+	 *            Field name to be checked against each field in Class.
+	 * @param columnMap
+	 *            Store found @Column as map. The key is column name specified in @Column and the value is Class
+	 *            represented by the field.
+	 * @return columnMap.
+	 */
+	private Map<String, Class> findFieldAnnotations(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast, Finder finder) {
+
+		if ( isNull( cls ) ) {
+			return Collections.EMPTY_MAP;
+		}
+
+		int size = cls.getDeclaredFields().length;
+		List fields = new ArrayList( Arrays.asList( cls.getDeclaredFields() ) );
+		String columnName = "";
+		if ( fieldName != null && !fieldName.equals( "" ) ) {
+			Pattern pattern = Pattern.compile( "^" + fieldName + "$", Pattern.CASE_INSENSITIVE );
+			for ( int i = 0; i < fields.size(); i++ ) {
+				addTo( i, fields, columnName, columnMap, pattern, GET_TYPE, GET_DECLARED_FIELDS, finder );
+
+				if ( fast && i == ( size - 1 ) ) {
+					break;
+				}
+			}
+		}
+		else {
+			for ( int i = 0; i < fields.size(); i++ ) {
+				addTo( i, fields, columnName, columnMap, null, GET_TYPE, GET_DECLARED_FIELDS, finder );
+
+				if ( fast && i == ( size - 1 ) ) {
+					break;
+				}
+			}
+		}
+
+		return columnMap;
+	}
+	
+	/**
+	 * 
+	 * @param cls
+	 * @param fieldName
+	 * @param columnMap
+	 * @param fast
+	 * @return
+	 */
+	public Map<String,Class> findMethodColumns(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast){
+		
+		return findMethodAnnotations(cls,fieldName,columnMap,
+				fast,columnFinder);
+	}
+	
+	/**
+	 * 
+	 * @param cls
+	 * @param fieldName
+	 * @param columnMap
+	 * @param fast
+	 * @return
+	 */
+	public Map<String, Class> findMethodJoinColumns(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast) {
+		return findMethodAnnotations( cls, fieldName, columnMap, fast, joinColumnFinder );
+	}
+	
+	public Map<String, Class> findMethodIds(Class cls, String fieldName, Map<String, Class> columnMap, boolean fast) {
+		return findMethodAnnotations( cls, fieldName, columnMap, fast, idFinder );
+	}
+	
+	/**
+	 * Finds methods containing the parameter, fieldName, annotated by @Column
+	 * 
+	 * @param cls
+	 *            Class to be examined.
+	 * @param fieldName
+	 *            Field name to be checked against each method in Class.
+	 * @param columnMap
+	 *            Store found @Column as map. The key is column name specified in @Column and the value is Class
+	 *            represented by the field.
+	 * @return columnMap.
+	 */
+	private Map<String, Class> findMethodAnnotations(Class cls, String fieldName, Map<String, Class> columnMap,
+			boolean fast, Finder finder) {
+
+		if ( isNull( cls ) ) {
+			return Collections.EMPTY_MAP;
+		}
+
+		int size = cls.getDeclaredMethods().length;
+		List methods = new ArrayList( Arrays.asList( cls.getDeclaredMethods() ) );
+		String columnName = "";
+
+		if ( fieldName != null && !fieldName.equals( "" ) ) {
+			Pattern pattern = Pattern.compile( "^(get|is)\\w*" + fieldName + "$", Pattern.CASE_INSENSITIVE );
+			for ( int i = 0; i < methods.size(); i++ ) {
+				addTo( i, methods, columnName, columnMap, pattern, GET_RETURN_TYPE, GET_DECLARED_METHODS, finder );
+
+				if ( fast && i == ( size - 1 ) ) {
+					break;
+				}
+			}
+		}
+		else {
+			for ( int i = 0; i < methods.size(); i++ ) {
+				addTo( i, methods, columnName, columnMap, null, GET_RETURN_TYPE, GET_DECLARED_METHODS, finder );
+
+				if ( fast && i == ( size - 1 ) ) {
+					break;
+				}
+			}
+		}
+
+		return columnMap;
+	}
+
+	/**
+	 * Checks if the parameter, str has the parameter, pattern.
+	 * 
+	 * @param str
+	 *            String to be examined.
+	 * @param pattern
+	 *            Used to check the parameter, str.
+	 * @return True if patter is included.
+	 */
+	private boolean hasPattern(String str, Pattern pattern) {
+
+		Matcher matcher = pattern.matcher( str );
+		while ( matcher.find() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Finds field annotated by @Column in List and adds it to the map, Map<String,Class>.
+	 * 
+	 * @param index
+	 *            Index in the List.
+	 * @param list
+	 *            Stores Field or Method.
+	 * @param columnName
+	 *            Used to check against every field or method name if the parameter is specified. If the parameter is
+	 *            null or ''
+	 *            then,
+	 *            all the fields or methods are picked up by the method instead of only fields or methods that have the
+	 *            specified name.
+	 * @param columnMap
+	 *            Store found field data as Map<String,Class>.
+	 * @param pattern
+	 *            Constraint for the search.
+	 * @param typeMethod
+	 *            Method to get the next candidate class, Field.getType() or Method.getReturnType().
+	 * @param fieldOrMethodGetter
+	 *            Method to get the next candidate fields or methods, Class.getDeclaredFields() or
+	 *            Class.getDeclaredMethods().
+	 */
+	private void addTo(int index, List list, String columnName, Map<String, Class> columnMap, Pattern pattern,
+			String typeMethod, String fieldOrMethodGetter, Finder finder) {
+		// TODO prepare for composite key support
+		try {
+			Object obj = list.get( index );
+
+			if ( pattern != null
+					&& !hasPattern( (String) obj.getClass().getDeclaredMethod( GET_NAME ).invoke( obj ), pattern ) ) {
+				columnName = null;
+			}
+			else if ( pattern == null
+					|| ( pattern != null && hasPattern(
+							(String) obj.getClass().getDeclaredMethod( GET_NAME ).invoke( obj ), pattern ) ) ) {
+				columnName = finder.findAnnotation( (Annotation[]) getInheritedMethod( obj, GET_DECLARED_ANNOTATIONS )
+						.invoke( obj ), obj );
+			}
+
+			Class cls = (Class) ( obj.getClass().getDeclaredMethod( typeMethod ).invoke( obj ) );
+			if ( columnName != null && !columnName.equals( "" ) ) {
+				columnMap.put( columnName, cls );
+			}
+
+			try {
+				list.addAll( Arrays.asList( addIfNotAlreadyExist( list,
+						(Object[]) cls.getDeclaredMethod( fieldOrMethodGetter ).invoke( cls ) ) ) );
+			}
+			catch ( NoSuchMethodException ex ) {
+				list.addAll( Arrays.asList( addIfNotAlreadyExist( list,
+						(Object[]) cls.getClass().getDeclaredMethod( fieldOrMethodGetter ).invoke( cls ) ) ) );
+			}
+		}
+		catch ( Throwable ex ) {
+			throw new RuntimeException( ex );
+		}
+	}
+
+	/**
+	 * Gets inherited method.
+	 * 
+	 * @param obj
+	 *            Object to be examined.
+	 * @param methodName
+	 *            Method name to be used to narrow.
+	 * @return Method whose name equals to the parameter, methodName.
+	 */
+	private Method getInheritedMethod(Object obj, String methodName) {
+
+		Class cl = obj.getClass();
+		Method[] methods = cl.getDeclaredMethods();
+		Method method = null;
+		int i = 0;
+		for ( ; i < methods.length; i++ ) {
+			if ( methods[i].getName().equals( methodName ) ) {
+				method = methods[i];
+				break;
+			}
+			else {
+				if ( i == ( methods.length - 1 ) && method == null ) {
+					cl = cl.getSuperclass();
+					methods = cl.getDeclaredMethods();
+					i = -1;
+				}
+			}
+		}
+
+		return method;
+	}
+
+	/**
+	 * Checks if a field or method is already contained in fields, the parameter. If there is, the field is not added,
+	 * otherwise added and is
+	 * examined for @Column annotation.
+	 * 
+	 * @param list
+	 *            List.
+	 * @param src
+	 *            Object array return by Class.getDeclaredFields() or Class.getDeclaredMethods().
+	 * @return Object array containing only unique fields or methods.
+	 */
+	private Object[] addIfNotAlreadyExist(List list, Object[] src) {
+
+		int duplicates = 0;
+		for ( Iterator itr = list.iterator(); itr.hasNext(); ) {
+			Object field = itr.next();
+			for ( int i = 0; i < src.length; i++ ) {
+				if ( field.equals( src[i] ) ) {
+					src[i] = null;
+					duplicates++;
+				}
+			}
+		}
+
+		Object[] uniqueFields = new Object[src.length - duplicates];
+		int index = 0;
+		for ( int i = 0; i < src.length; i++ ) {
+			if ( src[i] != null ) {
+				uniqueFields[index] = src[i];
+				index++;
+			}
+		}
+		return uniqueFields;
+	}
+
+	/**
+	 * Checks if an Object is null or not.
+	 * 
+	 * @param obj
+	 *            Examined if it's null or not.
+	 * @return True if it's not null, otherwise false.
+	 */
+	private boolean isNull(Object obj) {
+		return obj == null ? true : false;
+	}
+}

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/Finder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/Finder.java
@@ -1,0 +1,9 @@
+package org.hibernate.ogm.helper.annotation;
+
+import java.lang.annotation.Annotation;
+
+public interface Finder {
+	public String findAnnotation(Annotation[] annotations, Object obj);
+
+	public String findAnnotationBy(Annotation[] annotations, String ann, Object obj);
+}

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/ColumnFinder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/ColumnFinder.java
@@ -1,0 +1,34 @@
+package org.hibernate.ogm.helper.annotation.impl;
+
+import java.lang.annotation.Annotation;
+import java.util.regex.Pattern;
+
+import org.hibernate.ogm.helper.annotation.AbstractFinder;
+
+public class ColumnFinder extends AbstractFinder {
+
+	private final Pattern namePropertyPattern = Pattern.compile( "name\\p{Punct}\\w*" );
+	
+	/**
+	 * Finds column name from @Column annotation in Annotation array.
+	 * 
+	 * @param annotations
+	 *            Annotation array to be examined.
+	 * @return Column name from @Column annotation.
+	 */
+	public String findAnnotation(Annotation[] annotations, Object obj) {
+		return findAnnotationBy( annotations, "@javax.persistence.Column(", obj );
+	}
+
+	public String findAnnotationBy(Annotation[] annotations, String ann, Object obj) {
+		for ( Annotation annotation : annotations ) {
+			String annStr = annotation.toString();
+			if ( annStr.startsWith( ann ) ) {
+				return extractColumnNameFrom( annStr, namePropertyPattern );
+			}
+		}
+
+		return "";
+	}
+
+}

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/IdFinder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/IdFinder.java
@@ -1,0 +1,48 @@
+package org.hibernate.ogm.helper.annotation.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.hibernate.ogm.helper.annotation.AbstractFinder;
+
+public class IdFinder extends AbstractFinder {
+	
+	private final ColumnFinder columnFinder = new ColumnFinder();
+
+	public String findAnnotation(Annotation[] annotations, Object obj) {
+		return findAnnotationBy( annotations, "@javax.persistence.Id(", obj );
+	}
+
+	public String findAnnotationBy(Annotation[] annotations, String ann, Object obj) {
+		for ( Annotation annotation : annotations ) {
+			String annStr = annotation.toString();
+			if ( annStr.startsWith( ann ) ) {
+
+				try {
+					String name = "";
+					if ( obj instanceof Field ) {
+						name = columnFinder.findAnnotation(
+								(Annotation[]) getInheritedMethod( obj, "getDeclaredAnnotations" ).invoke( obj ), obj );
+						return name.equals( "" ) ? (String) obj.getClass().getDeclaredMethod( "getName" ).invoke( obj )
+								: name;
+					}
+					else if ( obj instanceof Method ) {
+						name = columnFinder.findAnnotation(
+								(Annotation[]) getInheritedMethod( obj, "getDeclaredAnnotations" ).invoke( obj ), obj );
+						return name.equals( "" ) ? findFieldNameFor(
+								(String) obj.getClass().getDeclaredMethod( "getName" ).invoke( obj ),
+								( (Class) obj.getClass().getDeclaredMethod( "getDeclaringClass" ).invoke( obj ) )
+										.getDeclaredFields() ) : name;
+					}
+				}
+				catch ( Throwable ex ) {
+					throw new RuntimeException( ex );
+				}
+			}
+		}
+
+		return "";
+	}
+
+}

--- a/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/JoinColumnFinder.java
+++ b/hibernate-ogm-voldemort/src/main/java/org/hibernate/ogm/helper/annotation/impl/JoinColumnFinder.java
@@ -1,0 +1,11 @@
+package org.hibernate.ogm.helper.annotation.impl;
+
+import java.lang.annotation.Annotation;
+
+public class JoinColumnFinder extends ColumnFinder {
+
+	@Override
+	public String findAnnotation(Annotation[] annotations, Object obj) {
+		return findAnnotationBy( annotations, "@javax.persistence.JoinColumn(", obj );
+	}
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Address.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Address.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.ogm.helper.annotation;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Embeddable
+public class Address {
+	public String getStreet1() { return street1; }
+	public void setStreet1(String street1) {  this.street1 = street1; }
+	private String street1;
+
+	public String getStreet2() { return street2; }
+	public void setStreet2(String street2) {  this.street2 = street2; }
+	private String street2;
+
+	public String getCity() { return city; }
+	public void setCity(String city) {  this.city = city; }
+	private String city;
+
+	@Column(name = "postal_code")
+	public String getZipCode() { return zipCode; }
+	public void setZipCode(String zipCode) {  this.zipCode = zipCode; }
+	private String zipCode;
+
+	public String getCountry() { return country; }
+	public void setCountry(String country) {  this.country = country; }
+	private String country;
+
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/AnnotationFinderTest.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/AnnotationFinderTest.java
@@ -1,0 +1,199 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.ogm.helper.annotation;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.ogm.helper.annotation.AnnotationFinder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Seiya Kawashima <skawashima@uchicago.edu>
+ */
+public class AnnotationFinderTest {
+
+	private AnnotationFinder finder;
+	private Job job;
+	private Person person;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		job = new Job();
+		person = new Person();
+		finder = new AnnotationFinder();
+	}
+
+	@Test
+	public void testIsEmbeddableAnnotated() {
+		assertTrue( finder.isEmbeddableAnnotated( job.getClass() ) );
+		assertFalse( finder.isEmbeddableAnnotated( person.getClass() ) );
+		assertFalse( finder.isEmbeddableAnnotated( getClass() ) );
+		assertFalse( finder.isEmbeddableAnnotated( null ) );
+	}
+
+	@Test
+	public void testFindFieldColumns() {
+		Map<String, Class> columnMap = new HashMap<String, Class>();
+		finder.findFieldColumns( job.getClass(), null, columnMap, false );
+		String columnType = columnMap.get( "summary" ).getCanonicalName();
+		assertEquals( "expecting 'java.lang.String' but found " + columnType, columnType, "java.lang.String" );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), null, columnMap, true );
+		assertNotNull( "expecting not null but found " + columnMap.get( "summary" ), columnMap.get( "summary" ) );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		columnMap.clear();
+		finder.findFieldColumns( person.getClass(), null, columnMap, false );
+		columnType = columnMap.get( "summary" ).getCanonicalName();
+		assertTrue( "expecting 'java.lang.String' but found " + columnType, columnType.equals( "java.lang.String" ) );
+		columnMap.clear();
+		finder.findFieldColumns( person.getClass(), null, columnMap, true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), "zipCode", columnMap, false );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), "zipCode", columnMap, true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), "name", columnMap, true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), "dummyFieldName", columnMap, false );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findFieldColumns( job.getClass(), "description", columnMap, true );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "summary" ), columnMap.get( "summary" ) );
+	}
+
+	@Test
+	public void testFindMethodColumns() {
+		Map<String, Class> columnMap = new HashMap<String, Class>();
+		finder.findMethodColumns( Job.class, null, columnMap, false );
+		String columnType = columnMap.get( "job_name" ).getCanonicalName();
+		assertTrue( "expecting size == 2 but found " + columnMap.size(), columnMap.size() == 2 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "job_name" ), columnMap.get( "job_name" ) );
+		assertNotNull( "expecting not null but found " + columnMap.get( "postal_code" ), columnMap.get( "postal_code" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Job.class, null, columnMap, true );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "job_name" ), columnMap.get( "job_name" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Address.class, "zipcode", columnMap, false );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "postal_code" ), columnMap.get( "postal_code" ) );
+		assertTrue( "expecting 'java.lang.String' but found " + columnMap.get( "postal_code" ).getCanonicalName(),
+				columnMap.get( "postal_code" ).getCanonicalName().equals( "java.lang.String" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Address.class, "zipcode", columnMap, true );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "postal_code" ), columnMap.get( "postal_code" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Person.class, "", columnMap, false );
+		assertTrue( "expecting size == 2 but found " + columnMap.size(), columnMap.size() == 2 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "job_name" ), columnMap.get( "job_name" ) );
+		assertNotNull( "expecting not null but found " + columnMap.get( "postal_code" ), columnMap.get( "postal_code" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Person.class, "", columnMap, true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findMethodColumns( Person.class, "name", columnMap, false );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "job_name" ), columnMap.get( "job_name" ) );
+		columnMap.clear();
+		finder.findMethodColumns( Person.class, "name", columnMap, true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap.clear();
+		finder.findMethodColumns( job.getClass(), "dummyMethodName", columnMap, false );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+	}
+
+	@Test
+	public void testFindAllColumnNamesFrom() {
+		checkColumnNameWith( finder.findAllColumnNamesFrom( job.getClass(), null, false ) );
+		checkColumnNameWith( finder.findAllColumnNamesFrom( person.getClass(), "", false ) );
+
+		Map<String, Class> columnMap = finder.findAllColumnNamesFrom( person.getClass(), "name", false );
+		assertEquals( columnMap.get( "job_name" ).getCanonicalName(), "java.lang.String" );
+		assertTrue( "expecting size == 1 but found " + columnMap.size(), columnMap.size() == 1 );
+
+		columnMap = finder.findAllColumnNamesFrom( person.getClass(), "dummy", false );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+
+		columnMap = finder.findAllColumnNamesFrom( job.getClass(), null, true );
+		assertTrue( "expecting size == 2 but found " + columnMap.size(), columnMap.size() == 2 );
+		assertNotNull( "expecting not null but found " + columnMap.get( "job_name" ), columnMap.get( "job_name" ) );
+		assertNotNull( "expecting not null but found " + columnMap.get( "summary" ), columnMap.get( "summary" ) );
+
+		columnMap = finder.findAllColumnNamesFrom( person.getClass(), "", true );
+		assertTrue( "expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+		columnMap = finder.findAllColumnNamesFrom( person.getClass(), "name", true );
+		assertTrue( "expecing size == 0 but found " + columnMap.size(), columnMap.isEmpty() );
+	}
+
+	private void checkColumnNameWith(Map<String, Class> columnMap) {
+		assertEquals( "expecting 'java.lang.String' but found " + columnMap.get( "job_name" ).getCanonicalName(),
+				columnMap.get( "job_name" ).getCanonicalName(), "java.lang.String" );
+		assertTrue( "expecting 'java.lang.String' but found " + columnMap.get( "summary" ).getCanonicalName(),
+				columnMap.get( "summary" ).getCanonicalName().equals( "java.lang.String" ) );
+		assertTrue( "expecting 'java.lang.String' but found " + columnMap.get( "postal_code" ).getCanonicalName(),
+				columnMap.get( "postal_code" ).getCanonicalName().equals( "java.lang.String" ) );
+		assertTrue( "expecting size == 3 but found " + columnMap.size() ,columnMap.size() == 3 );
+	}
+	
+	@Test
+	public void testFindAllJoinColumns(){
+		Map<String,Class> columnMap = finder.findAllJoinColumnNamesFrom(Person.class,null,true );
+		assertTrue("expecting size == 0 but found " + columnMap.size(),columnMap.isEmpty());
+		columnMap = finder.findAllJoinColumnNamesFrom( Person.class, "", false );
+		assertTrue("expecting size == 0 but found " + columnMap.size(), columnMap.isEmpty());
+		columnMap = finder.findAllJoinColumnNamesFrom( Beer.class, null, true );
+		assertTrue("expecting size == 1 but found " + columnMap.size(),columnMap.size() == 1);
+		assertNotNull("expecting not null but found " + columnMap.get( "brewery_id" ),columnMap.get( "brewery_id" ));
+		columnMap = finder.findAllJoinColumnNamesFrom( Brewery.class, "", false );
+		assertTrue("expecting size == 2 but found " + columnMap.size(),columnMap.size() == 1);
+		assertNotNull("expecting not null but found " + columnMap.get( "brewery_id" ),columnMap.get( "brewery_id" ));
+	}
+	
+	@Test
+	public void testFindAllIds() {
+		Map<String, Class> ids = finder.findAllIdsFrom( Person.class, null, true );
+		assertTrue( "expecting size == 1 but found " + ids.size(), ids.size() == 1 );
+		assertNotNull( "expecting not null but found " + ids.get( "id" ), ids.get( "id" ) );
+		ids = finder.findAllIdsFrom( Person.class, "id", true );
+		assertTrue( "expecting size == 1 but found " + ids.size(), ids.size() == 1 );
+		assertNotNull( "expecting not null but found " + ids.get( "id" ), ids.get( "id" ) );
+		ids = finder.findAllIdsFrom( Phone.class, "", true );
+		assertTrue( "expecting size == 1 but found " + ids.size(), ids.size() == 1 );
+		assertNotNull( "expecting not null but found " + ids.get( "p_id" ), ids.get( "p_id" ) );
+		ids = finder.findAllIdsFrom( Beer.class, "", false );
+		assertTrue( "edxpecting size == 2 but found " + ids.size(), ids.size() == 2 );
+		assertNotNull( "expecting not null but found " + ids.get( "beer_pk" ), ids.get( "beer_pk" ) );
+		assertNotNull( "expecting not null but found " + ids.get( "brewery_pk" ), ids.get( "brewery_pk" ) );
+	}
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Beer.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Beer.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.ogm.helper.annotation;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.GenericGenerator;
+
+/**
+ * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ */
+@Entity
+public class Beer {
+	@Id
+	@GeneratedValue(generator = "uuid") @GenericGenerator( name="uuid", strategy = "uuid2")
+	@Column(name = "beer_pk")
+	public String getId() { return id; }
+	public void setId(String id) {  this.id = id; }
+	private String id;
+
+	@ManyToOne @JoinColumn(insertable = false, updatable = false, name = "brewery_id")
+	public Brewery getBrewery() { return brewery; }
+	public void setBrewery(Brewery brewery) {  this.brewery = brewery; }
+	private Brewery brewery;
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Brewery.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Brewery.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.ogm.helper.annotation;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.GenericGenerator;
+
+/**
+ * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ */
+@Entity
+public class Brewery {
+	@Id
+	@GeneratedValue(generator = "uuid") @GenericGenerator( name="uuid", strategy = "uuid2")
+	@Column(name = "brewery_pk")
+	public String getId() { return id; }
+	public void setId(String id) {  this.id = id; }
+	private String id;
+
+	@OneToMany @JoinColumn(name = "brewery_id")
+	@Cascade( { CascadeType.PERSIST, CascadeType.SAVE_UPDATE} )
+	public Set<Beer> getBeers() { return beers; }
+	public void setBeers(Set<Beer> beers) {  this.beers = beers; }
+	private Set<Beer> beers = new HashSet<Beer>(  );
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Job.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Job.java
@@ -1,0 +1,60 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.ogm.helper.annotation;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+/**
+ * @author Seiya Kawashima <skawashima@uchicago.edu>
+ */
+@Embeddable
+public class Job {
+
+	@Column(name = "job_name")
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+
+	private String name;
+	@Column(name = "summary")
+	private String description;
+	private Address address;
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Person.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Person.java
@@ -1,0 +1,68 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.ogm.helper.annotation;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Seiya Kawashima <skawashima@uchicago.edu>
+ */
+@Entity
+public class Person {
+
+	@Id
+	private long id;
+	private String firstName;
+	private String lastName;
+	private Job job;
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public Job getJob() {
+		return job;
+	}
+
+	public void setJob(Job job) {
+		this.job = job;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+}

--- a/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Phone.java
+++ b/hibernate-ogm-voldemort/src/test/java/org/hibernate/ogm/helper/annotation/Phone.java
@@ -1,0 +1,47 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.ogm.helper.annotation;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+
+/**
+ * @author Seiya Kawashima <skawashima@uchicago.edu>
+ */
+public class Phone {
+
+	private String phone_id;
+	private String number;
+	
+	@Id
+	@Column(name="p_id")
+	public String getPhone_id() {
+		return phone_id;
+	}
+	public void setPhone_id(String phone_id) {
+		this.phone_id = phone_id;
+	}
+	public String getNumber() {
+		return number;
+	}
+	public void setNumber(String number) {
+		this.number = number;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>hibernate-ogm-core</module>
         <module>hibernate-ogm-ehcache</module>
         <module>hibernate-ogm-infinispan</module>
+        <module>hibernate-ogm-voldemort</module>
     </modules>
 
     <prerequisites>


### PR DESCRIPTION
Hi,

I'm not sure if I should do a pull request for this since it's a sub-task of `OGM-123 Add Voldemort datastore`, created by me and assigned to myself but this task is important for Voldemort and hopefully other datastore providers as well. I'll close the request if you think that is not relevant.

To make Voldemort work with `hibernate-ogm`, I used a method called  `getColumnMap` which calls `persister.getPropertyColumnNames( propName )[0]` internally to get property and column name mapping. As mentioned in line comment, it doesn't have to be there and it doesn't work as the relationship works.

However, getting the correct type of properties through their names or column names is necessary to deserialize values in the tuple with the correct type. Without the correct types, an exception is thrown. Instead of doing so previously in `EntityKeyBuilder`, I added a class called `AnnotationFinder` to solve the issue and also other tasks related to annotations as well.

Thank you
Seiya
