### PR TITLE
OGM-265 Validate collection names used for tables in MongoDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/util/impl/Contracts.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Contracts.java
@@ -47,6 +47,21 @@ public final class Contracts {
 		}
 	}
 
+	/**
+	 * Asserts that the given {@code String} is neither {@code null} nor an empty string.
+	 *
+	 * @param parameter the parameter to validate
+	 * @param parameterName the name of the parameter, will be used in the logging message in case the given object is
+	 * {@code null} or empty.
+	 * @throws IllegalArgumentException in case the given parameter is {@code null} or empty
+	 */
+	public static void assertStringParameterNotEmpty(String parameter, String parameterName) {
+		assertParameterNotNull( parameter, parameterName );
+		if ( parameter.length() == 0 ) {
+			throw log.parameterSringMustNotBeEmpty( parameterName );
+		}
+	}
+
 	public static void assertTrue(boolean condition, String message) {
 		if ( !condition ) {
 			throw new AssertionFailure( message );

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -260,4 +260,8 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = INFO)
 	@Message(id = 76, value = "No explicit or implicit defined JTAPlatform. Using NoJtaPlatform")
 	void noJtaPlatformDetected();
+
+	@Message(id = 77, value = "Parameter '%s' must not be an empty string")
+	IllegalArgumentException parameterSringMustNotBeEmpty(String parameterName);
+
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/CommunityMember.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/CommunityMember.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.innertypes;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public class CommunityMember {
+
+	@Id
+	public String name;
+
+	public CommunityMember() {
+	}
+
+	public CommunityMember(String name) {
+		this.name = name;
+	}
+
+	@Entity @Table(name = "employee")
+	public static class Employee extends CommunityMember {
+		public String employer;
+
+		public Employee() {
+			super();
+		}
+
+		public Employee(String name, String employer) {
+			super( name );
+			this.employer = employer;
+		}
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/InnerClassFindTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/InnerClassFindTest.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.innertypes;
+
+import static org.fest.assertions.Assertions.assertThat;
+import javax.persistence.EntityManager;
+import org.hibernate.ogm.backendtck.innertypes.CommunityMember.Employee;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.junit.Test;
+
+/**
+ * Verifies the dialect is able to store an entity which is represented as an inner type in Java.
+ *
+ * For example on MongoDB this implies the name of the class needs to avoid the dollar symbol,
+ * so this needs to be adjusted by forcing a valid name using the JPA Table annotation.
+ *
+ * See also org.hibernate.ogm.datastore.mongodb.test.datastore.CollectionNamingValidationTest in the MongoDB module.
+ *
+ * @author Davide D'Alto
+ * @author Sanne Grinovero
+ */
+@TestForIssue(jiraKey = "OGM-265")
+public class InnerClassFindTest extends JpaTestCase {
+
+	@Test
+	public void testInnerClassFind() throws Exception {
+		final EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+		CommunityMember member = new CommunityMember( "Davide" );
+		em.persist( member );
+
+		Employee employee = new Employee( "Alex", "EMPLOYER" );
+		em.persist( employee );
+		em.getTransaction().commit();
+
+		em.clear();
+
+		em.getTransaction().begin();
+		CommunityMember lh = em.find( CommunityMember.class, member.name );
+		assertThat( lh ).isNotNull();
+		assertThat( lh ).isInstanceOf( CommunityMember.class );
+
+		CommunityMember lsh = em.find( Employee.class, employee.name );
+		assertThat( lsh ).isNotNull();
+		assertThat( lsh ).isInstanceOf( Employee.class );
+		assertThat( ((Employee) employee).employer ).isEqualTo( employee.employer );
+
+		em.remove( lh );
+		em.remove( lsh );
+		em.getTransaction().commit();
+		em.close();
+	}
+
+	@Override
+	public Class<?>[] getEntities() {
+		return new Class<?>[]{ CommunityMember.class, Employee.class };
+	}
+
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBEntityMappingValidator.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBEntityMappingValidator.java
@@ -14,11 +14,17 @@ import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.spi.BaseSchemaDefiner;
 import org.hibernate.ogm.id.spi.PersistentNoSqlIdentifierGenerator;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.ogm.util.impl.Contracts;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Performs sanity checks of the mapped objects.
  *
  * @author Gunnar Morling
+ * @author Sanne Grinovero
  */
 public class MongoDBEntityMappingValidator extends BaseSchemaDefiner {
 
@@ -28,6 +34,42 @@ public class MongoDBEntityMappingValidator extends BaseSchemaDefiner {
 	public void validateMapping(SessionFactoryImplementor factory) {
 		Set<PersistentNoSqlIdentifierGenerator> persistentGenerators = getPersistentGenerators( factory );
 		validateGenerators( persistentGenerators );
+		validateEntityCollectionNames( getAllEntityKeyMetadata( factory ) );
+		validateAssociationNames( getAllAssociationKeyMetadata( factory ) );
+		validateAllPersisters( factory.getEntityPersisters().values() );
+	}
+
+	private void validateAllPersisters(Iterable<EntityPersister> persisters) {
+		for ( EntityPersister persister : persisters ) {
+			if ( persister instanceof OgmEntityPersister ) {
+				OgmEntityPersister ogmPersister = (OgmEntityPersister) persister;
+				int propertySpan = ogmPersister.getEntityMetamodel().getPropertySpan();
+				for ( int i = 0; i < propertySpan; i++ ) {
+					String[] columnNames = ogmPersister.getPropertyColumnNames( i );
+					for ( String columnName : columnNames ) {
+						validateAsMongoDBFieldName( columnName );
+					}
+				}
+			}
+		}
+	}
+
+	private void validateAssociationNames(Iterable<AssociationKeyMetadata> allAssociationKeyMetadata) {
+		for ( AssociationKeyMetadata associationKeyMetadata : allAssociationKeyMetadata ) {
+			validateAsMongoDBCollectionName( associationKeyMetadata.getTable() );
+			for ( String column : associationKeyMetadata.getRowKeyColumnNames() ) {
+				validateAsMongoDBFieldName( column );
+			}
+		}
+	}
+
+	private void validateEntityCollectionNames(Iterable<EntityKeyMetadata> allEntityKeyMetadata) {
+		for ( EntityKeyMetadata entityKeyMetadata : allEntityKeyMetadata ) {
+			validateAsMongoDBCollectionName( entityKeyMetadata.getTable() );
+			for ( String column : entityKeyMetadata.getColumnNames() ) {
+				validateAsMongoDBFieldName( column );
+			}
+		}
 	}
 
 	private void validateGenerators(Iterable<PersistentNoSqlIdentifierGenerator> generators) {
@@ -39,4 +81,38 @@ public class MongoDBEntityMappingValidator extends BaseSchemaDefiner {
 			}
 		}
 	}
+
+	/**
+	 * Validates a String to be a valid name to be used in MongoDB for a collection name.
+	 *
+	 * @param collectionName
+	 */
+	private static void validateAsMongoDBCollectionName(String collectionName) {
+		Contracts.assertStringParameterNotEmpty( collectionName, "requestedName" );
+		//Yes it has some strange requirements.
+		if ( collectionName.startsWith( "system." ) ) {
+			throw log.collectionNameHasInvalidSystemPrefix( collectionName );
+		}
+		else if ( collectionName.contains( "\u0000" ) ) {
+			throw log.collectionNameContainsNULCharacter( collectionName );
+		}
+		else if ( collectionName.contains( "$" ) ) {
+			throw log.collectionNameContainsDollarCharacter( collectionName );
+		}
+	}
+
+	/**
+	 * Validates a String to be a valid name to be used in MongoDB for a field name.
+	 *
+	 * @param fieldName
+	 */
+	private void validateAsMongoDBFieldName(String fieldName) {
+		if ( fieldName.startsWith( "$" ) ) {
+			throw log.fieldNameHasInvalidDollarPrefix( fieldName );
+		}
+		else if ( fieldName.contains( "\u0000" ) ) {
+			throw log.fieldNameContainsNULCharacter( fieldName );
+		}
+	}
+
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -11,6 +11,7 @@ import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.mongodb.MongoDBProperties;
 import org.jboss.logging.annotations.Cause;
@@ -77,4 +78,29 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 
 	@Message(id = 1219, value = "Database %s does not exist. Either create it yourself or set property '" + OgmProperties.CREATE_DATABASE + "' to true.")
 	HibernateException databaseDoesNotExistException(String databaseName);
+
+	// The following statements have to return MappingException to make sure Hibernate ORM doesn't wrap them in a generic failure
+	// but maintains the user friendly error message
+
+	@Message(id = 1220, value = "When using MongoDB it is not valid to use a name for a table (a collection) which starts with the 'system.' prefix."
+			+ " Please change name for '%s', for example by using @Table ")
+	MappingException collectionNameHasInvalidSystemPrefix(String qualifiedName);
+
+	@Message(id = 1221, value = "When using MongoDB it is not valid to use a name for a table (a collection) which contains the NUL character '\\0'."
+			+ " Please change name for '%s', for example by using @Table ")
+	MappingException collectionNameContainsNULCharacter(String qualifiedName);
+
+	@Message(id = 1222, value = "When using MongoDB it is not valid to use a name for a table (a collection) which contains the dollar character '$';"
+			+ " for example this is a common problem with inner classes."
+			+ " Please pick a valid collection name for '%s', for example by using @Table ")
+	MappingException collectionNameContainsDollarCharacter(String qualifiedName);
+
+	@Message(id = 1223, value = "When using MongoDB it is not valid to use a field name which starts with the prefix '$'."
+			+ " Please change name for '%s', for example by using @Column ")
+	MappingException fieldNameHasInvalidDollarPrefix(String columnName);
+
+	@Message(id = 1224, value = "When using MongoDB it is not valid to use a field name which contains the NUL character '\\0'."
+			+ " Please change name for '%s', for example by using @Column ")
+	MappingException fieldNameContainsNULCharacter(String fieldName);
+
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/CollectionNamingValidationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/CollectionNamingValidationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.datastore;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.hibernate.MappingException;
+import org.hibernate.ogm.OgmSessionFactory;
+import org.hibernate.ogm.cfg.OgmConfiguration;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Makes sure generated collection names are validated according to
+ * the restrictions imposed by MongoDB collection names.
+ *
+ * @author Sanne Grinovero
+ */
+@TestForIssue(jiraKey = "OGM-265")
+public class CollectionNamingValidationTest {
+
+	@Test
+	public void systemPrefixedTableNameIsIllegal() {
+		assertTableCausesException( SystemNamedTable.class, "OGM001220" );
+	}
+
+	@Test
+	public void nulTableNameIsIllegal() {
+		assertTableCausesException( NULNamedTable.class, "OGM001221" );
+	}
+
+	@Test
+	public void dollarTableNameIsIllegal() {
+		assertTableCausesException( DollarNamedTable.class, "OGM001222" );
+	}
+
+	@Test
+	public void dollarColumnNameIsIllegal() {
+		assertTableCausesException( InvalidColumnsTable.class, "OGM001223" );
+	}
+
+	@Test
+	public void defaultInnerClassNameIsIllegal() {
+		assertTableCausesException( DollarNamedTable.class, "OGM001222" );
+	}
+
+	private void assertTableCausesException(Class<?> mappedType, String expectedExceptionPrefix) {
+		OgmConfiguration configuration = TestHelper.getDefaultTestConfiguration( mappedType );
+		try {
+			OgmSessionFactory sessionFactory = configuration.buildSessionFactory();
+			sessionFactory.close();
+			Assert.fail( "An exception was expected" );
+		}
+		catch (MappingException me) {
+			assertThat( me.getMessage() ).startsWith( expectedExceptionPrefix );
+		}
+	}
+
+	@Entity
+	public static class EmptyNamedTable {
+		@Id Long id;
+	}
+
+	@Entity @Table(name = "system.blue.pill")
+	public static class SystemNamedTable {
+		@Id Long id;
+	}
+
+	@Entity @Table(name = "blah\0")
+	public static class NULNamedTable {
+		@Id Long id;
+	}
+
+	@Entity @Table(name = "blah$0")
+	public static class DollarNamedTable {
+		@Id Long id;
+	}
+
+	@Entity @Table(name = "valid")
+	public static class InvalidColumnsTable {
+		@Id Long id;
+		@Column(name = "$DOLLARS") String field;
+	}
+
+}


### PR DESCRIPTION
We've thrown the previous proposal for a generic validation contract away, this is the simplified form and is MongoDB specific.

 - https://hibernate.atlassian.net/browse/OGM-265

The better naming validation should be performed in Hibernate ORM, for example to validate to not use database specific keywords.