### PR TITLE
OGM-404 BuiltInTypeTest sometimes fails because of the TimeZone

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/test/type/BuiltInTypeTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/type/BuiltInTypeTest.java
@@ -30,6 +30,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 import java.util.Random;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import org.hibernate.Session;
@@ -39,6 +40,8 @@ import org.hibernate.ogm.grid.EntityKeyMetadata;
 import org.hibernate.ogm.test.utils.OgmTestCase;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -51,6 +54,19 @@ public class BuiltInTypeTest extends OgmTestCase {
 	private static final Log log = LoggerFactory.make();
 
 	private static final Random RANDOM = new Random();
+
+	private static TimeZone originalTimeZone = null;
+
+	@BeforeClass
+	public static void setDefaultTimeZone() {
+		originalTimeZone = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( "UTC" ) );
+	}
+
+	@AfterClass
+	public static void resetDefautlTimeZone() {
+		TimeZone.setDefault( originalTimeZone );
+	}
 
 	@Test
 	public void testTypesSupport() throws Exception {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-404

Only the commit https://github.com/DavideD/hibernate-ogm/commit/582e364a0822a39f59ba3a39757c23fa1cfdd2b5 is required to solve this issue but I was wondering if it is correct to set the TimeZone instead of using the default one before converting the dates.

In the end I've decided to use the default TimeZone before converting the dates but if there are good reason to use the UTC then feel free to remove the https://github.com/DavideD/hibernate-ogm/commit/5bba1d7e96855bae7cabd30c38acdee6e030adbc commit
