### PR TITLE
OGM-684 Wrap DatastoreProvider.start() calls in a ServiceException

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -23,6 +23,8 @@ import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.exception.EntityAlreadyExistsException;
 import org.hibernate.ogm.options.spi.AnnotationConverter;
+import org.hibernate.service.spi.ServiceException;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.FormatWith;
@@ -237,4 +239,7 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = WARN)
 	@Message(id = 70, value = "'%1$s' is no valid datastore provider short name. Valid values are: %2$s")
 	void noValidDatastoreProviderShortName(String providerName, String validProviderNames);
+
+	@Message(id = 71, value = "Unable to start datatore provider")
+	ServiceException unableToStartDatastoreProvider(@Cause Exception e);
 }

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/impl/CouchDBDatastoreProvider.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/impl/CouchDBDatastoreProvider.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.datastore.couchdb.impl;
 
 import java.util.Map;
 
+import org.hibernate.HibernateException;
 import org.hibernate.ogm.datastore.couchdb.CouchDBDialect;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.impl.CouchDBDatastore;
 import org.hibernate.ogm.datastore.couchdb.logging.impl.Log;
@@ -60,7 +61,14 @@ public class CouchDBDatastoreProvider extends BaseDatastoreProvider implements S
 	@Override
 	public void start() {
 		if ( isDatastoreNotInitialized() ) {
-			datastore = CouchDBDatastore.newInstance( getDatabase(), configuration.isCreateDatabase() );
+			try {
+				datastore = CouchDBDatastore.newInstance( getDatabase(), configuration.isCreateDatabase() );
+			}
+			catch (HibernateException e) {
+				// Wrap HibernateException in a ServiceException to make the stack trace more friendly
+				// Otherwise a generic unable to request service is thrown
+				throw logger.unableToStartDatastoreProvider( e );
+			}
 		}
 	}
 

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/InfinispanDatastoreProvider.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/InfinispanDatastoreProvider.java
@@ -67,6 +67,7 @@ public class InfinispanDatastoreProvider extends BaseDatastoreProvider implement
 			}
 		}
 		catch (RuntimeException e) {
+			// return a ServiceException to be stack trace friendly
 			throw LOG.unableToInitializeInfinispan( e );
 		}
 

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/logging/impl/Log.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/logging/impl/Log.java
@@ -7,6 +7,8 @@
 package org.hibernate.ogm.datastore.infinispan.logging.impl;
 
 import org.hibernate.HibernateException;
+import org.hibernate.service.spi.ServiceException;
+
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -24,5 +26,5 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	HibernateException unexpectedKeyVersion(Class<?> clazz, int version, int supportedVersion);
 
 	@Message(id = 1102, value = "Unable to find or initialize Infinispan CacheManager")
-	HibernateException unableToInitializeInfinispan(@Cause RuntimeException e);
+	ServiceException unableToInitializeInfinispan(@Cause RuntimeException e);
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/DatastoreInitializationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/DatastoreInitializationTest.java
@@ -7,14 +7,15 @@
 package org.hibernate.ogm.datastore.mongodb.test.datastore;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.ogm.cfg.OgmProperties;
@@ -23,6 +24,7 @@ import org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider;
 import org.hibernate.ogm.options.navigation.impl.OptionsServiceImpl;
 import org.hibernate.ogm.options.spi.OptionsService;
 import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.service.spi.ServiceException;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,8 +55,10 @@ public class DatastoreInitializationTest {
 		provider.injectServices( getServiceRegistry( cfg ) );
 		provider.configure( cfg );
 
-		error.expect( HibernateException.class );
-		error.expectMessage( "OGM001213" );
+		error.expect( ServiceException.class );
+		error.expectMessage( "OGM000071" );
+		//nested exception
+		error.expectCause( hasMessage( containsString( "OGM001213" ) ) );
 
 		provider.start();
 	}
@@ -68,8 +72,10 @@ public class DatastoreInitializationTest {
 		provider.injectServices( getServiceRegistry( cfg ) );
 		provider.configure( cfg );
 
-		error.expect( HibernateException.class );
-		error.expectMessage( "OGM001214" );
+		error.expect( ServiceException.class );
+		error.expectMessage( "OGM000071" );
+		//nested exception
+		error.expectCause( hasMessage( containsString( "OGM001214" ) ) );
 
 		provider.start();
 	}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/impl/Neo4jDatastoreProvider.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/impl/Neo4jDatastoreProvider.java
@@ -12,6 +12,8 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.ogm.datastore.neo4j.Neo4jDialect;
 import org.hibernate.ogm.datastore.neo4j.Neo4jProperties;
 import org.hibernate.ogm.datastore.neo4j.dialect.impl.Neo4jSequenceGenerator;
+import org.hibernate.ogm.datastore.neo4j.logging.impl.Log;
+import org.hibernate.ogm.datastore.neo4j.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jBasedQueryParserService;
 import org.hibernate.ogm.datastore.neo4j.spi.GraphDatabaseServiceFactory;
 import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
@@ -34,6 +36,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 public class Neo4jDatastoreProvider extends BaseDatastoreProvider implements Startable, Stoppable, Configurable, ServiceRegistryAwareService {
 
 	private static final int DEFAULT_SEQUENCE_QUERY_CACHE_MAX_SIZE = 128;
+	private static Log LOG = LoggerFactory.getLogger();
 
 	private GraphDatabaseService neo4jDb;
 
@@ -71,10 +74,15 @@ public class Neo4jDatastoreProvider extends BaseDatastoreProvider implements Sta
 
 	@Override
 	public void start() {
-		this.neo4jDb = graphDbFactory.create();
-		this.sequenceGenerator = new Neo4jSequenceGenerator( neo4jDb, sequenceCacheMaxSize );
-		this.graphDbFactory = null;
-		this.sequenceCacheMaxSize = null;
+		try {
+			this.neo4jDb = graphDbFactory.create();
+			this.sequenceGenerator = new Neo4jSequenceGenerator( neo4jDb, sequenceCacheMaxSize );
+			this.graphDbFactory = null;
+			this.sequenceCacheMaxSize = null;
+		}
+		catch (Exception e) {
+			throw LOG.unableToStartDatastoreProvider( e );
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This avoid generic exception wrapping from the service layer
