### PR TITLE
OGM-288 Remove Hibernate Search TesHelper class dependency

### DIFF
--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/massindex/AssociationMassIndexerTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/massindex/AssociationMassIndexerTest.java
@@ -34,11 +34,11 @@ import org.hibernate.ogm.test.hsearch.Insurance;
 import org.hibernate.ogm.test.id.NewsID;
 import org.hibernate.ogm.test.massindex.model.IndexedLabel;
 import org.hibernate.ogm.test.massindex.model.IndexedNews;
+import org.hibernate.ogm.test.utils.IndexDirectoryManager;
 import org.hibernate.ogm.test.utils.jpa.GetterPersistenceUnitInfo;
 import org.hibernate.ogm.test.utils.jpa.JpaTestCase;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
-import org.hibernate.search.test.TestConstants;
 import org.junit.After;
 import org.junit.Test;
 
@@ -159,7 +159,7 @@ public class AssociationMassIndexerTest extends JpaTestCase {
 		// the constructor File(File, String) is broken too, see :
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5066567
 		// So make sure to use File(String, String) in this case as TestConstants works with absolute paths!
-		baseDir = new File( TestConstants.getIndexDirectory(), shortTestName );
+		baseDir = new File( IndexDirectoryManager.getIndexDirectory( AssociationMassIndexerTest.class ), shortTestName );
 		return baseDir;
 	}
 

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/massindex/SimpleEntityMassIndexingTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/massindex/SimpleEntityMassIndexingTest.java
@@ -32,9 +32,9 @@ import org.hibernate.ogm.test.id.NewsID;
 import org.hibernate.ogm.test.massindex.model.IndexedLabel;
 import org.hibernate.ogm.test.massindex.model.IndexedNews;
 import org.hibernate.ogm.test.simpleentity.OgmTestCase;
+import org.hibernate.ogm.test.utils.IndexDirectoryManager;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
-import org.hibernate.search.test.TestConstants;
 import org.hibernate.search.util.impl.FileHelper;
 import org.junit.After;
 import org.junit.Test;
@@ -137,7 +137,7 @@ public class SimpleEntityMassIndexingTest extends OgmTestCase {
 		// the constructor File(File, String) is broken too, see :
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5066567
 		// So make sure to use File(String, String) in this case as TestConstants works with absolute paths!
-		File indexPath = new File( TestConstants.getIndexDirectory(), shortTestName );
+		File indexPath = new File( IndexDirectoryManager.getIndexDirectory( SimpleEntityMassIndexingTest.class ), shortTestName );
 		return indexPath;
 	}
 

--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/IndexDirectoryManager.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/utils/IndexDirectoryManager.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.ogm.test.utils;
+
+import java.io.File;
+import java.net.URL;
+
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
+
+/**
+ * Collects static constants used across several tests.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ */
+public class IndexDirectoryManager {
+
+	private static final Log log = LoggerFactory.make();
+
+	/**
+	 * Returns the target directory of the build.
+	 *
+	 * @param testClass the test class for which the target directory is requested.
+	 * @return the target directory of the build
+	 */
+	public static File getTargetDir(Class<?> testClass) {
+		ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+		// get a URL reference to something we now is part of the classpath (our own classes)
+		String currentTestClass = testClass.getName();
+		int hopsToCompileDirectory = currentTestClass.split( "\\." ).length;
+		int hopsToTargetDirectory = hopsToCompileDirectory + 1;
+		URL classURL = contextClassLoader.getResource( currentTestClass.replace( '.', '/' ) + ".class" );
+		// navigate back to '/target'
+		File targetDir = new File( classURL.getFile() );
+		// navigate back to '/target'
+		for ( int i = 0; i < hopsToTargetDirectory; i++ ) {
+			targetDir = targetDir.getParentFile();
+		}
+		return targetDir;
+	}
+
+	/**
+	 * Return the root directory to store test indexes in. Tests should never use or delete this directly
+	 * but rather nest sub directories in it to avoid interferences across tests.
+	 *
+	 * @param testClass the test class for which the index directory is requested.
+	 * @return Return the root directory to store test indexes
+	 */
+	public static String getIndexDirectory(Class<?> testClass) {
+		File targetDir = getTargetDir( testClass );
+		String indexDirPath = targetDir.getAbsolutePath() + File.separator + "indextemp";
+		log.debugf( "Using %s as index directory.", indexDirPath );
+		return indexDirPath;
+	}
+}


### PR DESCRIPTION
I've copied the class from Search but I've changed the name to be a bit more descriptive.
