### PR TITLE
OGM-793 limited fix for enum ordinals - in some non-sql backends the spe...

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/type/impl/EnumType.java
+++ b/core/src/main/java/org/hibernate/ogm/type/impl/EnumType.java
@@ -36,6 +36,10 @@ public class EnumType extends GridTypeDelegatingToCoreType {
 		isOrdinal = isOrdinal( coreEnumType.sqlTypes()[0] );
 	}
 
+	public boolean isOrdinal() {
+		return isOrdinal;
+	}
+
 	@Override
 	public Object nullSafeGet(Tuple rs, String[] names, SessionImplementor session, Object owner)
 			throws HibernateException {


### PR DESCRIPTION
...cific sqlType is unimportant, we just need to know if it's broadly text like or number like, for which isOrdinal is sufficient.