### PR TITLE
OGM-551

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/OgmSessionFactory.java
+++ b/core/src/main/java/org/hibernate/ogm/OgmSessionFactory.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm;
 
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SessionBuilderImplementor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 /**
@@ -14,4 +16,33 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
  * @author Gunnar Morling
  */
 public interface OgmSessionFactory extends SessionFactoryImplementor {
+
+	/**
+	 * A {@link SessionBuilderImplementor} which creates {@link OgmSession}s.
+	 *
+	 * @author Gunnar Morling
+	 *
+	 */
+	interface OgmSessionBuilderImplementor extends SessionBuilderImplementor {
+
+		@Override
+		OgmSession openSession();
+	}
+
+	@Override
+	OgmSessionBuilderImplementor withOptions();
+
+	/**
+	 * Opens a new session based on the configured NoSQL datastore.
+	 *
+	 * @return A new Hibernate OGM session
+	 */
+	@Override
+	OgmSession openSession() throws HibernateException;
+
+	@Override
+	OgmSession getCurrentSession() throws HibernateException;
+
+	@Override
+	OgmSession openTemporarySession() throws HibernateException;
 }

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionBuilderDelegator.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionBuilderDelegator.java
@@ -16,12 +16,14 @@ import org.hibernate.SessionEventListener;
 import org.hibernate.engine.spi.SessionBuilderImplementor;
 import org.hibernate.engine.spi.SessionOwner;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.OgmSessionFactory;
+import org.hibernate.ogm.OgmSessionFactory.OgmSessionBuilderImplementor;
 
 /**
  * @author Emmanuel Bernard <emmanuel@hibernate.org>
  */
-public class OgmSessionBuilderDelegator implements SessionBuilderImplementor {
+public class OgmSessionBuilderDelegator implements OgmSessionBuilderImplementor {
 	private final SessionBuilderImplementor builder;
 	private final OgmSessionFactory factory;
 
@@ -32,7 +34,7 @@ public class OgmSessionBuilderDelegator implements SessionBuilderImplementor {
 	}
 
 	@Override
-	public Session openSession() {
+	public OgmSession openSession() {
 		Session session = builder.openSession();
 		return new OgmSessionImpl( factory, (EventSource) session );
 	}

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
@@ -43,7 +43,6 @@ import org.hibernate.engine.query.spi.QueryPlanCache;
 import org.hibernate.engine.spi.FilterDefinition;
 import org.hibernate.engine.spi.NamedQueryDefinition;
 import org.hibernate.engine.spi.NamedSQLQueryDefinition;
-import org.hibernate.engine.spi.SessionBuilderImplementor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.exception.spi.SQLExceptionConverter;
@@ -52,6 +51,7 @@ import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.internal.NamedQueryRepository;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.metadata.CollectionMetadata;
+import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.OgmSessionFactory;
 import org.hibernate.ogm.exception.NotSupportedException;
 import org.hibernate.ogm.query.impl.NoSqlQueryParameterMetadataCache;
@@ -239,7 +239,7 @@ public class OgmSessionFactoryImpl implements SessionFactoryImplementor, OgmSess
 	}
 
 	@Override
-	public Session openTemporarySession() throws HibernateException {
+	public OgmSession openTemporarySession() throws HibernateException {
 		return new OgmSessionImpl( this, (EventSource) delegate.openTemporarySession() );
 	}
 
@@ -299,18 +299,18 @@ public class OgmSessionFactoryImpl implements SessionFactoryImplementor, OgmSess
 	}
 
 	@Override
-	public SessionBuilderImplementor withOptions() {
+	public OgmSessionBuilderImplementor withOptions() {
 		return new OgmSessionBuilderDelegator( delegate.withOptions(), this );
 	}
 
 	@Override
-	public Session openSession() throws HibernateException {
+	public OgmSession openSession() throws HibernateException {
 		final Session session = delegate.openSession();
 		return new OgmSessionImpl(this, (EventSource) session);
 	}
 
 	@Override
-	public Session getCurrentSession() throws HibernateException {
+	public OgmSession getCurrentSession() throws HibernateException {
 		final Session session = delegate.getCurrentSession();
 		return new OgmSessionImpl(this, (EventSource) session);
 	}

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
@@ -17,6 +17,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.OgmSessionFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -65,8 +66,8 @@ public abstract class OgmTestCase {
 	protected void configure(Configuration cfg) {
 	}
 
-	protected Session openSession() {
-		Session session = sessions.openSession();
+	protected OgmSession openSession() {
+		OgmSession session = sessions.openSession();
 		openedSessions.add( session );
 		return session;
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionNativeQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionNativeQueryTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto <davide@hibernate.org>
  */
-public class MongoDBSessionSQLQueryTest extends OgmTestCase {
+public class MongoDBSessionNativeQueryTest extends OgmTestCase {
 
 	private final OscarWildePoem portia = new OscarWildePoem( 1L, "Portia", "Oscar Wilde" );
 	private final OscarWildePoem athanasia = new OscarWildePoem( 2L, "Athanasia", "Oscar Wilde" );
@@ -63,7 +63,7 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testNativeQueryWithFirstResult() throws Exception {
-		OgmSession session = (OgmSession) openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		Query query = session.createNativeQuery( "{ $query : { author : 'Oscar Wilde' }, $orderby : { name : 1 } }" )
@@ -81,7 +81,7 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testNativeQueryWithMaxRows() throws Exception {
-		OgmSession session = (OgmSession) openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		Query query = session.createNativeQuery( "{ $query : { author : 'Oscar Wilde' }, $orderby : { name : 1 } }" )
@@ -99,12 +99,12 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testListMultipleResultQuery() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "{ $query : { author : 'Oscar Wilde' }, $orderby : { name : 1 } }";
 		@SuppressWarnings("unchecked")
-		List<OscarWildePoem> result = session.createSQLQuery( nativeQuery )
+		List<OscarWildePoem> result = session.createNativeQuery( nativeQuery )
 				.addEntity( OscarWildePoem.TABLE_NAME, OscarWildePoem.class )
 				.list();
 
@@ -117,12 +117,12 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testListMultipleResultQueryWithFirstResultAndMaxRows() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "{ $query : { author : 'Oscar Wilde' }, $orderby : { name : 1 } }";
 		@SuppressWarnings("unchecked")
-		List<OscarWildePoem> result = session.createSQLQuery( nativeQuery )
+		List<OscarWildePoem> result = session.createNativeQuery( nativeQuery )
 				.addEntity( OscarWildePoem.TABLE_NAME, OscarWildePoem.class )
 				.setFirstResult( 1 )
 				.setMaxResults( 1 )
@@ -137,12 +137,12 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testExceptionWhenReturnedEntityIsMissingAndUniqueResultIsExpected() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "{ $and: [ { name : 'Portia' }, { author : 'Oscar Wilde' } ] }";
 		try {
-			session.createSQLQuery( nativeQuery ).uniqueResult();
+			session.createNativeQuery( nativeQuery ).uniqueResult();
 			transaction.commit();
 		}
 		catch (Exception he) {
@@ -177,12 +177,12 @@ public class MongoDBSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testExceptionWhenReturnedEntityIsMissingAndManyResultsAreExpected() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "{ $query : { author : 'Oscar Wilde' }, $orderby : { name : 1 } }";
 		try {
-			session.createSQLQuery( nativeQuery ).list();
+			session.createNativeQuery( nativeQuery ).list();
 		}
 		catch (Exception he) {
 			transaction.rollback();

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/nativequery/Neo4jSessionNativeQueryTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/nativequery/Neo4jSessionNativeQueryTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -25,7 +26,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto <davide@hibernate.org>
  */
-public class Neo4jSessionSQLQueryTest extends OgmTestCase {
+public class Neo4jSessionNativeQueryTest extends OgmTestCase {
 
 	private final OscarWildePoem portia = new OscarWildePoem( 1L, "Portia", "Oscar Wilde", new GregorianCalendar( 1808, 3, 10, 12, 45 ).getTime() );
 	private final OscarWildePoem athanasia = new OscarWildePoem( 2L, "Athanasia", "Oscar Wilde", new GregorianCalendar( 1810, 3, 10 ).getTime() );
@@ -61,11 +62,11 @@ public class Neo4jSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testUniqueResultQuery() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "MATCH ( n:" + TABLE_NAME + " { name:'Portia', author:'Oscar Wilde' } ) RETURN n";
-		OscarWildePoem poem = (OscarWildePoem) session.createSQLQuery( nativeQuery )
+		OscarWildePoem poem = (OscarWildePoem) session.createNativeQuery( nativeQuery )
 				.addEntity( OscarWildePoem.TABLE_NAME, OscarWildePoem.class )
 				.uniqueResult();
 
@@ -78,12 +79,12 @@ public class Neo4jSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testListMultipleResultQuery() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "MATCH ( n:" + TABLE_NAME + " ) RETURN n ORDER BY n.name";
 		@SuppressWarnings("unchecked")
-		List<OscarWildePoem> result = session.createSQLQuery( nativeQuery )
+		List<OscarWildePoem> result = session.createNativeQuery( nativeQuery )
 				.addEntity( OscarWildePoem.TABLE_NAME, OscarWildePoem.class )
 				.list();
 
@@ -98,12 +99,12 @@ public class Neo4jSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testListMultipleResultQueryWithoutReturnedType() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		String nativeQuery = "MATCH ( n:" + TABLE_NAME + " ) RETURN n.name, n.author ORDER BY n.name";
 		@SuppressWarnings("unchecked")
-		List<Object[]> result = session.createSQLQuery( nativeQuery ).list();
+		List<Object[]> result = session.createNativeQuery( nativeQuery ).list();
 
 		assertThat( result ).as( "Unexpected number of results" ).hasSize( 2 );
 
@@ -122,7 +123,7 @@ public class Neo4jSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testUniqueResultNamedNativeQuery() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		try {
@@ -139,12 +140,12 @@ public class Neo4jSessionSQLQueryTest extends OgmTestCase {
 
 	@Test
 	public void testUniqueResultFromNativeQueryWithParameter() throws Exception {
-		Session session = openSession();
+		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();
 
 		try {
 			String nativeQuery = "MATCH ( n:" + TABLE_NAME + " { name:{name}, author:'Oscar Wilde' } ) RETURN n";
-			SQLQuery query = session.createSQLQuery( nativeQuery ).addEntity( OscarWildePoem.class );
+			SQLQuery query = session.createNativeQuery( nativeQuery ).addEntity( OscarWildePoem.class );
 			query.setParameter( "name", "Portia" );
 
 			OscarWildePoem uniqueResult = (OscarWildePoem) query.uniqueResult();


### PR DESCRIPTION
Avoids some casts and making the nicer `createNativeQuery()` method (rather than `createSQLQuery()`)  more easily available when e.g. bootstrapping via `OgmConfiguration`.
