### PR TITLE
OGM-202 Make TestHelper contract more flexible upon answering on the vol...

### DIFF
--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/collection/manytomany/ManyToManyTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/collection/manytomany/ManyToManyTest.java
@@ -43,8 +43,8 @@ public class ManyToManyTest extends OgmTestCase {
 		session.persist( owner );
 		tx.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 2 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 2 );
+		assertThat( assertNumberOfEntities( 2, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 2, sessions ) ).isTrue();
 
 		session.clear();
 
@@ -78,8 +78,8 @@ public class ManyToManyTest extends OgmTestCase {
 		session.delete( soge );
 		tx.commit();
 
-		assertThat( entityCacheSize( sessions ) ).isEqualTo( 2 );
-		assertThat( associationCacheSize( sessions ) ).isEqualTo( 2 );
+		assertThat( assertNumberOfEntities( 2, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 2, sessions ) ).isTrue();
 		session.clear();
 
 		//delete data
@@ -97,8 +97,8 @@ public class ManyToManyTest extends OgmTestCase {
 		session.delete( owner );
 		tx.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 0 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 0 );
+		assertThat( assertNumberOfEntities( 0, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 0, sessions ) ).isTrue();
 
 		session.close();
 		checkCleanCache();

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/collection/unidirectional/CollectionUnidirectionalTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/collection/unidirectional/CollectionUnidirectionalTest.java
@@ -23,10 +23,11 @@ package org.hibernate.ogm.test.associations.collection.unidirectional;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.test.simpleentity.OgmTestCase;
+import org.hibernate.ogm.test.utils.TestHelper;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.hibernate.ogm.test.utils.TestHelper.associationCacheSize;
-import static org.hibernate.ogm.test.utils.TestHelper.entityCacheSize;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfAssociations;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfEntities;
 
 /**
  * @author Emmanuel Bernard
@@ -48,12 +49,12 @@ public class CollectionUnidirectionalTest extends OgmTestCase {
 		cloud.getProducedSnowFlakes().add( sf2 );
 		session.persist( cloud );
 		session.flush();
-		assertThat(entityCacheSize( sessions )).isEqualTo( 3 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 3 );
+		assertThat( assertNumberOfEntities( 3, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 3, sessions ) ).isTrue();
 		transaction.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 3 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 3 );
+		assertThat( assertNumberOfEntities( 3, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 3, sessions ) ).isTrue();
 
 		session.clear();
 
@@ -69,8 +70,8 @@ public class CollectionUnidirectionalTest extends OgmTestCase {
 		cloud.getProducedSnowFlakes().add( sf3 );
 		transaction.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 4 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 3 );
+		assertThat( assertNumberOfEntities( 4, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 3, sessions ) ).isTrue();
 
 		session.clear();
 
@@ -92,8 +93,8 @@ public class CollectionUnidirectionalTest extends OgmTestCase {
 		cloud.getProducedSnowFlakes().clear();
 		transaction.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 1 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 0 );
+		assertThat( assertNumberOfEntities( 1, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 0, sessions ) ).isTrue();
 
 		session.clear();
 
@@ -105,8 +106,8 @@ public class CollectionUnidirectionalTest extends OgmTestCase {
 		session.flush();
 		transaction.commit();
 
-		assertThat(entityCacheSize( sessions )).isEqualTo( 0 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 0 );
+		assertThat( assertNumberOfEntities( 0, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 0, sessions ) ).isTrue();
 		session.close();
 
 		checkCleanCache();

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/manytoone/ManyToOneTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/manytoone/ManyToOneTest.java
@@ -23,11 +23,12 @@ package org.hibernate.ogm.test.associations.manytoone;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.test.simpleentity.OgmTestCase;
+import org.hibernate.ogm.test.utils.TestHelper;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfEntities;
 import static org.hibernate.ogm.test.utils.TestHelper.get;
-import static org.hibernate.ogm.test.utils.TestHelper.associationCacheSize;
-import static org.hibernate.ogm.test.utils.TestHelper.entityCacheSize;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfAssociations;
 
 /**
  * @author Emmanuel Bernard
@@ -45,11 +46,11 @@ public class ManyToOneTest extends OgmTestCase {
 		emmanuel.setMemberOf( jug );
 		session.persist( emmanuel );
 		session.flush();
-		assertThat(entityCacheSize( sessions )).isEqualTo( 2 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 1 );
+		assertThat( assertNumberOfEntities( 2, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 1, sessions ) ).isTrue();
 		transaction.commit();
-		assertThat(entityCacheSize( sessions )).isEqualTo( 2 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 1 );
+		assertThat( assertNumberOfEntities( 2, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 1, sessions ) ).isTrue();
 
 		session.clear();
 
@@ -59,8 +60,8 @@ public class ManyToOneTest extends OgmTestCase {
 		session.delete( emmanuel );
 		session.delete( jug );
 		transaction.commit();
-		assertThat(entityCacheSize( sessions )).isEqualTo( 0 );
-		assertThat(associationCacheSize( sessions )).isEqualTo( 0 );
+		assertThat( assertNumberOfEntities( 0, sessions ) ).isTrue();
+		assertThat( assertNumberOfAssociations( 0, sessions ) ).isTrue();
 
 		session.close();
 

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/jpa/JPAResourceLocalStandaloneTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/jpa/JPAResourceLocalStandaloneTest.java
@@ -22,7 +22,7 @@ package org.hibernate.ogm.test.jpa;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.hibernate.ogm.test.utils.TestHelper.dropSchemaAndDatabase;
-import static org.hibernate.ogm.test.utils.TestHelper.entityCacheSize;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfEntities;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -66,10 +66,10 @@ public class JPAResourceLocalStandaloneTest {
 				poem2.setName( "Wazaaaaa" );
 				em.persist( poem2 );
 				em.flush();
-				assertThat( entityCacheSize( em ) ).isEqualTo( 2 );
+				assertThat( assertNumberOfEntities( 2, em ) ).isTrue();
 				em.getTransaction().rollback();
 
-				assertThat( entityCacheSize( em ) ).isEqualTo( 1 );
+				assertThat( assertNumberOfEntities( 1, em ) ).isTrue();
 
 				em.getTransaction().begin();
 				poem = em.find( Poem.class, poem.getId() );

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/simpleentity/OgmTestCase.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/simpleentity/OgmTestCase.java
@@ -21,8 +21,8 @@
 package org.hibernate.ogm.test.simpleentity;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.hibernate.ogm.test.utils.TestHelper.associationCacheSize;
-import static org.hibernate.ogm.test.utils.TestHelper.entityCacheSize;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfAssociations;
+import static org.hibernate.ogm.test.utils.TestHelper.assertNumberOfEntities;
 import static org.hibernate.ogm.test.utils.TestHelper.dropSchemaAndDatabase;
 
 import java.io.InputStream;
@@ -406,7 +406,7 @@ public abstract class OgmTestCase extends TestCase {
 	}
 
 	public void checkCleanCache() {
-		assertThat(entityCacheSize( sessions )).as("Entity cache should be empty").isEqualTo( 0 );
-		assertThat(associationCacheSize( sessions )).as("Association cache should be empty").isEqualTo( 0 );
+		assertThat( assertNumberOfEntities( 0, sessions ) ).as("Entity cache should be empty").isTrue();
+		assertThat( assertNumberOfAssociations( 0, sessions ) ).as("Association cache should be empty").isTrue();
 	}
 }

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/HashMapTestHelper.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/HashMapTestHelper.java
@@ -36,13 +36,13 @@ import org.hibernate.ogm.grid.RowKey;
 public class HashMapTestHelper implements TestableGridDialect {
 
 	@Override
-	public int entityCacheSize(SessionFactory sessionFactory) {
-		return getEntityMap( sessionFactory ).size();
+	public boolean assertNumberOfEntities(int numberOfEntities, SessionFactory sessionFactory) {
+		return getEntityMap( sessionFactory ).size() == numberOfEntities;
 	}
 
 	@Override
-	public int associationCacheSize(SessionFactory sessionFactory) {
-		 return getAssociationCache( sessionFactory ).size();
+	public boolean assertNumberOfAssociations(int numberOfAssociations, SessionFactory sessionFactory) {
+		 return getAssociationCache( sessionFactory ).size() == numberOfAssociations;
 	}
 
 	@Override

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/TestHelper.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/TestHelper.java
@@ -45,8 +45,8 @@ public class TestHelper {
 	private static final Log log = LoggerFactory.make();
 	private static final TestableGridDialect helper = createStoreSpecificHelper();
 
-	public static int entityCacheSize(EntityManager em) {
-		return entityCacheSize( em.unwrap( Session.class ) );
+	public static boolean assertNumberOfEntities(int numberOfEntities, EntityManager em) {
+		return assertNumberOfEntities( numberOfEntities, em.unwrap( Session.class ) );
 	}
 
 	private static TestableGridDialect createStoreSpecificHelper() {
@@ -71,20 +71,21 @@ public class TestHelper {
 		return GridDialectType.valueFromHelperClass( helper.getClass() );
 	}
 
-	public static int entityCacheSize(Session session) {
-		return entityCacheSize( session.getSessionFactory() );
+	public static boolean assertNumberOfEntities(int numberOfEntities, Session session) {
+		return assertNumberOfEntities( numberOfEntities, session.getSessionFactory() );
 	}
 
-	public static int entityCacheSize(SessionFactory sessionFactory) {
-		return helper.entityCacheSize( sessionFactory );
+	public static boolean assertNumberOfEntities(int numberOfEntities, SessionFactory sessionFactory) {
+		return helper.assertNumberOfEntities( numberOfEntities, sessionFactory );
 	}
 
 	public static Map extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
 		return helper.extractEntityTuple( sessionFactory, key );
 	}
 
-	public static int associationCacheSize(SessionFactory sessionFactory) {
-		return helper.associationCacheSize( sessionFactory );
+	public static boolean assertNumberOfAssociations(int numberOfAssociations, SessionFactory sessionFactory) {
+		boolean result = helper.assertNumberOfAssociations( numberOfAssociations, sessionFactory );
+		return result;
 	}
 
 	public static boolean backendSupportsTransactions() {

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/TestableGridDialect.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/TestableGridDialect.java
@@ -35,16 +35,16 @@ import org.hibernate.ogm.grid.EntityKey;
 public interface TestableGridDialect {
 
 	/**
+	 * Check that the number of entities present matches expectations
 	 * @param sessionFactory
-	 * @return the number of elements stored in the entity "cache"
 	 */
-	int entityCacheSize(SessionFactory sessionFactory);
+	boolean assertNumberOfEntities(int numberOfEntities, SessionFactory sessionFactory);
 
 	/**
+	 * Check that the number of entities present matches expectations
 	 * @param sessionFactory
-	 * @return the number of elements stored in the association "cache"
 	 */
-	int associationCacheSize(SessionFactory sessionFactory);
+	boolean assertNumberOfAssociations(int numberOfAssociations, SessionFactory sessionFactory);
 
 	/**
 	 * Loads a specific entity tuple directly from the data store by entity key

--- a/hibernate-ogm-ehcache/src/test/java/org/hibernate/ogm/test/utils/EhcacheTestHelper.java
+++ b/hibernate-ogm-ehcache/src/test/java/org/hibernate/ogm/test/utils/EhcacheTestHelper.java
@@ -38,17 +38,17 @@ import static org.hibernate.ogm.datastore.spi.DefaultDatastoreNames.ENTITY_STORE
  */
 public class EhcacheTestHelper implements TestableGridDialect {
 	@Override
-	public int entityCacheSize(SessionFactory sessionFactory) {
-		return getEntityCache( sessionFactory ).getSize();
+	public boolean assertNumberOfEntities(int numberOfEntities, SessionFactory sessionFactory) {
+		return getEntityCache( sessionFactory ).getSize() == numberOfEntities;
 	}
 
 	@Override
-	public int associationCacheSize(SessionFactory sessionFactory) {
-		return getAssociationCache( sessionFactory ).getSize();
+	public boolean assertNumberOfAssociations(int numberOfAssociations, SessionFactory sessionFactory) {
+		return getAssociationCache( sessionFactory ).getSize() == numberOfAssociations;
 	}
 
 	@Override
-	public Map extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
+	public Map<String,Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
 		return (Map) getEntityCache( sessionFactory ).get( key ).getValue();
 	}
 

--- a/hibernate-ogm-infinispan/src/test/java/org/hibernate/ogm/test/utils/InfinispanTestHelper.java
+++ b/hibernate-ogm-infinispan/src/test/java/org/hibernate/ogm/test/utils/InfinispanTestHelper.java
@@ -38,17 +38,17 @@ import org.infinispan.Cache;
 public class InfinispanTestHelper implements TestableGridDialect {
 
 	@Override
-	public int entityCacheSize(SessionFactory sessionFactory) {
-		return getEntityCache( sessionFactory ).size();
+	public boolean assertNumberOfEntities(int numberOfEntities, SessionFactory sessionFactory) {
+		return getEntityCache( sessionFactory ).size() == numberOfEntities;
 	}
 
 	@Override
-	public int associationCacheSize(SessionFactory sessionFactory) {
-		 return getAssociationCache( sessionFactory ).size();
+	public boolean assertNumberOfAssociations(int numberOfAssociations, SessionFactory sessionFactory) {
+		 return getAssociationCache( sessionFactory ).size() == numberOfAssociations;
 	}
 
 	@Override
-	public Map extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
+	public Map<String,Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
 		return (Map) getEntityCache( sessionFactory ).get( key );
 	}
 


### PR DESCRIPTION
...ume of entities / associations

It makes debugging a failing test a tiny bit harder as you don't get the number difference. This would require the actual `TestableGridDialect` to report it as that cannot be shared.
