### PR TITLE
OGM-622 Upgrade Neo4j version to 2.1.5

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-cypher-compiler-1.9</artifactId>
-            <version>2.0.3</version>
+            <version>${neo4jCypherCompilerOlderVersion}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>neo4j-graph-matching</artifactId>
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-cypher-compiler-2.0</artifactId>
-            <version>2.0.3</version>
+            <version>${neo4jCypherCompilerOlderVersion}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>neo4j-graph-matching</artifactId>

--- a/modules/eap/src/main/modules/ogm/neo4j/module.xml
+++ b/modules/eap/src/main/modules/ogm/neo4j/module.xml
@@ -11,8 +11,8 @@
         <resource-root path="neo4j-${neo4jVersion}.jar" />
         <resource-root path="neo4j-cypher-${neo4jVersion}.jar" />
         <resource-root path="neo4j-cypher-commons-${neo4jVersion}.jar" />
-        <resource-root path="neo4j-cypher-compiler-1.9-2.0.3.jar" />
-        <resource-root path="neo4j-cypher-compiler-2.0-2.0.3.jar" />
+        <resource-root path="neo4j-cypher-compiler-1.9-${neo4jCypherCompilerOlderVersion}.jar" />
+        <resource-root path="neo4j-cypher-compiler-2.0-${neo4jCypherCompilerOlderVersion}.jar" />
         <resource-root path="neo4j-cypher-compiler-2.1-${neo4jVersion}.jar" />
         <resource-root path="neo4j-lucene-index-${neo4jVersion}.jar" />
         <resource-root path="neo4j-kernel-${neo4jVersion}.jar" />
@@ -20,11 +20,11 @@
         <resource-root path="neo4j-graph-algo-${neo4jVersion}.jar" />
         <resource-root path="neo4j-graph-matching-${neo4jVersion}.jar" />
         <resource-root path="neo4j-jmx-${neo4jVersion}.jar" />
-        <resource-root path="lucene-core-3.6.2.jar" />
-        <resource-root path="parboiled-scala_2.10-1.1.6.jar" />
-        <resource-root path="scala-library-2.10.4.jar" />
+        <resource-root path="lucene-core-${luceneVersion}.jar" />
+        <resource-root path="parboiled-scala_2.10-${parboiledVersion}.jar" />
+        <resource-root path="scala-library-${scalaLibraryVersion}.jar" />
         <resource-root path="neo4j-primitive-collections-${neo4jVersion}.jar" />
-        <resource-root path="concurrentlinkedhashmap-lru-1.3.1.jar" />
+        <resource-root path="concurrentlinkedhashmap-lru-${concurrentlinkedhashmapVersion}.jar" />
     </resources>
     <dependencies>
         <module name="org.hibernate" export="true" services="import" slot="${hibernate.ogm.module.slot}" />

--- a/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
@@ -11,8 +11,8 @@
         <resource-root path="neo4j-${neo4jVersion}.jar" />
         <resource-root path="neo4j-cypher-${neo4jVersion}.jar" />
         <resource-root path="neo4j-cypher-commons-${neo4jVersion}.jar" />
-        <resource-root path="neo4j-cypher-compiler-1.9-2.0.3.jar" />
-        <resource-root path="neo4j-cypher-compiler-2.0-2.0.3.jar" />
+        <resource-root path="neo4j-cypher-compiler-1.9-${neo4jCypherCompilerOlderVersion}.jar" />
+        <resource-root path="neo4j-cypher-compiler-2.0-${neo4jCypherCompilerOlderVersion}.jar" />
         <resource-root path="neo4j-cypher-compiler-2.1-${neo4jVersion}.jar" />
         <resource-root path="neo4j-lucene-index-${neo4jVersion}.jar" />
         <resource-root path="neo4j-kernel-${neo4jVersion}.jar" />
@@ -20,10 +20,10 @@
         <resource-root path="neo4j-graph-algo-${neo4jVersion}.jar" />
         <resource-root path="neo4j-graph-matching-${neo4jVersion}.jar" />
         <resource-root path="neo4j-jmx-${neo4jVersion}.jar" />
-        <resource-root path="parboiled-scala_2.10-1.1.6.jar" />
-        <resource-root path="scala-library-2.10.4.jar" />
+        <resource-root path="parboiled-scala_2.10-${parboiledVersion}.jar" />
+        <resource-root path="scala-library-${scalaLibraryVersion}.jar" />
         <resource-root path="neo4j-primitive-collections-${neo4jVersion}.jar" />
-        <resource-root path="concurrentlinkedhashmap-lru-1.3.1.jar" />
+        <resource-root path="concurrentlinkedhashmap-lru-${concurrentlinkedhashmapVersion}.jar" />
     </resources>
     <dependencies>
         <module name="org.hibernate" export="true" services="import" slot="${hibernate.ogm.module.slot}" />

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <infinispanVersion>6.0.0.Final</infinispanVersion>
         <mongodbVersion>2.12.4</mongodbVersion>
         <neo4jVersion>2.1.5</neo4jVersion>
+        <neo4jCypherCompilerOlderVersion>2.0.3</neo4jCypherCompilerOlderVersion>
         <hibernateVersion>4.3.6.Final</hibernateVersion>
         <hibernateSearchVersion>4.5.1.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.0.0.CR1</hibernateParserVersion>
@@ -137,6 +138,8 @@
         <resteasyVersion>3.0.9.Final</resteasyVersion>
         <jacksonVersion>2.4.1</jacksonVersion>
         <parboiledVersion>1.1.6</parboiledVersion>
+        <scalaLibraryVersion>2.10.4</scalaLibraryVersion>
+        <concurrentlinkedhashmapVersion>1.3.1</concurrentlinkedhashmapVersion>
         <asmVersion>4.1</asmVersion>
 
         <!-- test dependency versions, managed below -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-622

At the moment `org.neo4j:neo4j` includes different version of the same libraries. While this is not usually a problem because maven will automagically select only one to resolve conflicts this is a problme for because we use the enforce plugin.

That's the reason in the BOM I exclude some dependencies from neo4 to include them with the rgiht version.

I've talked with the Neo4j folks and they agreed to apply a patch if I send it, I will do that soon.
