### PR TITLE
OGM-576 Making sure locking strategies are correctly initialized;

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ExceptionThrowingLockingStrategy.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ExceptionThrowingLockingStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import java.io.Serializable;
+
+import org.hibernate.LockMode;
+import org.hibernate.StaleObjectStateException;
+import org.hibernate.dialect.lock.LockingStrategy;
+import org.hibernate.dialect.lock.LockingStrategyException;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
+/**
+ * A {@link LockingStrategy} which always raises an exception upon lock retrieval.
+ * <p>
+ * Used to initialize the locker infrastructure ORM while lazily raising an exception upon invocation of
+ * {@code EntityManager#lock()} or similar.
+ *
+ * @author Gunnar Morling
+ */
+public class ExceptionThrowingLockingStrategy implements LockingStrategy {
+
+	private static final Log LOG = LoggerFactory.make();
+
+	private final Class<? extends GridDialect> gridDialectClass;
+	private final LockMode lockMode;
+
+	public ExceptionThrowingLockingStrategy(GridDialect gridDialect, LockMode lockMode) {
+		this.gridDialectClass = gridDialect.getClass();
+		this.lockMode = lockMode;
+	}
+
+	@Override
+	public void lock(Serializable id, Object version, Object object, int timeout, SessionImplementor session) throws StaleObjectStateException,
+			LockingStrategyException {
+
+		throw LOG.unsupportedLockMode( gridDialectClass, lockMode );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
@@ -6,8 +6,12 @@
  */
 package org.hibernate.ogm.dialect.spi;
 
+import org.hibernate.LockMode;
+import org.hibernate.dialect.lock.LockingStrategy;
+import org.hibernate.ogm.dialect.impl.ExceptionThrowingLockingStrategy;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.type.spi.GridType;
+import org.hibernate.persister.entity.Lockable;
 import org.hibernate.type.Type;
 
 /**
@@ -16,6 +20,15 @@ import org.hibernate.type.Type;
  * @author Gunnar Morling
  */
 public abstract class BaseGridDialect implements GridDialect {
+
+	/**
+	 * Returns a no-op locking strategy for all lock modes which will raise an exception upon lock retrieval. Dialects
+	 * may override this method to provide support for those lock modes they can handle.
+	 */
+	@Override
+	public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
+		return new ExceptionThrowingLockingStrategy( this, lockMode );
+	}
 
 	@Override
 	public GridType overrideType(Type type) {

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
@@ -32,6 +32,14 @@ import org.hibernate.type.Type;
  */
 public interface GridDialect extends Service {
 
+	/**
+	 * Returns a {@link LockingStrategy} for locking the given lockable, using the given lock mode.
+	 *
+	 * @param lockable Static meta-data describing a lockable type
+	 * @param lockMode A lock mode
+	 * @return A locking strategy for the given lockable and lock mode or {@code null} if this dialect does not support
+	 * the specified lock mode
+	 */
 	LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode);
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -44,6 +44,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
 import org.hibernate.ogm.dialect.identity.spi.IdentityColumnAwareGridDialect;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
+import org.hibernate.ogm.dialect.impl.ExceptionThrowingLockingStrategy;
 import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.optimisticlock.spi.OptimisticLockingAwareGridDialect;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
@@ -285,6 +286,8 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		propertyMightRequireInverseAssociationManagement = getPropertyMightRequireInverseAssociationManagement();
 		mightRequireInverseAssociationManagement = initMayManageInverseAssociations();
 		usesNonAtomicOptimisticLocking = initUsesNonAtomicOptimisticLocking();
+
+		initLockers();
 	}
 
 	// Required to avoid null pointer errors when super.postInstantiate() is called
@@ -938,9 +941,9 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 	@Override
 	protected LockingStrategy generateLocker(LockMode lockMode) {
-		return gridDialect.getLockingStrategy( this, lockMode );
+		LockingStrategy lockingStrategy = gridDialect.getLockingStrategy( this, lockMode );
+		return lockingStrategy != null ? lockingStrategy : new ExceptionThrowingLockingStrategy( gridDialect, lockMode );
 	}
-
 
 	/**
 	 * Update an object

--- a/core/src/main/java/org/hibernate/ogm/util/impl/ClassObjectFormatter.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/ClassObjectFormatter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.util.impl;
+
+/**
+ * Used with JBoss Logging to display class names in log messages.
+ *
+ * @author Gunnar Morling
+ */
+public class ClassObjectFormatter {
+
+	private final String stringRepresentation;
+
+	public ClassObjectFormatter(Class<?> clazz) {
+		this.stringRepresentation = clazz.getName();
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -17,12 +17,15 @@ import java.lang.annotation.ElementType;
 import javax.transaction.SystemException;
 
 import org.hibernate.HibernateException;
+import org.hibernate.LockMode;
 import org.hibernate.TransactionException;
 import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.exception.EntityAlreadyExistsException;
 import org.hibernate.ogm.options.spi.AnnotationConverter;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Cause;
+import org.jboss.logging.FormatWith;
 import org.jboss.logging.LogMessage;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
@@ -216,4 +219,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 68, value = "Could not configure property %1$s#%2$s")
 	HibernateException couldNotConfigureProperty(String entityName, String string, @Cause Exception e);
+
+	@Message(id = 69, value = "Grid dialect %1$s does not support lock mode %2$s")
+	HibernateException unsupportedLockMode(@FormatWith(ClassObjectFormatter.class) Class<? extends GridDialect> dialectClass, LockMode lockMode);
 }

--- a/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
@@ -7,10 +7,8 @@
 package org.hibernate.ogm.test.batch;
 
 import org.fest.assertions.Assertions;
-import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
@@ -30,7 +28,6 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.utils.OgmTestCase;
-import org.hibernate.persister.entity.Lockable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,11 +99,6 @@ public class BatchExecutionTest extends OgmTestCase {
 		@Override
 		public void executeBatch(OperationsQueue queue) {
 			batchExecuted = true;
-		}
-
-		@Override
-		public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-			return null;
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
@@ -8,9 +8,7 @@ package org.hibernate.ogm.test.datastore;
 
 import java.util.Iterator;
 
-import org.hibernate.LockMode;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
@@ -30,7 +28,6 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.persister.entity.Lockable;
 
 /**
  * Example of datastore provider using metadata to generate some hypothetical
@@ -77,11 +74,6 @@ public class DatastoreProviderGeneratingSchema extends BaseDatastoreProvider {
 
 		public Dialect(DatastoreProviderGeneratingSchema provider) {
 
-		}
-
-		@Override
-		public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-			return null;
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
+++ b/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.ogm.test.options.mapping.model;
 
-import org.hibernate.LockMode;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
@@ -22,7 +20,6 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.persister.entity.Lockable;
 
 /**
  * @author Gunnar Morling
@@ -37,11 +34,6 @@ public class SampleDatastoreProvider extends BaseDatastoreProvider {
 	public static class SampleDialect extends BaseGridDialect {
 
 		public SampleDialect(SampleDatastoreProvider provider) {
-		}
-
-		@Override
-		public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-			return null;
 		}
 
 		@Override

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 import javax.persistence.OptimisticLockException;
 
-import org.hibernate.LockMode;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.impl.CouchDBDatastore;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.AssociationDocument;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.Document;
@@ -48,7 +46,6 @@ import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.type.impl.Iso8601StringCalendarType;
 import org.hibernate.ogm.type.impl.Iso8601StringDateType;
 import org.hibernate.ogm.type.spi.GridType;
-import org.hibernate.persister.entity.Lockable;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 
@@ -67,11 +64,6 @@ public class CouchDBDialect extends BaseGridDialect {
 
 	public CouchDBDialect(CouchDBDatastoreProvider provider) {
 		this.provider = provider;
-	}
-
-	@Override
-	public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-		return null;
 	}
 
 	@Override

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -71,7 +71,9 @@ public class EhcacheDialect extends BaseGridDialect {
 		else if ( lockMode == LockMode.OPTIMISTIC_FORCE_INCREMENT ) {
 			return new OptimisticForceIncrementLockingStrategy( lockable, lockMode );
 		}
-		throw new UnsupportedOperationException( "LockMode " + lockMode + " is not supported by the Ehcache GridDialect" );
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
@@ -88,8 +88,9 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 		else if ( lockMode == LockMode.OPTIMISTIC_FORCE_INCREMENT ) {
 			return new OptimisticForceIncrementLockingStrategy( lockable, lockMode );
 		}
-		throw new UnsupportedOperationException( "LockMode " + lockMode
-				+ " is not supported by the Infinispan GridDialect" );
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 import org.bson.types.ObjectId;
 import org.hibernate.HibernateException;
-import org.hibernate.LockMode;
 import org.hibernate.annotations.common.AssertionFailure;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.document.options.spi.AssociationStorageOption;
@@ -79,7 +77,6 @@ import org.hibernate.ogm.model.spi.TupleOperation;
 import org.hibernate.ogm.type.impl.StringCalendarDateType;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.ogm.util.impl.CollectionHelper;
-import org.hibernate.persister.entity.Lockable;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 import org.parboiled.Parboiled;
@@ -139,11 +136,6 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	public MongoDBDialect(MongoDBDatastoreProvider provider) {
 		this.provider = provider;
 		this.currentDB = this.provider.getDatabase();
-	}
-
-	@Override
-	public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-		throw new UnsupportedOperationException( "The MongoDB GridDialect does not support locking" );
 	}
 
 	@Override

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
@@ -20,8 +20,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.hibernate.AssertionFailure;
-import org.hibernate.LockMode;
-import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.TypedValue;
@@ -68,7 +66,6 @@ import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.ogm.type.spi.TypeTranslator;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.persister.entity.Lockable;
 import org.hibernate.service.spi.ServiceRegistryAwareService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.type.Type;
@@ -161,11 +158,6 @@ public class Neo4jDialect extends BaseGridDialect implements QueryableGridDialec
 			}
 		}
 		return queryMap;
-	}
-
-	@Override
-	public LockingStrategy getLockingStrategy(Lockable lockable, LockMode lockMode) {
-		throw new UnsupportedOperationException( "LockMode " + lockMode + " is not supported by the Neo4j GridDialect" );
 	}
 
 	@Override


### PR DESCRIPTION
- For unsupported lock modes using a no-op strategy which raises an exception upon lock retrieval
- Documenting GridDialect#getLockingStrategy() SPI
