### PR TITLE
OGM-621 Extracting intermediary parent POM to avoid exposure of Guava an...

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.ogm</groupId>
+        <artifactId>hibernate-ogm-parent</artifactId>
+        <version>4.1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-ogm-build-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate OGM Build Parent POM</name>
+    <description>Hibernate OGM Build Parent POM; Manages test-scoped / build-time dependencies dependencies</description>
+
+    <!-- Only for management of test-scoped dependencies; All other dependencies (which are exposed to users) are
+         managed in the BOM -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.easytesting</groupId>
+                <artifactId>fest-assert</artifactId>
+                <version>1.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.experlog</groupId>
+                <artifactId>xapool</artifactId>
+                <scope>test</scope>
+                <version>1.5.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.jboss.naming</groupId>
+              <artifactId>jnp-client</artifactId>
+              <scope>test</scope>
+              <version>${jbossNamingVersion}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.jboss.naming</groupId>
+              <artifactId>jnpserver</artifactId>
+              <scope>test</scope>
+              <version>${jbossNamingVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${shrinkwrapVersion}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.9.5</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>18.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmhVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmhVersion}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,9 +11,9 @@
 
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-core</artifactId>

--- a/couchdb/pom.xml
+++ b/couchdb/pom.xml
@@ -3,10 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>hibernate-ogm-parent</artifactId>
         <groupId>org.hibernate.ogm</groupId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-couchdb</artifactId>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -11,9 +11,9 @@
 
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-ehcache</artifactId>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -11,11 +11,11 @@
 
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
-    
+
     <artifactId>hibernate-ogm-infinispan</artifactId>
     <packaging>jar</packaging>
 

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -1,9 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-module-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
+        <relativePath>../module-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-integrationtest</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -1,10 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>hibernate-ogm-parent</artifactId>
         <groupId>org.hibernate.ogm</groupId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-mongodb</artifactId>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -7,11 +7,12 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-neo4j</artifactId>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -11,9 +11,9 @@
 
     <parent>
         <groupId>org.hibernate.ogm</groupId>
-        <artifactId>hibernate-ogm-parent</artifactId>
+        <artifactId>hibernate-ogm-build-parent</artifactId>
         <version>4.1.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-ogm-performancetest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <inceptionYear>2010</inceptionYear>
 
     <modules>
+        <module>build-parent</module>
         <module>bom</module>
         <module>core</module>
         <module>ehcache</module>
@@ -174,79 +175,6 @@
         <!-- Not using default port to reduce chances of shutting down an external MongoDB instance -->
         <embeddedMongoDbPort>27018</embeddedMongoDbPort>
     </properties>
-
-    <!-- Only for management of test-scoped dependencies; All other dependencies (which are exposed to users) are
-         managed in the BOM -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.11</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert</artifactId>
-                <version>1.4</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.experlog</groupId>
-                <artifactId>xapool</artifactId>
-                <scope>test</scope>
-                <version>1.5.0</version>
-            </dependency>
-            <dependency>
-              <groupId>org.jboss.naming</groupId>
-              <artifactId>jnp-client</artifactId>
-              <scope>test</scope>
-              <version>${jbossNamingVersion}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.jboss.naming</groupId>
-              <artifactId>jnpserver</artifactId>
-              <scope>test</scope>
-              <version>${jbossNamingVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-bom</artifactId>
-                <version>${shrinkwrapVersion}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>18.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.openjdk.jmh</groupId>
-                <artifactId>jmh-core</artifactId>
-                <version>${jmhVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openjdk.jmh</groupId>
-                <artifactId>jmh-generator-annprocess</artifactId>
-                <version>${jmhVersion}</version>
-                <scope>provided</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <defaultGoal>install</defaultGoal>


### PR DESCRIPTION
...d other test dependencies on the public BOM

It's the best coming to my mind to avoid the leakage of Guava and the other stuff we use for testing through the public BOM. I thought about having an additional "test-only BOM" but that seemed more prone to being accidentally imported by users.

Let me know in case you have better ideas. Thx!