### PR TITLE
OGM-378 Making dependency from Infinispan module to hibernate-search-orm...

### DIFF
--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-orm</artifactId>
-            <optional>true</optional>
         </dependency>
         <!-- Currently we don't have explicit tests using it, but we still need to define
             a dependency to include the dependency in the distribution -->


### PR DESCRIPTION
... mandatory as it is required by the provider's default parser
