### PR TITLE
test changes for cassandra backend

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyExtraTest.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.collection.manytomany;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestHelper;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.utils.TestHelper.getNumberOfAssociations;
+import static org.hibernate.ogm.utils.TestHelper.getNumberOfEntities;
+
+/**
+ * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
+ */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Classroom.students list - bag semantics unsupported (no primary key)"
+)
+public class ManyToManyExtraTest extends OgmTestCase {
+
+	@Test
+	public void testUnidirectionalManyToMany() {
+		Session session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Student john = new Student( "john", "John Doe" );
+		Student kate = new Student( "kate", "Kate Doe" );
+		Student mario = new Student( "mario", "Mario Rossi" );
+
+		ClassRoom math = new ClassRoom( 1L, "Math" );
+		math.getStudents().add( john );
+		math.getStudents().add( mario );
+		ClassRoom english = new ClassRoom( 2L, "English" );
+		english.getStudents().add( kate );
+		math.getStudents().add( mario );
+
+		persist( session, math, english, john, mario, kate );
+		tx.commit();
+
+		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 5 );
+		assertThat( getNumberOfAssociations( sessions ) ).isEqualTo( expectedAssociationNumber() );
+		session.clear();
+
+		delete( session, math, english, john, mario, kate );
+
+		session.close();
+		checkCleanCache();
+	}
+
+	private void persist(Session session, Object... entities) {
+		for ( Object entity : entities ) {
+			session.persist( entity );
+		}
+	}
+
+	private void delete(Session session, Object... entities) {
+		Transaction transaction = session.beginTransaction();
+		for ( Object entity : entities ) {
+			session.delete( entity );
+		}
+		transaction.commit();
+	}
+
+	private int expectedAssociationNumber() {
+		if ( TestHelper.getCurrentDialectType().equals( GridDialectType.NEO4J ) ) {
+			// In Neo4j relationships are bidirectional
+			return 1;
+		}
+		else {
+			return 2;
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Student.class,
+				ClassRoom.class
+		};
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyTest.java
@@ -24,35 +24,6 @@ import org.junit.Test;
 public class ManyToManyTest extends OgmTestCase {
 
 	@Test
-	public void testUnidirectionalManyToMany() {
-		Session session = openSession();
-		Transaction tx = session.beginTransaction();
-
-		Student john = new Student( "john", "John Doe" );
-		Student kate = new Student( "kate", "Kate Doe" );
-		Student mario = new Student( "mario", "Mario Rossi" );
-
-		ClassRoom math = new ClassRoom( 1L, "Math" );
-		math.getStudents().add( john );
-		math.getStudents().add( mario );
-		ClassRoom english = new ClassRoom( 2L, "English" );
-		english.getStudents().add( kate );
-		math.getStudents().add( mario );
-
-		persist( session, math, english, john, mario, kate );
-		tx.commit();
-
-		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 5 );
-		assertThat( getNumberOfAssociations( sessions ) ).isEqualTo( expectedAssociationNumber() );
-		session.clear();
-
-		delete( session, math, english, john, mario, kate );
-
-		session.close();
-		checkCleanCache();
-	}
-
-	@Test
 	public void testBidirectionalManyToMany() {
 		Session session = openSession();
 		Transaction tx = session.beginTransaction();
@@ -175,8 +146,6 @@ public class ManyToManyTest extends OgmTestCase {
 				BankAccount.class,
 				Car.class,
 				Tire.class,
-				Student.class,
-				ClassRoom.class
 		};
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J, GridDialectType.CASSANDRA },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class MapContentsStoredInSeparateDocumentTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -13,12 +13,19 @@ import static org.hibernate.ogm.utils.TestHelper.getNumberOfAssociations;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+
 import org.junit.Test;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "hibernate core doesn't supply required primary key metadata for collections"
+)
 public class MapTest extends OgmTestCase {
 
 	@Test

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/unidirectional/Cloud.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/unidirectional/Cloud.java
@@ -56,7 +56,7 @@ public class Cloud {
 	}
 
 	@OneToMany
-	@JoinTable
+	@JoinTable(name = "joinProducedSnowflakes")
 	public Set<SnowFlake> getProducedSnowFlakes() {
 		return producedSnowFlakes;
 	}
@@ -66,7 +66,7 @@ public class Cloud {
 	}
 
 	@OneToMany
-	@JoinTable
+	@JoinTable(name = "joinBackupSnowflakes")
 	public Set<SnowFlake> getBackupSnowFlakes() {
 		return backupSnowFlakes;
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/compositeid/ReferencedCompositeIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/compositeid/ReferencedCompositeIdTest.java
@@ -10,7 +10,10 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+
 import org.junit.Test;
 
 /**
@@ -18,6 +21,10 @@ import org.junit.Test;
  *
  * @author Gunnar Morling
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Director.Tournament list - bag semantics unsupported (no primary key)"
+)
 public class ReferencedCompositeIdTest extends OgmTestCase {
 
 	@Test

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneExtraTest.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.manytoone;
+
+import java.util.Arrays;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Basket.products list - bag semantics unsupported (no primary key)"
+)
+public class ManyToOneExtraTest extends OgmTestCase {
+
+	@Test
+	public void testUnidirectionalOneToMany() throws Exception {
+		final Session session = openSession();
+		Transaction tx = session.beginTransaction();
+		Product beer = new Product( "Beer", "Tactical nuclear penguin" );
+		session.persist( beer );
+
+		Product pretzel = new Product( "Pretzel", "Glutino Pretzel Sticks" );
+		session.persist( pretzel );
+
+		Basket basket = new Basket();
+		basket.setId( "davide_basket" );
+		basket.setOwner( "Davide" );
+		basket.setProducts( Arrays.asList( beer, pretzel ) );
+		session.persist( basket );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+		basket = (Basket) session.get( Basket.class, basket.getId() );
+		assertThat( basket ).isNotNull();
+		assertThat( basket.getId() ).isEqualTo( basket.getId() );
+		assertThat( basket.getProducts() )
+			.onProperty( "name" ).containsOnly( beer.getName(), pretzel.getName() );
+		tx.commit();
+
+		session.clear();
+
+		tx = session.beginTransaction();
+		session.delete( basket );
+		session.delete( pretzel );
+		session.delete( beer );
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Basket.class,
+				Product.class,
+		};
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
@@ -13,8 +13,6 @@ import static org.hibernate.ogm.utils.TestHelper.getNumberOfEntities;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
-
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.utils.GridDialectType;
@@ -258,45 +256,6 @@ public class ManyToOneTest extends OgmTestCase {
 	}
 
 	@Test
-	public void testUnidirectionalOneToMany() throws Exception {
-		final Session session = openSession();
-		Transaction tx = session.beginTransaction();
-		Product beer = new Product( "Beer", "Tactical nuclear penguin" );
-		session.persist( beer );
-
-		Product pretzel = new Product( "Pretzel", "Glutino Pretzel Sticks" );
-		session.persist( pretzel );
-
-		Basket basket = new Basket();
-		basket.setId( "davide_basket" );
-		basket.setOwner( "Davide" );
-		basket.setProducts( Arrays.asList( beer, pretzel ) );
-		session.persist( basket );
-
-		tx.commit();
-		session.clear();
-
-		tx = session.beginTransaction();
-		basket = (Basket) session.get( Basket.class, basket.getId() );
-		assertThat( basket ).isNotNull();
-		assertThat( basket.getId() ).isEqualTo( basket.getId() );
-		assertThat( basket.getProducts() )
-			.onProperty( "name" ).containsOnly( beer.getName(), pretzel.getName() );
-		tx.commit();
-
-		session.clear();
-
-		tx = session.beginTransaction();
-		session.delete( basket );
-		session.delete( pretzel );
-		session.delete( beer );
-		tx.commit();
-		session.close();
-
-		checkCleanCache();
-	}
-
-	@Test
 	public void testDefaultBiDirManyToOneCompositeKeyTest() throws Exception {
 		Session session = openSession();
 		Transaction transaction = session.beginTransaction();
@@ -348,8 +307,6 @@ public class ManyToOneTest extends OgmTestCase {
 				SalesGuy.class,
 				Beer.class,
 				Brewery.class,
-				Basket.class,
-				Product.class,
 				Game.class,
 				Court.class
 		};

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredProgrammaticallyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredProgrammaticallyTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J, GridDialectType.CASSANDRA },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class AssociationStorageConfiguredProgrammaticallyTest extends AssociationStorageTestBase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaAnnotationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaAnnotationsTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J, GridDialectType.CASSANDRA },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class AssociationStorageConfiguredViaAnnotationsTest extends AssociationStorageTestBase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaPropertyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaPropertyTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J, GridDialectType.CASSANDRA },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class AssociationStorageConfiguredViaPropertyTest extends AssociationStorageTestBase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableExtraTest.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.embeddable;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Tests for {@code @Embeddable} types and {@code @ElementCollection}s there-of.
+ *
+ * @author Emmanuel Bernard
+ * @author Gunnar Morling
+ */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "MultiAddressAccount.addresses list - bag semantics unsupported (no primary key)"
+)
+public class EmbeddableExtraTest extends OgmTestCase {
+
+	@Test
+	public void testElementCollectionOfEmbeddable() throws Exception {
+		final Session session = openSession();
+
+		Transaction transaction = session.beginTransaction();
+
+		Address address = new Address();
+		address.setCity( "Paris" );
+		address.setCountry( "France" );
+		address.setStreet1( "1 avenue des Champs Elysees" );
+		address.setZipCode( "75007" );
+
+		Address anotherAddress = new Address();
+		anotherAddress.setCity( "Rome" );
+		anotherAddress.setCountry( "Italy" );
+		anotherAddress.setStreet1( "Piazza del Colosseo, 1" );
+		anotherAddress.setZipCode( "00184" );
+		anotherAddress.setType( new AddressType( "primary" ) );
+
+		MultiAddressAccount account = new MultiAddressAccount();
+		account.setLogin( "gunnar" );
+		account.setPassword( "highly secret" );
+		account.getAddresses().add( address );
+		account.getAddresses().add( anotherAddress );
+
+		session.persist( account );
+		transaction.commit();
+
+		session.clear();
+
+		transaction = session.beginTransaction();
+		MultiAddressAccount loadedAccount = (MultiAddressAccount) session.get( MultiAddressAccount.class, account.getLogin() );
+		assertThat( loadedAccount ).as( "Cannot load persisted object" ).isNotNull();
+		assertThat( loadedAccount.getAddresses() ).onProperty( "city" ).containsOnly( "Paris", "Rome" );
+		assertThat( loadedAccount.getAddresses() ).onProperty( "zipCode" ).containsOnly( "75007", "00184" );
+		assertThat( loadedAccount.getAddresses() ).onProperty( "country" ).containsOnly( "France", "Italy" );
+		assertThat( loadedAccount.getAddresses() ).onProperty( "street2" ).containsOnly( null, null );
+		assertThat( loadedAccount.getAddresses() ).onProperty( "type" ).containsOnly( new AddressType( "primary" ), null );
+
+		Address loadedAddress1 = loadedAccount.getAddresses().get( 0 );
+		Address loadedAddress2 = loadedAccount.getAddresses().get( 1 );
+
+		transaction.commit();
+
+		session.clear();
+
+		transaction = session.beginTransaction();
+		loadedAddress1.setCountry( "USA" );
+		loadedAddress2.setCountry( "Germany" );
+
+		session.merge( loadedAccount );
+		transaction.commit();
+
+		session.clear();
+
+		transaction = session.beginTransaction();
+		MultiAddressAccount secondLoadedAccount = (MultiAddressAccount) session.get( MultiAddressAccount.class, account.getLogin() );
+		assertThat( secondLoadedAccount.getAddresses() ).onProperty( "city" ).contains( "Paris", "Rome" );
+		assertThat( secondLoadedAccount.getAddresses() ).onProperty( "country" ).contains( "USA", "Germany" );
+		session.delete( secondLoadedAccount );
+		transaction.commit();
+
+		session.clear();
+
+		transaction = session.beginTransaction();
+		assertThat( session.get( MultiAddressAccount.class, account.getLogin() ) ).isNull();
+		transaction.commit();
+
+		session.close();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { MultiAddressAccount.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableTest.java
@@ -77,77 +77,6 @@ public class EmbeddableTest extends OgmTestCase {
 	}
 
 	@Test
-	public void testElementCollectionOfEmbeddable() throws Exception {
-		final Session session = openSession();
-
-		Transaction transaction = session.beginTransaction();
-
-		Address address = new Address();
-		address.setCity( "Paris" );
-		address.setCountry( "France" );
-		address.setStreet1( "1 avenue des Champs Elysees" );
-		address.setZipCode( "75007" );
-
-		Address anotherAddress = new Address();
-		anotherAddress.setCity( "Rome" );
-		anotherAddress.setCountry( "Italy" );
-		anotherAddress.setStreet1( "Piazza del Colosseo, 1" );
-		anotherAddress.setZipCode( "00184" );
-		anotherAddress.setType( new AddressType( "primary" ) );
-
-		MultiAddressAccount account = new MultiAddressAccount();
-		account.setLogin( "gunnar" );
-		account.setPassword( "highly secret" );
-		account.getAddresses().add( address );
-		account.getAddresses().add( anotherAddress );
-
-		session.persist( account );
-		transaction.commit();
-
-		session.clear();
-
-		transaction = session.beginTransaction();
-		MultiAddressAccount loadedAccount = (MultiAddressAccount) session.get( MultiAddressAccount.class, account.getLogin() );
-		assertThat( loadedAccount ).as( "Cannot load persisted object" ).isNotNull();
-		assertThat( loadedAccount.getAddresses() ).onProperty( "city" ).containsOnly( "Paris", "Rome" );
-		assertThat( loadedAccount.getAddresses() ).onProperty( "zipCode" ).containsOnly( "75007", "00184" );
-		assertThat( loadedAccount.getAddresses() ).onProperty( "country" ).containsOnly( "France", "Italy" );
-		assertThat( loadedAccount.getAddresses() ).onProperty( "street2" ).containsOnly( null, null );
-		assertThat( loadedAccount.getAddresses() ).onProperty( "type" ).containsOnly( new AddressType( "primary" ), null );
-
-		Address loadedAddress1 = loadedAccount.getAddresses().get( 0 );
-		Address loadedAddress2 = loadedAccount.getAddresses().get( 1 );
-
-		transaction.commit();
-
-		session.clear();
-
-		transaction = session.beginTransaction();
-		loadedAddress1.setCountry( "USA" );
-		loadedAddress2.setCountry( "Germany" );
-
-		session.merge( loadedAccount );
-		transaction.commit();
-
-		session.clear();
-
-		transaction = session.beginTransaction();
-		MultiAddressAccount secondLoadedAccount = (MultiAddressAccount) session.get( MultiAddressAccount.class, account.getLogin() );
-		assertThat( secondLoadedAccount.getAddresses() ).onProperty( "city" ).contains( "Paris", "Rome" );
-		assertThat( secondLoadedAccount.getAddresses() ).onProperty( "country" ).contains( "USA", "Germany" );
-		session.delete( secondLoadedAccount );
-		transaction.commit();
-
-		session.clear();
-
-		transaction = session.beginTransaction();
-		assertThat( session.get( MultiAddressAccount.class, account.getLogin() ) ).isNull();
-		transaction.commit();
-
-		session.close();
-	}
-
-	@Test
 	public void testNestedEmbeddable() {
 		final Session session = openSession();
 
@@ -344,6 +273,6 @@ public class EmbeddableTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Account.class, MultiAddressAccount.class, AccountWithPhone.class, Order.class };
+		return new Class<?>[] { Account.class, AccountWithPhone.class, Order.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/failure/ErrorSpiJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/failure/ErrorSpiJpaTest.java
@@ -49,6 +49,10 @@ import org.junit.Test;
  * @author Gunnar Morling
  *
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Cassandra always upserts, doesn't read-lock before write, doesn't support uniq constraint even on primary key except by explicit/slow CAS use"
+)
 public class ErrorSpiJpaTest  extends JpaTestCase {
 
 	@Rule

--- a/core/src/test/java/org/hibernate/ogm/backendtck/failure/ErrorSpiTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/failure/ErrorSpiTest.java
@@ -48,6 +48,10 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  *
  * @author Gunnar Morling
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Cassandra always upserts, doesn't read-lock before write, doesn't support uniq constraint even on primary key except by explicit/slow CAS use"
+)
 public class ErrorSpiTest extends OgmTestCase {
 
 	private static ExecutorService executor;

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/DuplicateIdDetectionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/DuplicateIdDetectionTest.java
@@ -13,6 +13,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.jpa.JpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -23,6 +25,10 @@ import static org.junit.Assert.fail;
  *
  * @author Gunnar Morling
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "Cassandra always upserts, doesn't read-lock before write, doesn't support uniq constraint even on primary key except by explicit/slow CAS use"
+)
 public class DuplicateIdDetectionTest extends JpaTestCase {
 	EntityManager em;
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
@@ -15,7 +15,9 @@ import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.TestSessionFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +31,10 @@ import org.junit.rules.ExpectedException;
  * @author Gunnar Morling
  * @author Davide D'Alto
  */
+@SkipByGridDialect(
+		value = { GridDialectType.CASSANDRA },
+		comment = "WithEmbedded list fields - bag semantics unsupported (no primary key)"
+)
 public class QueriesWithEmbeddedTest extends OgmTestCase {
 
 	@TestSessionFactory

--- a/core/src/test/java/org/hibernate/ogm/test/type/StringMappedTypeSerialisationTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/type/StringMappedTypeSerialisationTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.ogm.backendtck.type;
+package org.hibernate.ogm.test.type;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.ogm.backendtck.type.Bookmark;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;


### PR DESCRIPTION
Exclude tests that cassandra can't support, which in some cases requires moving them to separate files to prevent annotated POJOs being processed if they would result in unsupported mappings.