### PR TITLE
OGM-339 Skip integration test modules when 'skipITs' property  is used

### DIFF
--- a/hibernate-ogm-integrationtest/hibernate-ogm-integrationtest-mongodb/pom.xml
+++ b/hibernate-ogm-integrationtest/hibernate-ogm-integrationtest-mongodb/pom.xml
@@ -19,7 +19,10 @@
         </testResources>
         <plugins>
             <plugin>
-                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -29,14 +32,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build-test-jar</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -144,22 +139,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>extract-as</id>
-            <activation>
-                <property>
-                    <name>skipTests</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/hibernate-ogm-integrationtest/hibernate-ogm-integrationtest-testcase/pom.xml
+++ b/hibernate-ogm-integrationtest/hibernate-ogm-integrationtest-testcase/pom.xml
@@ -20,44 +20,20 @@
         </testResources>
         <plugins>
             <plugin>
-                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build-test-jar</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>extract-as</id>
-            <activation>
-                <property>
-                    <name>skipTests</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <module>hibernate-ogm-infinispan</module>
         <module>hibernate-ogm-mongodb</module>
         <module>hibernate-ogm-modules</module>
-        <module>hibernate-ogm-integrationtest</module>
     </modules>
 
     <prerequisites>
@@ -975,6 +974,18 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <id>integrationtest</id>
+            <activation>
+                <property>
+                    <name>skipITs</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>hibernate-ogm-integrationtest</module>
+            </modules>
+        </profile>
         <profile>
             <id>doc</id>
             <activation>

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,16 @@ To build the project, run
 
     mvn clean install -s settings-example.xml
 
+### Integration tests
+
+You can skip integration tests by specifying the `skipITs` property:
+
+    mvn clean install -DskipITs -s settings-example.xml
+
+or
+
+    mvn clean install -DskipITs=true -s settings-example.xml
+
 ### Documentation
 
 The documentation is built by default as part of the project build. You can skip it by specifying the `skipDocs` property:

--- a/src/main/assembly/dist.xml
+++ b/src/main/assembly/dist.xml
@@ -26,7 +26,7 @@
 <!--
   When updating this file, make sure we don't include duplicate jars in different subdirectories.
   Generate the distribution preview to see how it looks like:
-   mvn clean package assembly:assembly -DskipTests=true -DbuildDocs=true
+   mvn clean package assembly:assembly -DskipTests=true -DskipITs=true -DbuildDocs=true
 
   To inspect which jars are being distributed and look for duplicates this might be handy:
   tar -ztvf target/*-dist.tar.gz | grep .jar| sed -e "s/.*\/dist//" -e "s/\(\/lib\/[^\/]*\)\/\(.*\)/\2 \t\t\t\1/" | sort


### PR DESCRIPTION
JIRA: https://hibernate.atlassian.net/browse/OGM-339

In the integration tests sub-modules the build is always skipping the installation of the test sources. This cause failures when in the jar with tje tests sources is not in the local repository.

I've also change the name of the property from 'skipTests' to 'skipITs'. This way it is possible to run unit tests without running and build the integration tests.
