### PR TITLE
OGM-558 Remove early access repository

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -194,73 +194,13 @@
         </profile>
         <profile>
             <!--
-                This profile will download EAP 6.1.Alpha1 from the Red Hat repository but it requires
-                the Red Hat repository defined in the maven settings.
-
-                Example from hibernate-ogm/integrationtest folder:
-
-                mvn install -Peap -s ../settings-example.xml
-            -->
-            <id>eap</id>
-            <properties>
-                    <version.arquillian.jbossas>7.2.0.Final</version.arquillian.jbossas>
-                    <version.jbossas>7.2.0.Alpha1-redhat-4</version.jbossas>
-                    <jboss.home>${project.build.directory}/jboss-eap-6.1</jboss.home>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.as</groupId>
-                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
-                    <version>${version.arquillian.jbossas}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.jboss.as</groupId>
-                                            <artifactId>jboss-as-dist</artifactId>
-                                            <version>${version.jbossas}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}</outputDirectory>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>hibernate-ogm-modules-eap6</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${jboss.home}/modules</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <!--
                 This profile won't download EAP and it will use the one defined in the variable eap.home.
 
                 Example from hibernate-ogm/integrationtest:
 
                 mvn install -Deap.home=/home/user/jbossas/jboss-eap-6.2
             -->
-            <id>eap-custom</id>
+            <id>eap</id>
             <activation>
                 <property>
                     <name>eap.home</name>

--- a/readme.md
+++ b/readme.md
@@ -60,13 +60,10 @@ The distribution bundle is built by default as part of the project build. You ca
 Integration tests can be run from the integrationtest module and the default behaviour is to download the WildFly application server,
 unpack the modules in it and run the tests using Arquillian.
 
-There are two additional profiles that can be used to run the test on JBoss EAP 6 instead. The first one will download EAP 6.1:
+There is an additional profile that can be used to run the test on JBoss EAP 6 instead. You need an existing installation
+of EAP to run the tests:
 
-   mvn clean install -Peap -s settings.xml
-
-The second one will use an existing installation of JBoss EAP 6:
-
-   mvn clean install -Deap.home=/home/user/eap_home -s settings.xml
+   mvn clean install -Deap.home=/home/user/eap_home -s settings-example.xml
 
 [WARNING]
 ====

--- a/settings-example.xml
+++ b/settings-example.xml
@@ -289,33 +289,11 @@ under the License.
         </profile>
         <!-- jboss.org config end -->
 
-        <!-- Include early access of application server and other products -->
-        <profile>
-            <id>redhat-earlyaccess-repository</id>
-            <repositories>
-                <repository>
-                    <id>redhat-earlyaccess-repository-group</id>
-                    <name>Red Hat early access repository</name>
-                    <url>http://maven.repository.redhat.com/earlyaccess/all/</url>
-                    <layout>default</layout>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
-
     </profiles>
 
     <!-- jboss.org config start -->
     <activeProfiles>
         <activeProfile>jboss-public-repository</activeProfile>
-        <activeProfile>redhat-earlyaccess-repository</activeProfile>
     </activeProfiles>
     <!-- jboss.org config end -->
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-558

  The repository is used only to downaload EAP 6.1, but the
  version downloaded is quite old and we don't need to support it.

  At the moment there is not a EAP 6.2 version on the repository,
  the only way to run the integration test is to have an
  installation somewhere.
