### PR TITLE
FIX FAILING TESTS OGM-244 Ehcache doesn't support transactions yet

### DIFF
--- a/hibernate-ogm-ehcache/src/test/java/org/hibernate/ogm/test/utils/EhcacheTestHelper.java
+++ b/hibernate-ogm-ehcache/src/test/java/org/hibernate/ogm/test/utils/EhcacheTestHelper.java
@@ -79,7 +79,7 @@ public class EhcacheTestHelper implements TestableGridDialect {
 	 */
 	@Override
 	public boolean backendSupportsTransactions() {
-		return true;
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Sorry, previous OGM-244 pull (now merged) contained a change which I shouldn't have been included.

I had turned transactions on to verify some things (basically how far it was broken).

This reverts that one liner and restores all tests.
