### PR TITLE
OGM-315 OneToOneTest does not completly clean the datastore at the end

### DIFF
--- a/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/onetoone/OneToOneTest.java
+++ b/hibernate-ogm-core/src/test/java/org/hibernate/ogm/test/associations/onetoone/OneToOneTest.java
@@ -131,6 +131,7 @@ public class OneToOneTest extends OgmTestCase {
 		husband.setWife( null );
 		session.delete( husband );
 		session.delete( wife );
+		session.delete( bea2 );
 		transaction.commit();
 		session.close();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-315

OneToOneTest#testBidirectionalManyToOne is sometimes executed before OneToOneTest#testUnidirectionalManyToOne.

Because one entity is not deleted there is sometimes a failure when the method checkCleanCache(); is called in  testUnidirectionalManyToOne

I'm starting to think that this method should be called after every test.
