### PR TITLE
OGM-587 Added test case that shows the failure

### DIFF
--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/EmbeddedList.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/EmbeddedList.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.nativequery;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import java.util.List;
+
+@Embeddable
+public class EmbeddedList {
+	private String name;
+
+	@ElementCollection
+	private List<String> list;
+
+	protected EmbeddedList() { }
+
+	public EmbeddedList(String name, List<String> list) {
+		this.name = name;
+		this.list = list;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<String> getList() {
+		return list;
+	}
+
+	public void setList(List<String> list) {
+		this.list = list;
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBEntityManagerNativeQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBEntityManagerNativeQueryTest.java
@@ -36,11 +36,12 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 
 	private final OscarWildePoem portia = new OscarWildePoem( 1L, "Portia", "Oscar Wilde" );
 	private final OscarWildePoem athanasia = new OscarWildePoem( 2L, "Athanasia", "Oscar Wilde", (byte) 5 );
+	private final User wombatSoftware = new User("1", "Wombat Software");
 
 	@Before
 	public void init() throws Exception {
 		begin();
-		EntityManager em = persist( portia, athanasia );
+		EntityManager em = persist( portia, athanasia, wombatSoftware);
 		commit();
 		close( em );
 	}
@@ -56,7 +57,7 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 	@After
 	public void tearDown() throws Exception {
 		begin();
-		EntityManager em = delete( portia, athanasia );
+		EntityManager em = delete( portia, athanasia, wombatSoftware);
 		commit();
 		close( em );
 	}
@@ -72,6 +73,38 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 		assertAreEquals( portia, poem );
 
 		commit();
+		close( em );
+	}
+
+	@Test
+	@Ignore
+	public void testSingleResultQueryWithEmbeddedList() throws Exception {
+		begin();
+		EntityManager em = createEntityManager();
+
+		String nativeQuery = "{ name : 'Wombat Software' }";
+		User user = (User) em.createNativeQuery( nativeQuery, User.class ).getSingleResult();
+
+		assertAreEquals( wombatSoftware, user );
+
+		commit();
+		close( em );
+	}
+
+	@Test
+	public void testPersistUserWithEmbeddedList() throws Exception {
+		begin();
+		EntityManager em = createEntityManager();
+
+		User wombatSoftware2 = new User( "2", "Wombat Software 2" );
+		wombatSoftware2.setList( new EmbeddedList( "New List", Arrays.asList( "1", "2" )));
+
+		em.persist( wombatSoftware2 );
+
+		commit();
+
+		em.remove(wombatSoftware2);
+
 		close( em );
 	}
 
@@ -238,9 +271,15 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 		assertThat( poem.getAuthor() ).as( "Wrong Author" ).isEqualTo( expectedPoem.getAuthor() );
 	}
 
+	private void assertAreEquals(User expectedUser, User user) {
+		assertThat( user ).isNotNull();
+		assertThat( user.getId() ).as( "Wrong Id" ).isEqualTo( expectedUser.getId() );
+		assertThat( user.getName() ).as( "Wrong Name" ).isEqualTo( expectedUser.getName() );
+	}
+
 	@Override
 	public Class<?>[] getEntities() {
-		return new Class<?>[] { OscarWildePoem.class };
+		return new Class<?>[] { OscarWildePoem.class, User.class, EmbeddedList.class };
 	}
 
 	private void close(EntityManager em) {

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/User.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/User.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.nativequery;
+
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class User {
+	@Id
+	private String id;
+
+	@Embedded
+	private EmbeddedList list;
+
+	private String name;
+
+	protected User() { }
+
+	public User(String id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public EmbeddedList getList() {
+		return list;
+	}
+
+	public void setList(EmbeddedList list) {
+		this.list = list;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}


### PR DESCRIPTION
I have an entity (User) which contains an embedded document (EmbeddedList) which contains an @ElementCollection List<String> and another field.
As soon as I try to save the user with an empty embedded document, the process fails with "com.mongodb.MongoException$DuplicateKey error" although the entity has not been stored so far.
