### PR TITLE
OGM-395 update documentation and comments that refer to the obsolete 'buildDocs'  property

### DIFF
--- a/documentation/manual/src/main/asciidoc/en-US/modules/how-to-contribute.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/how-to-contribute.asciidoc
@@ -77,11 +77,11 @@ according to the descriptions available
 http://community.jboss.org/wiki/MavenGettingStarted-Users[on this jboss.org wiki page].
 ====
 
-To build the documentation, set the +buildDocs+ property to true:
+To skip building the documentation, set the +skipDocs+ property to true:
 
 [source]
 ----
-mvn clean install -DbuildDocs=true -s settings-example.xml
+mvn clean install -DskipDocs=true -s settings-example.xml
 ----
 
 [TIP]

--- a/src/main/assembly/dist.xml
+++ b/src/main/assembly/dist.xml
@@ -26,7 +26,7 @@
 <!--
   When updating this file, make sure we don't include duplicate jars in different subdirectories.
   Generate the distribution preview to see how it looks like:
-   mvn clean package assembly:assembly -DskipTests=true -DskipITs=true -DbuildDocs=true
+   mvn clean package assembly:assembly -DskipTests=true -DskipITs=true
 
   To inspect which jars are being distributed and look for duplicates this might be handy:
   tar -ztvf target/*-dist.tar.gz | grep .jar| sed -e "s/.*\/dist//" -e "s/\(\/lib\/[^\/]*\)\/\(.*\)/\2 \t\t\t\1/" | sort


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-395
