### PR TITLE
OGM-273 DO NOT INCLUDE Method to get the entity from a tuple

### DIFF
--- a/hibernate-ogm-core/src/main/java/org/hibernate/ogm/jdbc/TupleAsMapResultSet.java
+++ b/hibernate-ogm-core/src/main/java/org/hibernate/ogm/jdbc/TupleAsMapResultSet.java
@@ -71,6 +71,10 @@ public class TupleAsMapResultSet implements ResultSet {
 		this.tuples.add( tuple );
 	}
 
+	public void setTuples(List<Tuple> tuples) {
+		this.tuples = tuples;
+	}
+
 	/**
 	 * Retrieve the current value for the collection entry
 	 */

--- a/hibernate-ogm-core/src/main/java/org/hibernate/ogm/loader/OgmLoader.java
+++ b/hibernate-ogm-core/src/main/java/org/hibernate/ogm/loader/OgmLoader.java
@@ -45,6 +45,7 @@ import org.hibernate.ogm.jdbc.TupleAsMapResultSet;
 import org.hibernate.ogm.persister.EntityKeyBuilder;
 import org.hibernate.ogm.persister.OgmCollectionPersister;
 import org.hibernate.ogm.persister.OgmEntityPersister;
+import org.hibernate.ogm.type.GridType;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
 import org.hibernate.ogm.util.impl.PropertyMetadataProvider;
@@ -142,7 +143,7 @@ public class OgmLoader implements UniqueEntityLoader {
 	 */
 	@Override
 	public Object load(Serializable id, Object optionalObject, SessionImplementor session, LockOptions lockOptions) {
-		List results = loadEntity( id, optionalObject, session, lockOptions );
+		List results = loadEntity( id, optionalObject, session, lockOptions, OgmLoadingContext.EMPTY_CONTEXT );
 		if ( results.size()==1 ) {
 			return results.get(0);
 		}
@@ -161,13 +162,26 @@ public class OgmLoader implements UniqueEntityLoader {
 		}
 	}
 
-	private List<Object> loadEntity(Serializable id, Object optionalObject, SessionImplementor session, LockOptions lockOptions) {
+	private List<Object> loadEntity(
+			Serializable id,
+			Object optionalObject,
+			SessionImplementor session,
+			LockOptions lockOptions,
+			OgmLoadingContext ogmLoadingContext) {
 		final OgmEntityPersister currentPersister = entityPersisters[0];
 		if ( log.isDebugEnabled() ) {
-			log.debug(
-					"loading entity: " +
-					MessageHelper.infoString( currentPersister, id, currentPersister.getIdentifierType(), session.getFactory() )
+			if ( id != null ) {
+				log.debug(
+						"loading entity: " +
+						MessageHelper.infoString( currentPersister, id, currentPersister.getIdentifierType(), session.getFactory() )
+					);
+			}
+			else {
+				log.debug(
+						"loading entities from list of tuples: " +
+						MessageHelper.infoString( currentPersister, id, currentPersister.getIdentifierType(), session.getFactory() )
 				);
+			}
 		}
 		QueryParameters qp = new QueryParameters();
 		qp.setPositionalParameterTypes( new Type[] { currentPersister.getIdentifierType() } );
@@ -180,9 +194,18 @@ public class OgmLoader implements UniqueEntityLoader {
 		List<Object> result = doQueryAndInitializeNonLazyCollections(
 				session,
 				qp,
+				ogmLoadingContext,
 				false
 			);
 		return result;
+	}
+
+	/**
+	 * Load a list of entities from a list of tuples
+	 * TODO it sucks that we have to expose Tuple to a public API of OgmLoader
+	 */
+	public List<Object> loadEntities(SessionImplementor session, LockOptions lockOptions, OgmLoadingContext ogmContext) {
+		return loadEntity( null, null, session, lockOptions, ogmContext );
 	}
 
 	/**
@@ -205,6 +228,7 @@ public class OgmLoader implements UniqueEntityLoader {
 		doQueryAndInitializeNonLazyCollections(
 				session,
 				qp,
+				OgmLoadingContext.EMPTY_CONTEXT,
 				true
 			);
 
@@ -222,6 +246,7 @@ public class OgmLoader implements UniqueEntityLoader {
 	private List<Object> doQueryAndInitializeNonLazyCollections(
 			SessionImplementor session,
 			QueryParameters qp,
+			OgmLoadingContext ogmLoadingContext,
 			boolean returnProxies) {
 
 
@@ -235,6 +260,7 @@ public class OgmLoader implements UniqueEntityLoader {
 				result = doQuery(
 						session,
 						qp,
+						ogmLoadingContext,
 						returnProxies
 				);
 			}
@@ -258,14 +284,27 @@ public class OgmLoader implements UniqueEntityLoader {
 	private List<Object> doQuery(
 			SessionImplementor session,
 			QueryParameters qp,
+			OgmLoadingContext ogmLoadingContext,
 			boolean returnProxies) {
 		//TODO support lock timeout
 
 		int entitySpan = entityPersisters.length;
 		final List<Object> hydratedObjects = entitySpan == 0 ? null : new ArrayList<Object>( entitySpan * 10 );
 		//TODO yuk! Is there a cleaner way to access the id?
-		final Serializable id = qp.getOptionalId() != null ? qp.getOptionalId() : ( Serializable ) qp.getCollectionKeys()[0];
-		TupleAsMapResultSet resultset = getResultSet( id, session );
+		final Serializable id;
+		// first look for direct id
+		// then for a tuple based result set we could extract the id
+		// otherwise that's a collection so we use the collection key
+		if ( qp.getOptionalId() != null ) {
+			id = qp.getOptionalId();
+		}
+		else if ( ogmLoadingContext.hasResultSet() ) {
+			id = null;
+		}
+		else {
+			id = qp.getCollectionKeys()[0];
+		}
+		TupleAsMapResultSet resultset = getResultSet( id, ogmLoadingContext, session );
 
 		//Todo implement lockmode
 		//final LockMode[] lockModesArray = getLockModes( queryParameters.getLockOptions() );
@@ -287,6 +326,7 @@ public class OgmLoader implements UniqueEntityLoader {
 						resultset,
 						session,
 						qp,
+						ogmLoadingContext,
 						//lockmodeArray,
 						qp.getOptionalId(),
 						hydratedObjects,
@@ -350,6 +390,7 @@ public class OgmLoader implements UniqueEntityLoader {
 			ResultSet resultset,
 			SessionImplementor session,
 			QueryParameters qp,
+			OgmLoadingContext ogmLoadingContext,
 			Serializable optionalId,
 			List<Object> hydratedObjects,
 			org.hibernate.engine.spi.EntityKey[] keys,
@@ -357,7 +398,7 @@ public class OgmLoader implements UniqueEntityLoader {
 	throws SQLException {
 		final OgmEntityPersister[] persisters = getEntityPersisters();
 		final int entitySpan = persisters.length;
-		extractKeysFromResultSet( session, optionalId, keys );
+		extractKeysFromResultSet( session, optionalId, ogmLoadingContext, keys );
 
 		registerNonExists( keys, persisters, session);
 
@@ -398,19 +439,34 @@ public class OgmLoader implements UniqueEntityLoader {
 		return getResultColumnOrRow( row );
 	}
 
-	private void extractKeysFromResultSet(SessionImplementor session, Serializable optionalId, org.hibernate.engine.spi.EntityKey[] keys) {
+	private void extractKeysFromResultSet(
+			SessionImplementor session,
+			Serializable optionalId,
+			OgmLoadingContext ogmLoadingContext,
+			org.hibernate.engine.spi.EntityKey[] keys) {
 		//TODO Implement all Loader#extractKeysFromResultSet (ie resolution in case of composite ids with associations)
 		//in the mean time the next two lines are the simplified version
+		//we do not handle multiple Loaders but that's OK for now
 		if (keys.length == 0) {
 			//do nothing, this is a collection
 		}
 		else {
+			if (optionalId == null) {
+				final OgmEntityPersister currentPersister = entityPersisters[0];
+				Tuple tuple =  ogmLoadingContext.getResultSet().getTuple();
+				GridType gridIdentifierType = currentPersister.getGridIdentifierType();
+				optionalId = (Serializable) gridIdentifierType.nullSafeGet( tuple, currentPersister.getIdentifierColumnNames(), session, null );
+			}
 			final org.hibernate.engine.spi.EntityKey key = session.generateEntityKey( optionalId,  entityPersisters[0] );
 			keys[0] = key;
 		}
 	}
 
-	private TupleAsMapResultSet getResultSet(Serializable id, SessionImplementor session) {
+	private TupleAsMapResultSet getResultSet(Serializable id, OgmLoadingContext ogmLoadingContext, SessionImplementor session) {
+		if ( id == null && ogmLoadingContext.hasResultSet() ) {
+			return ogmLoadingContext.getResultSet();
+		}
+
 		//TODO this if won't work when we will support collections inside the entity tuple but that will do for now
 		final TupleAsMapResultSet resultset = new TupleAsMapResultSet();
 		if ( getEntityPersisters().length > 0 ) {

--- a/hibernate-ogm-core/src/main/java/org/hibernate/ogm/loader/OgmLoadingContext.java
+++ b/hibernate-ogm-core/src/main/java/org/hibernate/ogm/loader/OgmLoadingContext.java
@@ -1,0 +1,41 @@
+package org.hibernate.ogm.loader;
+
+import org.hibernate.ogm.datastore.spi.Tuple;
+import org.hibernate.ogm.jdbc.TupleAsMapResultSet;
+
+import java.sql.ResultSet;
+import java.util.List;
+
+/**
+ * Object holding contextual information around data loading
+ * and that are OGM specific. This object is used by {@link OgmLoader}.
+ *
+ * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ */
+public class OgmLoadingContext {
+	/**
+	 * Do not edit this reference. Shared by everyone and still mutable.
+	 */
+	public static final OgmLoadingContext EMPTY_CONTEXT = new OgmLoadingContext();
+
+	private TupleAsMapResultSet resultSet;
+
+	public boolean hasResultSet() {
+		return resultSet != null;
+	}
+
+	public TupleAsMapResultSet getResultSet() {
+		return resultSet;
+	}
+
+	public void setTuples(List<Tuple> tuples) {
+		if ( tuples == null ) {
+			this.resultSet = null;
+		}
+		else {
+			TupleAsMapResultSet tupleResultSet = new TupleAsMapResultSet();
+			tupleResultSet.setTuples( tuples );
+			this.resultSet = tupleResultSet;
+		}
+	}
+}

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/loader/Feeling.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/loader/Feeling.java
@@ -1,0 +1,23 @@
+package org.hibernate.ogm.test.loader;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ */
+@Entity
+public class Feeling {
+	@Id
+	@GeneratedValue(generator = "uuid") @GenericGenerator( name="uuid", strategy = "uuid2")
+	public String getUUID() { return uuid; }
+	public void setUUID(String uuid) { this.uuid = uuid; }
+	private String uuid;
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	private String name;
+}

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/loader/LoaderFromTupleTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/loader/LoaderFromTupleTest.java
@@ -1,0 +1,63 @@
+package org.hibernate.ogm.test.loader;
+
+import org.hibernate.LockOptions;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.datastore.impl.MapTupleSnapshot;
+import org.hibernate.ogm.datastore.spi.Tuple;
+import org.hibernate.ogm.grid.EntityKey;
+import org.hibernate.ogm.loader.OgmLoader;
+import org.hibernate.ogm.loader.OgmLoadingContext;
+import org.hibernate.ogm.persister.OgmEntityPersister;
+import org.hibernate.ogm.test.simpleentity.OgmTestCase;
+import org.hibernate.persister.entity.EntityPersister;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.test.utils.TestHelper.extractEntityTuple;
+
+/**
+ * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ */
+public class LoaderFromTupleTest extends OgmTestCase {
+	@Test
+	public void testLoadingFromTuple() throws Exception {
+		final Session session = openSession();
+
+		Transaction transaction = session.beginTransaction();
+		Feeling feeling = new Feeling();
+		feeling.setName( "Moody" );
+		session.persist( feeling );
+		transaction.commit();
+
+		session.clear();
+
+		EntityKey key = new EntityKey( "Feeling", new String[]{ "UUID" }, new Object[]{ feeling.getUUID() } );
+		Map<String, Object> entityTuple = (Map<String, Object>) extractEntityTuple( sessions, key );
+		final Tuple tuple = new Tuple( new MapTupleSnapshot( entityTuple ) );
+
+		EntityPersister persister = ( (SessionFactoryImplementor) session.getSessionFactory() ).getEntityPersister( Feeling.class.getName() );
+		OgmLoader loader = new OgmLoader( new OgmEntityPersister[] { (OgmEntityPersister) persister } );
+		OgmLoadingContext ogmLoadingContext = new OgmLoadingContext();
+		List<Tuple> tuples = new ArrayList<Tuple>();
+		tuples.add( tuple );
+		ogmLoadingContext.setTuples(tuples);
+		List<Object> entities = loader.loadEntities( (SessionImplementor) session, LockOptions.NONE, ogmLoadingContext );
+		assertThat(entities.size()).isEqualTo( 1 );
+		assertThat( ( (Feeling) entities.get(0) ).getName() ).isEqualTo( "Moody" );
+
+		session.close();
+	}
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Feeling.class
+		};
+	}
+}


### PR DESCRIPTION
`LoaderFromTupleTest` shows how to use it.
Note that the test fails for MongoDB because MongoDB does a maping between the logical id column and `_id`. The test does not take that into account.

We need to add a `GridDialect.getAllTuples(Consumer, EntityKeyMetadata...)`

That way the driver has access to the table as well as the id column names will be via the `EntityMetadataKey`. The related issue is https://hibernate.onjira.com/browse/OGM-151
The MongoDB driver will provide a specific snapshot that takes the EntityKeyMetadata info into account.

I think we can carry on in the mean time and fix OGM-151 in parallel.
