### PR TITLE
OGM-678 Remove AssociationOperationType.PUT_NULL operation

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapHelpers.java
@@ -69,7 +69,6 @@ public final class MapHelpers {
 				case PUT:
 					underlyingMap.put( action.getKey(), MapHelpers.associationRowToMap( action.getValue() ) );
 					break;
-				case PUT_NULL:
 				case REMOVE:
 					underlyingMap.remove( action.getKey() );
 					break;

--- a/core/src/main/java/org/hibernate/ogm/model/spi/AssociationOperationType.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/AssociationOperationType.java
@@ -12,8 +12,11 @@ package org.hibernate.ogm.model.spi;
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 public enum AssociationOperationType {
+	/**
+	 * The PUT operation is never for a null value.
+	 * Use REMOVE instead.
+	 */
 	PUT,
 	REMOVE,
-	PUT_NULL,
 	CLEAR
 }

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -160,7 +160,6 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 			switch ( action.getType() ) {
 				case CLEAR:
 					associationRows.clear();
-				case PUT_NULL:
 				case PUT:
 					associationRows.put( new SerializableRowKey( action.getKey() ), MapHelpers.associationRowToMap( action.getValue() ) );
 					break;

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
@@ -353,7 +353,6 @@ public class Neo4jDialect extends BaseGridDialect implements QueryableGridDialec
 		case PUT:
 			putAssociationOperation( association, key, operation, associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata() );
 			break;
-		case PUT_NULL:
 		case REMOVE:
 			removeAssociationOperation( association, key, operation, associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata() );
 			break;


### PR DESCRIPTION
It was never used and is quite doubtful it would be necessary.
I added a Contracts.assertNotNull on association.put to prevent setting
the value to null.
