### PR TITLE
OGM-267 Upgrade mongodb java driver to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <properties>
         <ehcacheVersion>2.5.1</ehcacheVersion>
         <infinispanVersion>5.2.1.Final</infinispanVersion>
-        <mongodbVersion>2.9.0</mongodbVersion>
+        <mongodbVersion>2.10.1</mongodbVersion>
         <hibernateVersion>4.2.0.CR1</hibernateVersion>
         <hibernateSearchVersion>4.2.0.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.0.0.Alpha1</hibernateParserVersion>


### PR DESCRIPTION
With the version upgrade I got rid of the safe mode option which is no longer existing.
The new MongoClient class is using by default WriteConcern.ACKNOWLEDGMENT
