### PR TITLE
OGM-639 Ignore unrecognized parameters with JDK 9

### DIFF
--- a/integrationtest/couchdb/src/test/resources/arquillian.xml
+++ b/integrationtest/couchdb/src/test/resources/arquillian.xml
@@ -19,6 +19,7 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property> -->
         </configuration>

--- a/integrationtest/mongodb/src/test/resources/arquillian.xml
+++ b/integrationtest/mongodb/src/test/resources/arquillian.xml
@@ -19,6 +19,7 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property> -->
         </configuration>

--- a/integrationtest/neo4j/src/test/resources/arquillian.xml
+++ b/integrationtest/neo4j/src/test/resources/arquillian.xml
@@ -19,6 +19,7 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property>  -->
         </configuration>

--- a/integrationtest/testcase/src/test/resources/arquillian.xml
+++ b/integrationtest/testcase/src/test/resources/arquillian.xml
@@ -19,6 +19,7 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property> -->
         </configuration>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-639

This should make the integration tests work with JDK 9. Currently they are disabled on CI
