### PR TITLE
Having generated logging source folder being added as Eclipse source dir...

### DIFF
--- a/hibernate-ogm-core/pom.xml
+++ b/hibernate-ogm-core/pom.xml
@@ -127,6 +127,10 @@
                 <artifactId>maven-processor-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>

--- a/hibernate-ogm-mongodb/pom.xml
+++ b/hibernate-ogm-mongodb/pom.xml
@@ -30,6 +30,10 @@
                 <artifactId>maven-processor-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,25 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>1.8</version>
+                    <executions>
+                        <execution>
+                            <id>add-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>${project.build.directory}/generated-sources/apt</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.12</version>


### PR DESCRIPTION
...ectory automatically

With this change, running "Maven" -> "Generate Sources" will automatically add `target/generated-sources/apt` as source folder to the Eclipse projects for core and mongodb.
