### PR TITLE
Support WildFly 9

### DIFF
--- a/documentation/manual/pom.xml
+++ b/documentation/manual/pom.xml
@@ -91,6 +91,8 @@
                         <hibernate-orm-version>${hibernateVersion}</hibernate-orm-version>
                         <hibernate-search-version>${hibernateSearchVersion}</hibernate-search-version>
                         <hibernate-search-module-slot>${hibernate-search.module.slot}</hibernate-search-module-slot>
+                        <hibernate-search-major-minor-version>${hibernate-search-major-minor-version}</hibernate-search-major-minor-version>
+                        <hibernate-search-full-module-id>${hibernate-search-full-module-id}</hibernate-search-full-module-id>
                         <infinispan-version>${infinispanVersion}</infinispan-version>
                         <jboss-jta-version>${jbossjtaVersion}</jboss-jta-version>
                         <mongodb-version>${mongodbVersion}</mongodb-version>

--- a/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
@@ -384,7 +384,7 @@ https://docs.jboss.org/author/display/WFLY8/Class+Loading+in+WildFly[WildFly doc
 
 The Hibernate OGM module does not include the Hibernate Search module, so this will need to be downloaded separately.
 
-The Hibernate Search documentation has a similar section describing the details: http://docs.jboss.org/hibernate/search/{hibernate-search-module-slot}/reference/en-US/html/search-configuration.html#_update_and_activate_latest_hibernate_search_version_in_wildfly[Update and activate latest Hibernate Search version in WildFly].
+The Hibernate Search documentation has a similar section describing the details: http://docs.jboss.org/hibernate/search/{hibernate-search-major-minor-version}/reference/en-US/html/search-configuration.html#_update_and_activate_latest_hibernate_search_version_in_wildfly[Update and activate latest Hibernate Search version in WildFly].
 
 If your application needs to use both Hibernate OGM and Hibernate Search, your MANIFEST.MF will look like:
 
@@ -393,6 +393,6 @@ If your application needs to use both Hibernate OGM and Hibernate Search, your M
 [source]
 [subs="verbatim,attributes"]
 ----
-org.hibernate:ogm services, org.hibernate.ogm.couchdb services, org.hibernate.search.orm:{hibernate-search-module-slot} services
+org.hibernate:ogm services, org.hibernate.ogm.couchdb services, {hibernate-search-full-module-id} services
 ----
 ====

--- a/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
@@ -323,32 +323,33 @@ This is useful even if you don't plan to use Infinispan as your primary data sto
 
 [[ogm-configuration-jbossmodule]]
 
-=== How to package Hibernate OGM applications for WildFly 8.2
+=== How to package Hibernate OGM applications for WildFly 9
 
-Provided you're deploying on WildFly 8.2,
+Provided you're deploying on WildFly,
 there is an additional way to add the OGM dependencies to your application.
 
-In WildFly 8.2, class loading is based on modules
-that have to define explicit dependencies on other modules.
+In WildFly, class loading is based on modules; this system defines explicit, non-transitive dependencies on other modules.
+
 Modules allow to share the same artifacts across multiple applications,
-getting you smaller and quicker deployments.
+making deployments smaller and quicker, and also making it possible to deploy multiple different versions of any library.
 
 More details about modules are described in
-https://docs.jboss.org/author/display/WFLY8/Class+Loading+in+WildFly[Class Loading in WildFly].
+https://docs.jboss.org/author/display/WFLY9/Class+Loading+in+WildFly[Class Loading in WildFly].
 
-==== Packaging Hibernate OGM applications for WildFly 8.2
+If you apply the following instructions you can create super small deployments which do not include any dependency.
 
-You can download the pre-packaged module ZIP from:
+==== Packaging Hibernate OGM applications for WildFly 9
+
+You can download the pre-packaged module ZIP for this version of Hibernate OGM from:
 
 * https://downloads.sourceforge.net/project/hibernate/hibernate-ogm/{hibernate-ogm-version}/hibernate-ogm-modules-wildfly9-{hibernate-ogm-version}.zip[Sourceforge]
 * https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=central&g=org.hibernate.ogm&a=hibernate-ogm-modules-wildfly9&v={hibernate-ogm-version}&e=zip[JBoss's Maven repository]
 
-Unpack the archive into the +modules+ folder of your WildFly 8.2 installation.
+Unpack the archive into the +modules+ folder of your WildFly 9 installation.
 The modules included are:
 
 * _org.hibernate:ogm_, the core Hibernate OGM library and the Infinispan datastore provider.
-* _org.hibernate.ogm.<%DATASTORE%>:main_, one module for each datastore provider besides Infinispan, with _<%DATASTORE%>_ being one of _ehcache_, _mongodb_ etc.
-You only need to add those modules which you actually intend to use.
+* _org.hibernate.ogm.<%DATASTORE%>:main_, one module for each datastore, with _<%DATASTORE%>_ being one of _ehcache_, _mongodb_ etc.
 * Several shared dependencies such as _org.hibernate.hql:<%VERSION%>_ (containing the query parser) and others
 
 There are two ways to include the dependencies in your project:
@@ -378,15 +379,19 @@ Add a +WEB-INF/jboss-deployment-structure.xml+ in your archive with the followin
 ----
 
 More information about the descriptor can be found in the
-https://docs.jboss.org/author/display/WFLY8/Class+Loading+in+WildFly[WildFly documentation].
+https://docs.jboss.org/author/display/WFLY9/Class+Loading+in+WildFly[WildFly documentation].
 
-==== Loading both the Hibernate Search and Hibernate OGM modules WildFly 8.2
+==== Enabling both the Hibernate Search and Hibernate OGM modules
 
-The Hibernate OGM module does not include the Hibernate Search module, so this will need to be downloaded separately.
+A compatible Hibernate Search module is included in WildFly 9: all you have to do is activate the dependency.
 
-The Hibernate Search documentation has a similar section describing the details: http://docs.jboss.org/hibernate/search/{hibernate-search-major-minor-version}/reference/en-US/html/search-configuration.html#_update_and_activate_latest_hibernate_search_version_in_wildfly[Update and activate latest Hibernate Search version in WildFly].
+When using WildFly, no library is available to your deployments unless you explicitly request it, or unless it is the implementation for a JavaEE service which your application is using.
+For example, Hibernate ORM will be available by default to your application if you are including the definition of a persistence unit,
+although there are options to prevent that, for example to use a different JPA implementor or to use a different version of Hibernate ORM.
 
-If your application needs to use both Hibernate OGM and Hibernate Search, your MANIFEST.MF will look like:
+Hibernate Search is not automatically provided, so you have to make it available explicitly either via the +MANIFEST.MF+ or via a custom +jboss-deployment-structure.xml+.
+
+To do that, the +MANIFEST.MF+ of your deployment will look like:
 
 .Example MANIFEST.MF for an application using Hibernate OGM for CouchDB and also Hibernate Search
 ====
@@ -396,3 +401,11 @@ If your application needs to use both Hibernate OGM and Hibernate Search, your M
 org.hibernate:ogm services, org.hibernate.ogm.couchdb services, {hibernate-search-full-module-id} services
 ----
 ====
+
+Optionally you could download a different version of the Hibernate Search modules, provided it is compatible with the Hibernate OGM version you plan to use.
+For example you might want to download a more recent micro version of what is included in WildFly 9 at the time of publishing this documentation.
+
+The Hibernate Search documentation explains the details of downloading and deploying a custom version: http://docs.jboss.org/hibernate/search/{hibernate-search-major-minor-version}/reference/en-US/html/search-configuration.html#_update_and_activate_latest_hibernate_search_version_in_wildfly[Update and activate latest Hibernate Search version in WildFly].
+
+This approach might require you to make changes to the XML definitions of the Hibernate OGM modules to change the references to the Hibernate Search slot
+to the slot version that you plan to use.

--- a/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
@@ -340,8 +340,8 @@ https://docs.jboss.org/author/display/WFLY8/Class+Loading+in+WildFly[Class Loadi
 
 You can download the pre-packaged module ZIP from:
 
-* https://downloads.sourceforge.net/project/hibernate/hibernate-ogm/{hibernate-ogm-version}/hibernate-ogm-modules-wildfly8-{hibernate-ogm-version}.zip[Sourceforge]
-* https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=central&g=org.hibernate.ogm&a=hibernate-ogm-modules-wildfly8&v={hibernate-ogm-version}&e=zip[JBoss's Maven repository]
+* https://downloads.sourceforge.net/project/hibernate/hibernate-ogm/{hibernate-ogm-version}/hibernate-ogm-modules-wildfly9-{hibernate-ogm-version}.zip[Sourceforge]
+* https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=central&g=org.hibernate.ogm&a=hibernate-ogm-modules-wildfly9&v={hibernate-ogm-version}&e=zip[JBoss's Maven repository]
 
 Unpack the archive into the +modules+ folder of your WildFly 8.2 installation.
 The modules included are:

--- a/integrationtest/couchdb/src/test/resources/jboss-deployment-structure-couchdb.xml
+++ b/integrationtest/couchdb/src/test/resources/jboss-deployment-structure-couchdb.xml
@@ -13,7 +13,7 @@
         <dependencies>
             <module name="org.hibernate" slot="ogm" services="import" />
             <module name="org.hibernate.ogm.couchdb" services="import" />
-            <module name="org.hibernate.search.orm" slot="${hibernateSearchVersion}" services="import" />
+            <module name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}" services="import" />
             <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
         </dependencies>
         <exclusions>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -193,7 +193,7 @@
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>${project.groupId}</groupId>
-                                            <artifactId>hibernate-ogm-modules-wildfly8</artifactId>
+                                            <artifactId>hibernate-ogm-modules-wildfly9</artifactId>
                                             <version>${project.version}</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -199,6 +199,8 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${jboss.home}/modules</outputDirectory>
                                         </artifactItem>
+                                        <!-- The following modules are disabled as *with this specific version* we can
+                                          use the main modules as bundled with WildFly
                                         <artifactItem>
                                             <groupId>org.hibernate</groupId>
                                             <artifactId>hibernate-search-modules</artifactId>
@@ -216,6 +218,7 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${jboss.home}/modules</outputDirectory>
                                         </artifactItem>
+                                         -->
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -150,14 +150,15 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <version.wildfly>8.2.0.Final</version.wildfly>
+                <version.wildfly>9.0.0.CR1</version.wildfly>
+                <version.org.wildfly.arquillian>1.0.0.Alpha5</version.org.wildfly.arquillian>
                 <jboss.home>${project.build.directory}/wildfly-${version.wildfly}</jboss.home>
             </properties>
             <dependencies>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <version>${version.wildfly}</version>
+                <version>${version.org.wildfly.arquillian}</version>
                 <scope>test</scope>
                 <exclusions>
                     <!-- This exclusion is needed to be able to setup the project in Windows:

--- a/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/util/ModuleMemberRegistrationDeployment.java
+++ b/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/util/ModuleMemberRegistrationDeployment.java
@@ -87,7 +87,11 @@ public class ModuleMemberRegistrationDeployment {
 			for ( Entry<Object,Object> entry : entrySet ) {
 				String key = (String) entry.getKey();
 				String value = (String) entry.getValue();
+				String original = dependencies;
 				dependencies = dependencies.replace( "${" + key + "}", value );
+				if ( ! original.equals( dependencies ) ) {
+					System.out.println( "\n\n\t***\tDependency version injected: " + key + " = " + value + "\n" );
+				}
 			}
 			return dependencies;
 		}

--- a/integrationtest/testcase/src/test/resources/jboss-deployment-structure-ehcache.xml
+++ b/integrationtest/testcase/src/test/resources/jboss-deployment-structure-ehcache.xml
@@ -13,7 +13,7 @@
         <dependencies>
             <module name="org.hibernate" slot="ogm" services="import" />
             <module name="org.hibernate.ogm.ehcache" services="import" />
-            <module name="org.hibernate.search.orm" slot="${hibernateSearchVersion}" services="import" />
+            <module name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}" services="import" />
         </dependencies>
     </deployment>
 </jboss-deployment-structure>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -27,6 +27,7 @@
         <hibernate.ogm.infinispan.module.slot>main</hibernate.ogm.infinispan.module.slot>
         <hibernate.ogm.mongodb.module.slot>main</hibernate.ogm.mongodb.module.slot>
         <hibernate.ogm.neo4j.module.slot>main</hibernate.ogm.neo4j.module.slot>
+        <hibernate.ogm.neo4j-lucene.module.slot>main</hibernate.ogm.neo4j-lucene.module.slot>
         <hibernate.ogm.couchdb.module.slot>main</hibernate.ogm.couchdb.module.slot>
         <org.parboiled.module.slot>main</org.parboiled.module.slot>
     </properties>

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <hibernate.hql.module.slot>${hibernateParserVersion}</hibernate.hql.module.slot>
-        <infinispan.module.slot>ispn-7.2</infinispan.module.slot>
+        <infinispan.module.slot>main</infinispan.module.slot>
     </properties>
 
     <dependencies>

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>hibernate-envers</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- This is to satisfy Neo4J's custom Lucene,
+          not to be confused with the one used by Hibernate Search -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <optional>true</optional>
+            <version>${neo4jLuceneVersion}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -13,7 +13,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>hibernate-ogm-modules-wildfly8</artifactId>
+    <artifactId>hibernate-ogm-modules-wildfly9</artifactId>
     <packaging>pom</packaging>
 
     <name>Hibernate OGM WildFly Module</name>

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -5,7 +5,7 @@
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
 <assembly>
-    <id>wildfly8</id>
+    <id>wildfly9</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -34,9 +34,14 @@
              <outputDirectory>/org/hibernate/ogm/mongodb/main</outputDirectory>
              <filtered>true</filtered>
         </file>
-         <file>
+        <file>
              <source>${module.xml.basedir}/ogm/neo4j/module.xml</source>
              <outputDirectory>/org/hibernate/ogm/neo4j/${hibernate.ogm.neo4j.module.slot}</outputDirectory>
+             <filtered>true</filtered>
+        </file>
+        <file>
+             <source>${module.xml.basedir}/ogm/neo4j-lucene/module.xml</source>
+             <outputDirectory>/org/hibernate/ogm/neo4j/lucene/${hibernate.ogm.neo4j-lucene.module.slot}</outputDirectory>
              <filtered>true</filtered>
         </file>
         <file>
@@ -128,6 +133,16 @@
                   <include>org.scala-lang:scala-library</include>
                   <include>org.neo4j:neo4j-primitive-collections</include>
                   <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
+              </includes>
+       </dependencySet>
+       <dependencySet>
+              <useProjectArtifact>false</useProjectArtifact>
+              <outputDirectory>org/hibernate/ogm/neo4j/lucene/${hibernate.ogm.neo4j-lucene.module.slot}</outputDirectory>
+              <useTransitiveFiltering>false</useTransitiveFiltering>
+              <unpack>false</unpack>
+              <includes>
+                  <!-- Include the Lucene version used by Neo4J, not the one from Hibernate Search! -->
+                  <include>org.apache.lucene:lucene-core</include>
               </includes>
        </dependencySet>
        <!-- HQL -->

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -8,6 +8,7 @@
     <id>wildfly9</id>
     <formats>
         <format>zip</format>
+        <format>dir</format> <!-- For ease of debugging only -->
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <baseDirectory>/</baseDirectory>

--- a/modules/wildfly/src/main/modules/hql/module.xml
+++ b/modules/wildfly/src/main/modules/hql/module.xml
@@ -17,7 +17,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.hibernate.search.engine" optional="true" slot="${hibernateSearchVersion}" />
+        <module name="org.hibernate.search.engine" optional="true" slot="${hibernate-search.module.slot}" />
         <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/modules/wildfly/src/main/modules/ogm/infinispan/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/infinispan/module.xml
@@ -14,6 +14,7 @@
         <module name="org.hibernate.hql" slot="${hibernate.hql.module.slot}" />
 
         <module name="org.infinispan" slot="${infinispan.module.slot}" />
+        <module name="org.infinispan.commons" slot="${infinispan.module.slot}" />
         <module name="javax.api" />
         <module name="javax.persistence.api" />
         <module name="javax.transaction.api" />

--- a/modules/wildfly/src/main/modules/ogm/neo4j-lucene/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/neo4j-lucene/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.ogm.neo4j.lucene" slot="${hibernate.ogm.neo4j-lucene.module.slot}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="lucene-core-${neo4jLuceneVersion}.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
+</module>

--- a/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
@@ -29,10 +29,12 @@
         <module name="org.hibernate" slot="${hibernate.ogm.module.slot}" />
         <module name="org.hibernate.hql" slot="${hibernate.hql.module.slot}" />
 
+        <!-- Separate module to make sure it's not visible to the applications -->
+        <module name="org.hibernate.ogm.neo4j.lucene" slot="${hibernate.ogm.neo4j-lucene.module.slot}" />
+
         <module name="javax.api" />
         <module name="javax.persistence.api" />
         <module name="javax.transaction.api" />
-        <module name="org.apache.lucene" />
         <module name="org.jboss.logging" />
         <module name="org.parboiled" />
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,11 @@
         <!-- Since we require users to import a specific Hibernate Search module explicitly,
          all integration tests need to know which version that shall be.
          So the property needs to be defined in the global parent pom -->
-        <hibernate-search.module.slot>5.2</hibernate-search.module.slot>
+        <hibernate-search.module.slot>main</hibernate-search.module.slot>
+        <!-- Following might not match the slot, for example when 'main' is being used. Needed in docs URL rendering. -->
+        <hibernate-search-major-minor-version>5.2</hibernate-search-major-minor-version>
+        <!-- For documentation, to omit the slot when not needed: -->
+        <hibernate-search-full-module-id>org.hibernate.search.orm</hibernate-search-full-module-id>
     </properties>
 
     <!-- Only for management of test-scoped dependencies; All other dependencies (which are exposed to users) are

--- a/src/main/release-scripts/upload_distribution.sh
+++ b/src/main/release-scripts/upload_distribution.sh
@@ -8,5 +8,5 @@ scp readme.md frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
 scp changelog.txt frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
 scp distribution/target/hibernate-ogm-$RELEASE_VERSION-dist.zip frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
 scp distribution/target/hibernate-ogm-$RELEASE_VERSION-dist.tar.gz frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
-scp modules/wildfly/target/hibernate-ogm-modules-wildfly8-$RELEASE_VERSION.zip frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
+scp modules/wildfly/target/hibernate-ogm-modules-wildfly9-$RELEASE_VERSION.zip frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION
 scp modules/eap/target/hibernate-ogm-modules-eap6-$RELEASE_VERSION-experimental.zip frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION


### PR DESCRIPTION
This has been tested successfully with WildFly 9.0.0.CR2-SNAPSHOT, but the PR refers to 9.0.0.CR1 (both work).

Some points of interest:
 - I had to better hide the Lucene version used by Neo4J as classloader precedence in WF9 would otherwise expose it to the wrong Lucene version
 - the custom Lucene module uses the 'org.hibernate.ogm.neo4j.lucene' module id to prevent slot conflicts with other projects (this being the one provided by OGM)
 - turns out some slot definitions were wrong 
 - this does replace (remove) the support for WildFly 8, as agreed on the mailing list.
 - the artifact id for Arquillian changed

The download/unpacking of the Hibernate Search and Infinispan modules for integration tests - not needed in this specific version - is simply commented out as I don't think it's worth to fight Maven to automate that: we'll probably need that soon again, and it's going to be impossible to forget about that w/o having tests to complain.
