### PR TITLE
OGM-346 Queries selecting entire entity shouldn't return a list of arrays

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/JpaQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/JpaQueriesTest.java
@@ -58,6 +58,17 @@ public class JpaQueriesTest extends JpaTestCase {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
+	public void testGetResultListWithSelect() throws Exception {
+		List<Helicopter> helicopters = em.createQuery( "SELECT h FROM Helicopter h WHERE h.name = :name" )
+				.setParameter( "name", POLICE_HELICOPTER )
+				.getResultList();
+
+		assertThat( helicopters.size() ).isEqualTo( 1 );
+		assertThat( helicopters.get( 0 ).getName() ).isEqualTo( POLICE_HELICOPTER );
+	}
+
+	@Test
 	public void testGetResultListWithTypedQuery() throws Exception {
 		List<Helicopter> helicopters = em.createQuery( "FROM Helicopter WHERE name = :name", Helicopter.class )
 				.setParameter( "name", POLICE_HELICOPTER )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-346

When we set the alias in the select clause the `LuceneQueryParsingResult#getProjections()` will return the value `{__HSearch_This}` instead of an empty list and this resulted in the list of arrays as result type instead of the entity type.

This solution is very simple but I'm not sure if it is the right approach, @Sanne, WDYT?
