### PR TITLE
OGM-692 Query on embedded properties for Neo4j (and MongoDB)

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/AnotherEmbeddable.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/AnotherEmbeddable.java
@@ -14,16 +14,23 @@ import org.hibernate.search.annotations.Store;
 
 @Embeddable
 public class AnotherEmbeddable {
+
 	// Store.YES for filtering in query
 	// Analyze.NO for projection in query
 	@Field(store = Store.YES, analyze = Analyze.NO)
-	String embeddedString;
+	private String embeddedString;
+
+	// Store.YES for filtering in query
+	// Analyze.NO for projection in query
+	@Field(store = Store.YES, analyze = Analyze.NO)
+	private Integer embeddedInteger;
 
 	public AnotherEmbeddable() {
 	}
 
-	public AnotherEmbeddable(String embeddedString) {
+	public AnotherEmbeddable(String embeddedString, Integer embeddedInteger) {
 		this.embeddedString = embeddedString;
+		this.embeddedInteger = embeddedInteger;
 	}
 
 	public String getEmbeddedString() {
@@ -32,5 +39,13 @@ public class AnotherEmbeddable {
 
 	public void setEmbeddedString(String embeddedString) {
 		this.embeddedString = embeddedString;
+	}
+
+	public Integer getEmbeddedInteger() {
+		return embeddedInteger;
+	}
+
+	public void setEmbeddedInteger(Integer embeddedInteger) {
+		this.embeddedInteger = embeddedInteger;
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
@@ -1,0 +1,173 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.queries;
+
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.TestSessionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ * @author Gunnar Morling
+ * @author Davide D'Alto
+ */
+public class QueriesWithEmbeddedTest extends OgmTestCase {
+
+	@TestSessionFactory
+	public static SessionFactory sessions;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private Session session;
+
+	private Transaction tx;
+
+	@Before
+	public void createSession() {
+		closeSession();
+		session = sessions.openSession();
+		tx = session.beginTransaction();
+	}
+
+	@After
+	public void closeSession() {
+		if ( tx != null && tx.isActive() ) {
+			tx.commit();
+			tx = null;
+		}
+		if ( session != null ) {
+			session.close();
+			session = null;
+		}
+	}
+
+	@Test
+	public void testQueryWithEmbeddableInWhereClause() throws Exception {
+		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.embeddedString = 'string 1'" ).list();
+		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
+	}
+
+	@Test
+	public void testQueryWithNestedEmbeddableInWhereClause() throws Exception {
+		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.anotherEmbeddable.embeddedString = 'string 2'" ).list();
+		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
+	}
+
+	@Test
+	public void testQueryWithEmbeddablePropertyInSelectClause() throws Exception {
+		List<ProjectionResult> result = asProjectionResults( "select e.id, e.anEmbeddable.embeddedString from WithEmbedded e" );
+		assertThat( result ).containsOnly( new ProjectionResult( 1L, "string 1" ) );
+	}
+
+	@Test
+	public void testQueryReturningEmbeddedObject() {
+		List<?> list = session.createQuery( "from WithEmbedded we" ).list();
+
+		assertThat( list )
+			.onProperty( "anEmbeddable" )
+			.onProperty( "embeddedString" )
+			.containsExactly( "string 1" );
+
+		assertThat( list )
+			.onProperty( "anEmbeddable" )
+			.onProperty( "anotherEmbeddable" )
+			.onProperty( "embeddedString" )
+			.containsExactly( "string 2" );
+	}
+
+	@BeforeClass
+	public static void insertTestEntities() throws Exception {
+		final Session session = sessions.openSession();
+		Transaction transaction = session.beginTransaction();
+
+		WithEmbedded with = new WithEmbedded( 1L, new AnEmbeddable( "string 1", new AnotherEmbeddable( "string 2" ) ) );
+		session.persist( with );
+
+		transaction.commit();
+		session.close();
+	}
+
+	private List<ProjectionResult> asProjectionResults(String projectionQuery) {
+		List<?> results = session.createQuery( projectionQuery ).list();
+		List<ProjectionResult> projectionResults = new ArrayList<ProjectionResult>();
+
+		for ( Object result : results ) {
+			if ( !( result instanceof Object[] ) ) {
+				throw new IllegalArgumentException( "No projection result: " + result );
+			}
+			projectionResults.add( ProjectionResult.forArray( (Object[]) result ) );
+		}
+
+		return projectionResults;
+	}
+
+	private static class ProjectionResult {
+
+		private Object[] elements;
+
+		public ProjectionResult(Object... elements) {
+			this.elements = elements;
+		}
+
+		public static ProjectionResult forArray(Object[] element) {
+			ProjectionResult result = new ProjectionResult();
+			result.elements = element;
+			return result;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + Arrays.hashCode( elements );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			ProjectionResult other = (ProjectionResult) obj;
+			if ( !Arrays.equals( elements, other.elements ) ) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return Arrays.deepToString( elements );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { WithEmbedded.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
@@ -185,21 +185,18 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { NEO4J }, comment = "Selecting from embedded entities is not yet implemented.")
 	public void testQueryWithEmbeddableInWhereClause() throws Exception {
 		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.embeddedString = 'string 1'" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
 	}
 
 	@Test
-	@SkipByGridDialect(value = { NEO4J }, comment = "Selecting from embedded entities is not yet implemented.")
 	public void testQueryWithNestedEmbeddableInWhereClause() throws Exception {
 		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.anotherEmbeddable.embeddedString = 'string 2'" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
 	}
 
 	@Test
-	@SkipByGridDialect(value = { NEO4J }, comment = "Selecting from embedded entities is not yet implemented.")
 	public void testQueryWithEmbeddablePropertyInSelectClause() throws Exception {
 		List<ProjectionResult> result = asProjectionResults( "select e.id, e.anEmbeddable.embeddedString from WithEmbedded e" );
 		assertThat( result ).containsOnly( new ProjectionResult( 1L, "string 1" ) );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
@@ -85,7 +85,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 
 	@Test
 	public void testSimpleQueryOnUnindexedSuperType() throws Exception {
-		assertQuery( session, 18, session.createQuery(
+		assertQuery( session, 17, session.createQuery(
 				"from java.lang.Object" ) );
 	}
 
@@ -182,24 +182,6 @@ public class SimpleQueriesTest extends OgmTestCase {
 	public void testQueryWithPropertyFromAssociatedEntityInWhereClause() throws Exception {
 		List<?> result = session.createQuery( "from Hypothesis h where h.author.name = 'alfred'" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( "16" );
-	}
-
-	@Test
-	public void testQueryWithEmbeddableInWhereClause() throws Exception {
-		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.embeddedString = 'string 1'" ).list();
-		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
-	}
-
-	@Test
-	public void testQueryWithNestedEmbeddableInWhereClause() throws Exception {
-		List<?> result = session.createQuery( "from WithEmbedded e where e.anEmbeddable.anotherEmbeddable.embeddedString = 'string 2'" ).list();
-		assertThat( result ).onProperty( "id" ).containsOnly( 1L );
-	}
-
-	@Test
-	public void testQueryWithEmbeddablePropertyInSelectClause() throws Exception {
-		List<ProjectionResult> result = asProjectionResults( "select e.id, e.anEmbeddable.embeddedString from WithEmbedded e" );
-		assertThat( result ).containsOnly( new ProjectionResult( 1L, "string 1" ) );
 	}
 
 	@Test
@@ -489,22 +471,6 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	public void testQueryReturningEmbeddedObject() {
-		List<?> list = session.createQuery( "from WithEmbedded we" ).list();
-
-		assertThat( list )
-			.onProperty( "anEmbeddable" )
-			.onProperty( "embeddedString" )
-			.containsExactly( "string 1" );
-
-		assertThat( list )
-			.onProperty( "anEmbeddable" )
-			.onProperty( "anotherEmbeddable" )
-			.onProperty( "embeddedString" )
-			.containsExactly( "string 2" );
-	}
-
-	@Test
 	@TestForIssue(jiraKey = "OGM-424")
 	public void testAutoFlushIsAppliedDuringQueryExecution() throws Exception {
 		Query query = session.createQuery( "from Hypothesis" );
@@ -696,9 +662,6 @@ public class SimpleQueriesTest extends OgmTestCase {
 		fool.setDate( calendar.getTime() );
 		session.persist( fool );
 
-		WithEmbedded with = new WithEmbedded( 1L, new AnEmbeddable( "string 1", new AnotherEmbeddable( "string 2" ) ) );
-		session.persist( with );
-
 		transaction.commit();
 		session.close();
 	}
@@ -775,6 +738,6 @@ public class SimpleQueriesTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Hypothesis.class, Helicopter.class, Author.class, Address.class, WithEmbedded.class };
+		return new Class<?>[] { Hypothesis.class, Helicopter.class, Author.class, Address.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/WithEmbedded.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/WithEmbedded.java
@@ -24,6 +24,10 @@ public class WithEmbedded {
 	@IndexedEmbedded
 	private AnEmbeddable anEmbeddable;
 
+	@Embedded
+	@IndexedEmbedded
+	private AnEmbeddable yetAnotherEmbeddable;
+
 	public WithEmbedded() {
 	}
 
@@ -38,5 +42,13 @@ public class WithEmbedded {
 
 	public AnEmbeddable getAnEmbeddable() {
 		return anEmbeddable;
+	}
+
+	public AnEmbeddable getYetAnotherEmbeddable() {
+		return yetAnotherEmbeddable;
+	}
+
+	public void setYetAnotherEmbeddable(AnEmbeddable yetAnotherEmbeddable) {
+		this.yetAnotherEmbeddable = yetAnotherEmbeddable;
 	}
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBPredicateFactory.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBPredicateFactory.java
@@ -53,13 +53,13 @@ public class MongoDBPredicateFactory implements PredicateFactory<DBObject> {
 
 	@Override
 	public ComparisonPredicate<DBObject> getComparisonPredicate(String entityType, Type comparisonType, List<String> propertyPath, Object value) {
-		String columnName = propertyHelper.getColumnName( entityType, StringHelper.join( propertyPath, "." ) );
+		String columnName = columnName( entityType, propertyPath );
 		return new MongoDBComparisonPredicate( columnName, comparisonType, value );
 	}
 
 	@Override
 	public RangePredicate<DBObject> getRangePredicate(String entityType, List<String> propertyPath, Object lowerValue, Object upperValue) {
-		String columnName = propertyHelper.getColumnName( entityType, propertyPath.get( propertyPath.size() - 1 ) );
+		String columnName = columnName( entityType, propertyPath );
 		return new MongoDBRangePredicate( columnName, lowerValue, upperValue );
 	}
 
@@ -80,19 +80,23 @@ public class MongoDBPredicateFactory implements PredicateFactory<DBObject> {
 
 	@Override
 	public InPredicate<DBObject> getInPredicate(String entityType, List<String> propertyPath, List<Object> typedElements) {
-		String columnName = propertyHelper.getColumnName( entityType, propertyPath.get( propertyPath.size() - 1 ) );
+		String columnName = columnName( entityType, propertyPath );
 		return new MongoDBInPredicate( columnName, typedElements );
 	}
 
 	@Override
 	public IsNullPredicate<DBObject> getIsNullPredicate(String entityType, List<String> propertyPath) {
-		String columnName = propertyHelper.getColumnName( entityType, propertyPath.get( propertyPath.size() - 1 ) );
+		String columnName = columnName( entityType, propertyPath );
 		return new MongoDBIsNullPredicate( columnName );
 	}
 
 	@Override
 	public LikePredicate<DBObject> getLikePredicate(String entityType, List<String> propertyPath, String patternValue, Character escapeCharacter) {
-		String columnName = propertyHelper.getColumnName( entityType, propertyPath.get( propertyPath.size() - 1 ) );
+		String columnName = columnName( entityType, propertyPath );
 		return new MongoDBLikePredicate( columnName, patternValue, escapeCharacter );
+	}
+
+	private String columnName(String entityType, List<String> propertyPath) {
+		return propertyHelper.getColumnName( entityType, StringHelper.join( propertyPath, "." ) );
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/id/objectid/ObjectIdWithEmbeddableTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/id/objectid/ObjectIdWithEmbeddableTest.java
@@ -62,7 +62,7 @@ public class ObjectIdWithEmbeddableTest extends OgmTestCase {
 
 		// given
 		EntityWithObjectIdAndEmbeddable entity = new EntityWithObjectIdAndEmbeddable();
-		AnotherEmbeddable anotherEmbeddable = new AnotherEmbeddable( "Another nice string ... nested" );
+		AnotherEmbeddable anotherEmbeddable = new AnotherEmbeddable( "Another nice string ... nested", 5 );
 		AnEmbeddable anEmbeddable = new AnEmbeddable( "a very nice string", anotherEmbeddable );
 		entity.setAnEmbeddable( anEmbeddable );
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/cypherdsl/impl/CypherDSL.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/cypherdsl/impl/CypherDSL.java
@@ -31,6 +31,12 @@ public class CypherDSL {
 		escapeIdentifier( builder, identifier );
 	}
 
+	public static String identifier(String identifier, String propertyName) {
+		StringBuilder builder = new StringBuilder();
+		identifier( builder, identifier, propertyName );
+		return builder.toString();
+	}
+
 	public static StringBuilder identifier(StringBuilder builder, String identifier, String propertyName) {
 		identifier( builder, identifier );
 		if ( propertyName != null ) {
@@ -57,11 +63,21 @@ public class CypherDSL {
 	public static StringBuilder node(StringBuilder builder, String alias, String... labels) {
 		builder.append( "(" );
 		escapeIdentifier( builder, alias );
-		for ( String label : labels ) {
-			builder.append( ":" );
-			escapeIdentifier( builder, label );
+		if ( labels != null ) {
+			for ( String label : labels ) {
+				builder.append( ":" );
+				escapeIdentifier( builder, label );
+			}
 		}
 		builder.append( ")" );
+		return builder;
+	}
+
+
+	public static StringBuilder relationship(StringBuilder builder, String relationshipType) {
+		builder.append( " -[:" );
+		escapeIdentifier( builder, relationshipType );
+		builder.append( "]-> " );
 		return builder;
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/EmbeddedAliasTree.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/EmbeddedAliasTree.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.query.parsing.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tree structure that can be used to store alias of embedded components in Neo4j.
+ * <p>
+ * For example, a path to two properties like:
+ * <ol>
+ * <li>n.first.anotherEmbedded</li>
+ * <li>n.second.anotherEmbedded</li>
+ * </ol>
+ * Might be represented with the following structure:
+ * <pre>
+ * n (alias = n)|- first (alias = n_0)  -- anotherEmbedded (alias = n_0_0)
+ *              |
+ *              -- second (alias = n_1) -- anotherEmbedded (alias = n_0_1)
+ * </pre>
+ *
+ * @author Davide D'Alto
+ */
+public class EmbeddedAliasTree {
+
+	private final String name;
+	private final String alias;
+	private final List<EmbeddedAliasTree> children;
+
+	/**
+	 * Creates a tree node.
+	 *
+	 * @param alias the alias used for the embedded
+	 * @param name the name of the property representing the emebedded
+	 */
+	public EmbeddedAliasTree(String alias, String name) {
+		this.name = name;
+		this.alias = alias;
+		this.children = new ArrayList<EmbeddedAliasTree>();
+	}
+
+	public EmbeddedAliasTree findChild(String name) {
+		for ( EmbeddedAliasTree child : children ) {
+			if ( child.getName().equals( name ) ) {
+				return child;
+			}
+		}
+		return null;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void addChild(EmbeddedAliasTree embeddedNode) {
+		children.add( embeddedNode );
+	}
+
+	public String getAlias() {
+		return alias;
+	}
+
+	public List<EmbeddedAliasTree> getChildren() {
+		return Collections.unmodifiableList( children );
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append( "[name=" );
+		builder.append( name );
+		builder.append( ", alias=" );
+		builder.append( alias );
+		builder.append( "]" );
+		return builder.toString();
+	}
+
+}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/Neo4jQueryResolverDelegate.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/Neo4jQueryResolverDelegate.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.neo4j.query.parsing.impl;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.antlr.runtime.tree.Tree;
@@ -26,6 +27,8 @@ public class Neo4jQueryResolverDelegate implements QueryResolverDelegate {
 	 */
 	private final Map<String, String> aliasToEntityType = new HashMap<String, String>();
 	private final Map<String, String> aliases = new HashMap<String, String>();
+	private final Map<String, EmbeddedAliasTree> embeddedAliases = new HashMap<String, EmbeddedAliasTree>();
+	private int embeddedCounter = 0;
 
 	@Override
 	public void registerPersisterSpace(Tree entityName, Tree alias) {
@@ -118,4 +121,84 @@ public class Neo4jQueryResolverDelegate implements QueryResolverDelegate {
 		return aliases.get( entityType );
 	}
 
+	/**
+	 * Given the path to an embedded property, it will create an alias to use in the query for the embedded containing
+	 * the property.
+	 * <p>
+	 * The alias will be saved and can be returned using the method {@link #findAliasForEmbedded(String, List)}.
+	 * <p>
+	 * For example, using n as entity alias and [embedded, anotherEmbedded, property] as path to the property will
+	 * return "n_2" as alias for "n.embedded.anotherEmbedded".
+	 *
+	 * @param entityAlias the alias of the entity that contains the embedded
+	 * @param propertyPathWithoutAlias the path to the property without the alias
+	 * @return the alias of the embedded containing the property
+	 */
+	public String createAliasForEmbedded(String entityAlias, List<String> propertyPathWithoutAlias) {
+		EmbeddedAliasTree embeddedAlias = embeddedAliases.get( entityAlias );
+		if ( embeddedAlias == null ) {
+			embeddedAlias = new EmbeddedAliasTree( entityAlias, entityAlias );
+			embeddedAliases.put( entityAlias, embeddedAlias );
+		}
+		for ( int i = 0; i < propertyPathWithoutAlias.size() - 1; i++ ) {
+			String name = propertyPathWithoutAlias.get( i );
+			EmbeddedAliasTree child = embeddedAlias.findChild( name );
+			if ( child == null ) {
+				embeddedCounter++;
+				String childAlias = "_" + entityAlias + embeddedCounter;
+				child = new EmbeddedAliasTree( childAlias, name );
+				embeddedAlias.addChild( child );
+			}
+			embeddedAlias = child;
+		}
+		return embeddedAlias.getAlias();
+	}
+
+	/**
+	 * Given the alias of the entity and the path to the embedded properties it will return the alias
+	 * of the embedded component containing the property.
+	 *
+	 * @see #createAliasForEmbedded(String, List)
+	 * @param entityAlias the alias of the entity that contains the embedded
+	 * @param propertyPathWithoutAlias the path to the property without the alias
+	 * @return the alias of the embedded containing the property or null
+	 */
+	public String findAliasForEmbedded(String entityAlias, List<String> propertyPathWithoutAlias) {
+		EmbeddedAliasTree aliasTree = embeddedAliases.get( entityAlias );
+		if ( aliasTree == null ) {
+			return null;
+		}
+		EmbeddedAliasTree embedded = aliasTree;
+		for ( int i = 0; i < propertyPathWithoutAlias.size() - 1; i++ ) {
+			embedded = embedded.findChild( propertyPathWithoutAlias.get( i ) );
+			if ( embedded == null ) {
+				return null;
+			}
+		}
+		return embedded.getAlias();
+	}
+
+	/**
+	 * Given the alias of the entity it will return a tree structure containing all the aliases for the embedded
+	 * properties of the entity.
+	 * <p>
+	 * The tree has the entity alias as root and the embedded alias as children.
+	 * For example, a path to two properties like:
+	 * <ol>
+	 * <li>n.first.anotherEmbedded</li>
+	 * <li>n.second.anotherEmbedded</li>
+	 * </ol>
+	 *
+	 * Might be represented with the following structure:
+	 * <pre>
+	 * n (alias = n)|- first (alias = _n1)  -- anotherEmbedded (alias = _n2)
+	 *              |
+	 *              -- second (alias = _n3) -- anotherEmbedded (alias = _n4)
+	 * </pre>
+	 * @param entityAlias the alias of the entity that contains the embedded
+	 * @return the corresponding {@link EmbeddedAliasTree} or null
+	 */
+	public EmbeddedAliasTree getAliasTree(String entityAlias) {
+		return embeddedAliases.get( entityAlias );
+	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/Neo4jQueryResolverDelegateTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/Neo4jQueryResolverDelegateTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.EmbeddedAliasTree;
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jQueryResolverDelegate;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class Neo4jQueryResolverDelegateTest {
+
+	@Test
+	public void testEmbeddedAliasCreation() throws Exception {
+		Neo4jQueryResolverDelegate resolverDelegate = new Neo4jQueryResolverDelegate();
+
+		String aliasForEmbedded1 = createAliasForEmbedded( resolverDelegate, "n", "embedded.anotherEmbedded.property" );
+		assertThat( aliasForEmbedded1 ).isEqualTo( "_n2" );
+
+		String aliasForEmbedded2 = createAliasForEmbedded( resolverDelegate, "n", "yetAnotherEmbedded.anotherEmbedded.property" );
+		assertThat( aliasForEmbedded2 ).isEqualTo( "_n4" );
+	}
+
+	@Test
+	public void testCreationOfSameAliasForTwoPropertiesOfTheSameEmbedded() throws Exception {
+		Neo4jQueryResolverDelegate resolverDelegate = new Neo4jQueryResolverDelegate();
+
+		String aliasForEmbedded1 = createAliasForEmbedded( resolverDelegate, "n", "embedded.anotherEmbedded.property1" );
+		assertThat( aliasForEmbedded1 ).isEqualTo( "_n2" );
+
+		String aliasForEmbedded2 = createAliasForEmbedded( resolverDelegate, "n", "embedded.anotherEmbedded.property2" );
+		assertThat( aliasForEmbedded2 ).isEqualTo( aliasForEmbedded1 );
+	}
+
+	@Test
+	public void testEmbeddedTreeCreation() throws Exception {
+		Neo4jQueryResolverDelegate resolverDelegate = new Neo4jQueryResolverDelegate();
+
+		createAliasForEmbedded( resolverDelegate, "n", "embedded.anotherEmbedded.property" );
+		createAliasForEmbedded( resolverDelegate, "n", "yetAnotherEmbedded.anotherEmbedded.property" );
+
+		// Root node: the entity alias
+		EmbeddedAliasTree aliasTree = resolverDelegate.getAliasTree( "n" );
+		assertThat( aliasTree.getAlias() ).isEqualTo( "n" );
+		assertThat( aliasTree.getName() ).isEqualTo( "n" );
+		assertThat( aliasTree.getChildren() ).onProperty( "alias" ).containsOnly( "_n1", "_n3" );
+
+		// Level one: the "n.embedded" node
+		EmbeddedAliasTree embeddedNode = aliasTree.findChild( "embedded" );
+		assertThat( embeddedNode.getChildren() ).onProperty( "alias" ).containsExactly( "_n2" );
+
+		// Level two: the "n.embedded.anotherEmbedded" node
+		EmbeddedAliasTree embeddedAnotherEmbeddedNode = embeddedNode.findChild( "anotherEmbedded" );
+		assertThat( embeddedAnotherEmbeddedNode.getChildren() ).isEmpty();
+
+		// Level one: the "n.yetAnotherEmbedded" node
+		EmbeddedAliasTree yetAnotherEmbeddedNode = aliasTree.findChild( "yetAnotherEmbedded" );
+		assertThat( yetAnotherEmbeddedNode.getChildren() ).onProperty( "alias" ).containsExactly( "_n4" );
+
+		// Level one: the "n.yetAnotherEmbedded.anotherEmbedded" node
+		EmbeddedAliasTree yetAnotherEmbeddedAnotherEmbeddedNode = yetAnotherEmbeddedNode.findChild( "anotherEmbedded" );
+		assertThat( yetAnotherEmbeddedAnotherEmbeddedNode.getChildren() ).isEmpty();
+	}
+
+	private String createAliasForEmbedded(Neo4jQueryResolverDelegate resolverDelegate, String entityAlias, String propertyPath) {
+		List<String> embeddedProperty1 = Arrays.asList( propertyPath.split( "\\." ) );
+		return resolverDelegate.createAliasForEmbedded( entityAlias, embeddedProperty1 );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-692
Rebased for 4,2 branch

To create the queries in Neo4j I need to create and keep track of aliases for the various embedded nodes using a tree structure. Alias are created starting form the alias of the entity and adding the position of the
node as a suffix.

For example, an embedded represented in the query as *n.embedded.anotherEmbedded* will generate the following aliases *n_0* for (n.embedded) and *n_0_0* for (n.embedded.anotherEmbedded).

The following query
```
FROM WithEmbedded e
WHERE e.anEmbeddable.anotherEmbeddable.embeddedString = 'string 2'
``` 
becomes:
```
MATCH (e:WithEmbedded)
OPTIONAL MATCH (e) -[:anEmbeddable]-> (`e_0`:EMBEDDED) -[:anotherEmbeddable]->(`e_0_0`:EMBEDDED)
WHERE `e_0_0`.embeddedString="string 2"
RETURN e
```

I noticed that we didn't have enough tests for queries on embedded and I decided to extract the existing one, move them in a separate class and add missing use cases. This caused some errors in MongoDB that should be now solved.

In the process I also discovered [OGM-751](https://hibernate.atlassian.net/browse/OGM-751)