### PR TITLE
Preview: Update to Hibernate Search 5.0

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchCoordinator.java
+++ b/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchCoordinator.java
@@ -18,7 +18,7 @@ import org.hibernate.ogm.util.impl.LoggerFactory;
 import org.hibernate.search.backend.PurgeAllLuceneWork;
 import org.hibernate.search.backend.impl.batch.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
-import org.hibernate.search.engine.spi.SearchFactoryImplementor;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.ErrorHandler;
 
 /**
@@ -34,7 +34,7 @@ public class BatchCoordinator implements Runnable {
 	private static final Log log = LoggerFactory.make();
 
 	private final Class<?>[] rootEntities; // entity types to reindex excluding all subtypes of each-other
-	private final SearchFactoryImplementor searchFactoryImplementor;
+	private final ExtendedSearchIntegrator searchFactoryImplementor;
 	private final SessionFactoryImplementor sessionFactory;
 	private final int typesToIndexInParallel;
 	private final CacheMode cacheMode;
@@ -47,7 +47,7 @@ public class BatchCoordinator implements Runnable {
 
 	private final GridDialect gridDialect;
 
-	public BatchCoordinator(GridDialect gridDialect, Set<Class<?>> rootEntities, SearchFactoryImplementor searchFactoryImplementor,
+	public BatchCoordinator(GridDialect gridDialect, Set<Class<?>> rootEntities, ExtendedSearchIntegrator searchFactoryImplementor,
 			SessionFactoryImplementor sessionFactory, int typesToIndexInParallel, CacheMode cacheMode, boolean optimizeAtEnd, boolean purgeAtStart,
 			boolean optimizeAfterPurge, MassIndexerProgressMonitor monitor) {
 		this.gridDialect = gridDialect;

--- a/core/src/main/java/org/hibernate/ogm/massindex/impl/OgmMassIndexer.java
+++ b/core/src/main/java/org/hibernate/ogm/massindex/impl/OgmMassIndexer.java
@@ -18,9 +18,10 @@ import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
 import org.hibernate.search.MassIndexer;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
-import org.hibernate.search.engine.spi.SearchFactoryImplementor;
-import org.hibernate.search.impl.SimpleIndexingProgressMonitor;
-import org.hibernate.search.jmx.IndexingProgressMonitor;
+import org.hibernate.search.batchindexing.impl.SimpleIndexingProgressMonitor;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.jmx.impl.JMXRegistrar.IndexingProgressMonitor;
+import org.hibernate.search.spi.SearchIntegrator;
 
 /**
  * {@link MassIndexer} that can be register in Hibernate Search to index existing data stores.
@@ -32,7 +33,7 @@ public class OgmMassIndexer implements MassIndexer {
 
 	private static final Log log = LoggerFactory.make();
 
-	private final SearchFactoryImplementor searchFactory;
+	private final ExtendedSearchIntegrator searchIntegrator;
 	private final SessionFactoryImplementor sessionFactory;
 	private final GridDialect gridDialect;
 
@@ -45,15 +46,15 @@ public class OgmMassIndexer implements MassIndexer {
 
 	private final Set<Class<?>> rootEntities;
 
-	public OgmMassIndexer(GridDialect gridDialect, SearchFactoryImplementor searchFactory, SessionFactoryImplementor sessionFactory, Class<?>... entities) {
+	public OgmMassIndexer(GridDialect gridDialect, SearchIntegrator searchFactory, SessionFactoryImplementor sessionFactory, Class<?>... entities) {
 		this.gridDialect = gridDialect;
-		this.searchFactory = searchFactory;
+		this.searchIntegrator = searchFactory.unwrap( ExtendedSearchIntegrator.class );
 		this.sessionFactory = sessionFactory;
-		this.rootEntities = toRootEntities( searchFactory, entities );
-		this.monitor = createMonitor( searchFactory );
+		this.rootEntities = toRootEntities( searchIntegrator, entities );
+		this.monitor = createMonitor( searchIntegrator );
 	}
 
-	private MassIndexerProgressMonitor createMonitor(SearchFactoryImplementor searchFactory) {
+	private MassIndexerProgressMonitor createMonitor(ExtendedSearchIntegrator searchFactory) {
 		return searchFactory.isJMXEnabled() ? new IndexingProgressMonitor() : new SimpleIndexingProgressMonitor();
 	}
 
@@ -72,12 +73,6 @@ public class OgmMassIndexer implements MassIndexer {
 	@Override
 	public MassIndexer threadsForSubsequentFetching(int numberOfThreads) {
 		log.unsupportedIndexerConfigurationOption( "threadForSubsequentFetching" );
-		return this;
-	}
-
-	@Override
-	@Deprecated
-	public MassIndexer threadsForIndexWriter(int numberOfThreads) {
 		return this;
 	}
 
@@ -148,7 +143,7 @@ public class OgmMassIndexer implements MassIndexer {
 	}
 
 	protected BatchCoordinator createCoordinator() {
-		return new BatchCoordinator( gridDialect, rootEntities, searchFactory, sessionFactory, typesToIndexInParallel, cacheMode, optimizeOnFinish,
+		return new BatchCoordinator( gridDialect, rootEntities, searchIntegrator, sessionFactory, typesToIndexInParallel, cacheMode, optimizeOnFinish,
 				purgeAllOnStart, optimizeAfterPurge, monitor );
 	}
 
@@ -164,7 +159,7 @@ public class OgmMassIndexer implements MassIndexer {
 	 *
 	 * @return a new set of entities
 	 */
-	private static Set<Class<?>> toRootEntities(SearchFactoryImplementor searchFactoryImplementor, Class<?>... selection) {
+	private static Set<Class<?>> toRootEntities(ExtendedSearchIntegrator searchFactoryImplementor, Class<?>... selection) {
 		Set<Class<?>> entities = new HashSet<Class<?>>();
 		// first build the "entities" set containing all indexed subtypes of "selection".
 		for ( Class<?> entityType : selection ) {

--- a/core/src/main/java/org/hibernate/ogm/massindex/impl/OgmMassIndexerFactory.java
+++ b/core/src/main/java/org/hibernate/ogm/massindex/impl/OgmMassIndexerFactory.java
@@ -11,9 +11,8 @@ import java.util.Properties;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.search.MassIndexer;
-import org.hibernate.search.engine.spi.SearchFactoryImplementor;
-import org.hibernate.search.hcore.impl.MassIndexerFactoryProvider;
-import org.hibernate.search.spi.MassIndexerFactory;
+import org.hibernate.search.batchindexing.spi.MassIndexerFactory;
+import org.hibernate.search.spi.SearchIntegrator;
 
 /**
  * {@link MassIndexerFactory} that can be used to register the {@link OgmMassIndexer} to Hibernate Search.
@@ -28,7 +27,7 @@ public class OgmMassIndexerFactory implements MassIndexerFactory {
 	}
 
 	@Override
-	public MassIndexer createMassIndexer(SearchFactoryImplementor searchFactory, SessionFactoryImplementor sessionFactory,
+	public MassIndexer createMassIndexer(SearchIntegrator searchFactory, SessionFactoryImplementor sessionFactory,
 			Class<?>... entities) {
 		return new OgmMassIndexer( sessionFactory.getServiceRegistry().getService( GridDialect.class ), searchFactory, sessionFactory, entities );
 	}

--- a/core/src/main/java/org/hibernate/ogm/query/impl/FullTextSearchQueryTranslator.java
+++ b/core/src/main/java/org/hibernate/ogm/query/impl/FullTextSearchQueryTranslator.java
@@ -32,11 +32,11 @@ import org.hibernate.internal.util.collections.BoundedConcurrentHashMap;
 import org.hibernate.ogm.service.impl.SessionFactoryEntityNamesResolver;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
-import org.hibernate.search.ProjectionConstants;
 import org.hibernate.search.Search;
-import org.hibernate.search.engine.spi.SearchFactoryImplementor;
+import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
+import org.hibernate.search.spi.SearchIntegrator;
 
 /**
  * A {@link QueryTranslator} which translates JP-QL queries into equivalent Lucene queries and executes those via
@@ -145,7 +145,7 @@ public class FullTextSearchQueryTranslator extends LegacyParserBridgeQueryTransl
 	}
 
 	private LuceneProcessingChain createProcessingChain(Map<String, Object> namedParameters, FullTextSession fullTextSession) {
-		SearchFactoryImplementor searchFactory = (SearchFactoryImplementor) fullTextSession.getSearchFactory();
+		SearchIntegrator searchFactory = fullTextSession.getSearchFactory().unwrap( SearchIntegrator.class );
 
 		return new LuceneProcessingChain.Builder( searchFactory, entityNamesResolver )
 				.namedParameters( namedParameters )

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
@@ -142,7 +142,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	@SkipByGridDialect(value = { MONGODB, NEO4J }, comment = "Doesn't apply to MongoDB or Neo4j queries.")
 	public void testSelectingCompleteIndexedEmbeddedEntityInProjectionQueryRaisesException() throws Exception {
 		thrown.expect( ParsingException.class );
-		thrown.expectMessage( "HQLLUCN000005" );
+		thrown.expectMessage( "HQL100005" );
 
 		session.createQuery( "select h.author from Hypothesis h" ).list();
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/WithEmbedded.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/WithEmbedded.java
@@ -10,16 +10,13 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
-import org.hibernate.search.annotations.Store;
 
 @Indexed
 @Entity
 public class WithEmbedded {
 
-	@Field(store = Store.YES)
 	@Id
 	private Long id;
 

--- a/core/src/test/java/org/hibernate/ogm/utils/jpa/JpaTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/jpa/JpaTestCase.java
@@ -29,7 +29,7 @@ import org.hibernate.ogm.jpa.HibernateOgmPersistence;
 import org.hibernate.ogm.massindex.impl.OgmMassIndexerFactory;
 import org.hibernate.ogm.utils.GridDialectSkippableTestRunner;
 import org.hibernate.ogm.utils.TestHelper;
-import org.hibernate.search.hcore.impl.MassIndexerFactoryProvider;
+import org.hibernate.search.batchindexing.spi.MassIndexerFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -76,7 +76,7 @@ public abstract class JpaTestCase {
 		info.setSharedCacheMode( SharedCacheMode.ENABLE_SELECTIVE );
 		info.setTransactionType( PersistenceUnitTransactionType.JTA );
 		info.setValidationMode( ValidationMode.AUTO );
-		info.getProperties().setProperty( MassIndexerFactoryProvider.MASS_INDEXER_FACTORY_CLASSNAME, OgmMassIndexerFactory.class.getName() );
+		info.getProperties().setProperty( MassIndexerFactory.MASS_INDEXER_FACTORY_CLASSNAME, OgmMassIndexerFactory.class.getName() );
 		for ( Map.Entry<String, String> entry : TestHelper.getEnvironmentProperties().entrySet() ) {
 			info.getProperties().setProperty( entry.getKey(), entry.getValue() );
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         -->
         <neo4jCypherCompilerOlderVersion>2.0.3</neo4jCypherCompilerOlderVersion>
         <hibernateVersion>4.3.7.Final</hibernateVersion>
-        <hibernateSearchVersion>4.5.1.Final</hibernateSearchVersion>
-        <hibernateParserVersion>1.0.0.CR1</hibernateParserVersion>
+        <hibernateSearchVersion>5.0.0.Final</hibernateSearchVersion>
+        <hibernateParserVersion>1.1.0.Final</hibernateParserVersion>
         <hibernateCommonsAnnotationsVersion>4.0.5.Final</hibernateCommonsAnnotationsVersion>
         <jbossjtaVersion>4.16.4.Final</jbossjtaVersion>
         <jbossLoggingVersion>3.1.4.GA</jbossLoggingVersion>


### PR DESCRIPTION
This is a preview for the changes which will be needed to upgrade to HS5.
I still need to release the new HQL Parser, will do that when I'll have resolved one last problem with the hot rod integration - but tests with OGM are fully passing now.

What needs to be discussed: how to isolate the Neo4J / Lucene 3 dependency?
It currently fails the dependency convergence tests.
