### PR TITLE
OGM-639 Exclude jconsole.jar as transitive dependency

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -110,6 +110,14 @@
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- This exclusion is needed to be able to setup the project in Windows:
+                     it otherwise includes transitive dependency to the JDK JConsole -->
+                <exclusion>
+                    <artifactId>wildfly-patching</artifactId>
+                    <groupId>org.wildfly</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.ejb</groupId>
@@ -153,12 +161,20 @@
                 <jboss.home>${project.build.directory}/wildfly-${version.wildfly}</jboss.home>
             </properties>
             <dependencies>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.wildfly}</version>
-                    <scope>test</scope>
-                </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-arquillian-container-managed</artifactId>
+                <version>${version.wildfly}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!-- This exclusion is needed to be able to setup the project in Windows:
+                         it otherwise includes transitive dependency to the JDK JConsole -->
+                    <exclusion>
+                        <artifactId>wildfly-patching</artifactId>
+                        <groupId>org.wildfly</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
  This has two benefits:
- the build is possible in Windows
- the build works with JDK 9

This a missing commit to make the integration tests work with JDK 9 on jenkins
