### PR TITLE
OGM-502 Update configuration of the maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -688,9 +688,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <goals>deploy assembly:assembly</goals>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -916,9 +913,16 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5</version>
                     <configuration>
+                        <goals>deploy</goals>
                         <preparationGoals>clean install</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
+                        <releaseProfiles>distro</releaseProfiles>
+                        <arguments>-DskipTests</arguments>
+                        <pushChanges>false</pushChanges>
+                        <localCheckout>true</localCheckout>
+                        <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Copied from hibernate search, the preparation of the release won't change the remote repository and it won't require the addiional online parameters.

I will update the wiki soon.
