### PR TITLE
OGM-837 Support queries on composite ids on Neo4j and MongoDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/query/parsing/impl/ParserPropertyHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/query/parsing/impl/ParserPropertyHelper.java
@@ -125,6 +125,13 @@ public class ParserPropertyHelper implements PropertyHelper {
 		return (OgmEntityPersister) sessionFactory.getEntityPersister( targetedType.getName() );
 	}
 
+	/**
+	 * Checks if the path leads to an embedded property or association.
+	 *
+	 * @param targetTypeName the entity with the property
+	 * @param namesWithoutAlias the path to the the property with all the aliases resolved
+	 * @return {@code true} if the property is an embedded, {@code false} otherwise.
+	 */
 	public boolean isEmbeddedProperty(String targetTypeName, List<String> namesWithoutAlias) {
 		OgmEntityPersister persister = getPersister( targetTypeName );
 		Type propertyType = persister.getPropertyType( namesWithoutAlias.get( 0 ) );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/News.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/News.java
@@ -80,4 +80,15 @@ public class News {
 		result = 31 * result + ( labels != null ? labels.hashCode() : 0 );
 		return result;
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append( "News [newsId=" );
+		builder.append( newsId );
+		builder.append( ", content=" );
+		builder.append( content );
+		builder.append( "]" );
+		return builder.toString();
+	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/News.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/News.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.backendtck.id;
 
 import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -63,9 +64,6 @@ public class News {
 		if ( content != null ? !content.equals( news.content ) : news.content != null ) {
 			return false;
 		}
-		if ( labels != null ? !labels.equals( news.labels ) : news.labels != null ) {
-			return false;
-		}
 		if ( newsId != null ? !newsId.equals( news.newsId ) : news.newsId != null ) {
 			return false;
 		}
@@ -77,7 +75,6 @@ public class News {
 	public int hashCode() {
 		int result = newsId != null ? newsId.hashCode() : 0;
 		result = 31 * result + ( content != null ? content.hashCode() : 0 );
-		result = 31 * result + ( labels != null ? labels.hashCode() : 0 );
 		return result;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/NewsID.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/NewsID.java
@@ -70,4 +70,15 @@ public class NewsID implements Serializable {
 		result = 31 * result + ( author != null ? author.hashCode() : 0 );
 		return result;
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append( "NewsID [title=" );
+		builder.append( title );
+		builder.append( ", author=" );
+		builder.append( author );
+		builder.append( "]" );
+		return builder.toString();
+	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/NewsID.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/NewsID.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.backendtck.id;
 
 import java.io.Serializable;
+
 import javax.persistence.Embeddable;
 
 /**
@@ -44,30 +45,42 @@ public class NewsID implements Serializable {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
 			return true;
 		}
-		if ( o == null || getClass() != o.getClass() ) {
+		if ( obj == null ) {
 			return false;
 		}
-
-		NewsID newsID = (NewsID) o;
-
-		if ( author != null ? !author.equals( newsID.author ) : newsID.author != null ) {
+		if ( getClass() != obj.getClass() ) {
 			return false;
 		}
-		if ( title != null ? !title.equals( newsID.title ) : newsID.title != null ) {
+		NewsID other = (NewsID) obj;
+		if ( author == null ) {
+			if ( other.author != null ) {
+				return false;
+			}
+		}
+		else if ( !author.equals( other.author ) ) {
 			return false;
 		}
-
+		if ( title == null ) {
+			if ( other.title != null ) {
+				return false;
+			}
+		}
+		else if ( !title.equals( other.title ) ) {
+			return false;
+		}
 		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		int result = title != null ? title.hashCode() : 0;
-		result = 31 * result + ( author != null ? author.hashCode() : 0 );
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( author == null ) ? 0 : author.hashCode() );
+		result = prime * result + ( ( title == null ) ? 0 : title.hashCode() );
 		return result;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/CompositeIdQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/CompositeIdQueriesTest.java
@@ -1,0 +1,120 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.queries;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.utils.SessionHelper.asProjectionResults;
+import static org.hibernate.ogm.utils.SessionHelper.delete;
+import static org.hibernate.ogm.utils.SessionHelper.persist;
+
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.backendtck.id.Label;
+import org.hibernate.ogm.backendtck.id.News;
+import org.hibernate.ogm.backendtck.id.NewsID;
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SessionHelper.ProjectionResult;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestSessionFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+@SkipByGridDialect(
+	value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN },
+	comment = "Hibernate Search does not store properties of the @EmbeddedId by default in the index, it requires the use of @FieldBridge."
+			+ "It is also not sufficient to add a custom field bridge because the properties of the embedded id won't be recognized as properties of the entity."
+			+ "There is a JIRA to keep track of this: OGM-849")
+public class CompositeIdQueriesTest extends OgmTestCase {
+
+	@TestSessionFactory
+	public static SessionFactory sessions;
+
+	private static final String author = "Guillaume";
+
+	private static final String titleOGM = "How to use Hibernate OGM ?";
+	private static final String titleAboutJUG = "What is a JUG ?";
+	private static final String titleCountJUG = "There are more than 20 JUGs in France";
+
+	private static final String contentOGM = "Simple, just like ORM but with a NoSQL database";
+	private static final String contentAboutJUG = "JUG means Java User Group";
+	private static final String contentCountJUG = "Great! Congratulations folks";
+
+	private static final News aboutJUG = new News( new NewsID( titleAboutJUG, author ), contentAboutJUG, null );
+	private static final News ogmHowTo = new News( new NewsID( titleOGM, author ), contentOGM, null );
+	private static final News countJUG = new News( new NewsID( titleCountJUG, author ), contentCountJUG, null );
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private Session session;
+
+	private Transaction tx;
+
+	@BeforeClass
+	public static void insertTestEntities() throws Exception {
+		persist( sessions, ogmHowTo, aboutJUG, countJUG );
+	}
+
+	@Test
+	public void testQueryWithFileterOnAttribute() throws Exception {
+		News result = (News) session.createQuery( "FROM News n WHERE n.newsId.title = '" + ogmHowTo.getNewsId().getTitle() + "'" ).uniqueResult();
+		assertThat( result ).isEqualTo( ogmHowTo );
+	}
+
+	@Test
+	public void testSingleAttributeProjection() throws Exception {
+		String result = (String) session.createQuery( "SELECT n.newsId.title FROM News n WHERE n.newsId.title = '" + ogmHowTo.getNewsId().getTitle() + "'" ).uniqueResult();
+		assertThat( result ).isEqualTo( ogmHowTo.getNewsId().getTitle() );
+	}
+
+	@Test
+	public void testProjections() throws Exception {
+		List<ProjectionResult> result = asProjectionResults( session, "SELECT n.newsId.title, n.newsId.author, n.content FROM News n WHERE n.newsId.title = '" + ogmHowTo.getNewsId().getTitle() + "'" );
+		assertThat( result ).containsExactly( new ProjectionResult( ogmHowTo.getNewsId().getTitle(), ogmHowTo.getNewsId().getAuthor(), ogmHowTo.getContent() ) );
+	}
+
+	@Before
+	public void createSession() {
+		closeSession();
+		session = sessions.openSession();
+		tx = session.beginTransaction();
+	}
+
+	@After
+	public void closeSession() {
+		if ( tx != null && tx.isActive() ) {
+			tx.commit();
+			tx = null;
+		}
+		if ( session != null ) {
+			session.close();
+			session = null;
+		}
+	}
+
+	@AfterClass
+	public static void removeTestEntities() throws Exception {
+		delete( sessions, News.class, ogmHowTo.getNewsId(), aboutJUG.getNewsId(), countJUG.getNewsId() );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { News.class, Label.class };
+	}
+}

--- a/documentation/manual/src/main/asciidoc/en-US/modules/query.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/query.asciidoc
@@ -121,11 +121,17 @@ from Helicopter h order by h.make desc, h.name
 ----
 ====
 
-Inner `JOIN` on an embedded association is partially supported.
-In particular, filtering the elements of the association works for all the datastores
-but projecting properties won't work if you are using Hibernate Search queries.
+There are also features that are partially supported:
 
-This is better illustrated by the following example:
+* Inner `JOIN` on an embedded association:
+  works as expected with Neo4j and MongoDB;
+  doesn't work if your datastore provider implements JP-QL queries using Hibernate Search.
+
+* Projections or filters on properties of an embedded identifier:
+  works as expected with Neo4j and MongoDB;
+  doesn't work if your datastore provider implements JP-QL queries using Hibernate Search.
+
+These are better illustrated by the following example:
 
 .Entity with embedded collection and supported JP-QL queries
 ====
@@ -135,12 +141,26 @@ This is better illustrated by the following example:
 @Entity
 public class StoryGame {
 
+    @DocumentId
+    @EmbeddedId
+    @FieldBridge(impl = NewsIdFieldBridge.class)
+    private StoryID storyId;
+
     @ElementCollection
     @IndexedEmbedded
     private List<OptionalStoryBranch> optionalEndings;
 
     ...
 
+}
+
+@Embeddable
+public class StoryID implements Serializable {
+
+    private String title;
+    private String author;
+
+    ...
 }
 
 @Embeddable
@@ -166,15 +186,36 @@ String query =
 List<StoryGame> stories = session.createQuery( query ).list();
 ----
 
-Projection will  work with Neo4j or MongoDB but it won't give the expected results with the other
-datastores:
+Projection of properties of an embedded association works with Neo4j and MongoDB,
+but the other datastores will only return one element from the association.
+This is due to the fact that Hibernate Search is currently not supporting projection
+of associations.
+Here's an example of a query affected by this:
 
 [source, JAVA]
 ----
 String query =
      "SELECT ending.text " +
-     "FROM StoryGame sg JOIN sg.optionalEndings ending WHERE ending.text = 'Happy ending'";
+     "FROM StoryGame sg JOIN sg.optionalEndings ending WHERE ending.text LIKE 'Happy%'";
 List<String> endings = session.createQuery( query ).list();
+----
+
+Projecting and filtering on embedded id properties works with Neo4j and MongoDB
+but throws an exception with the other datastores:
+
+[source, JAVA]
+----
+String query =
+     "SELECT sg.storyId.title FROM StoryGame sg WHERE sg.storyId.title = 'Best Story Ever'";
+List<String> title = session.createQuery( query ).list();
+----
+
+It will cause the following exception if the datastore uses Hibernate Search
+to execute JP-QL queries:
+
+[source, JAVA]
+----
+org.hibernate.hql.ParsingException: HQL100002: The type [storyId] has no indexed property named title.
 ----
 ====
 

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBPropertyHelper.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBPropertyHelper.java
@@ -36,13 +36,16 @@ public class MongoDBPropertyHelper extends ParserPropertyHelper implements Prope
 		return getColumnName( getPersister( entityType ), propertyPath );
 	}
 
-	public String getColumnName(OgmEntityPersister persister, List<String> propertyName) {
-		String columnName = StringHelper.join( propertyName, "." );
-
-		if ( columnName.equals( persister.getIdentifierPropertyName() ) ) {
+	public String getColumnName(OgmEntityPersister persister, List<String> propertyPath) {
+		String propertyName = StringHelper.join( propertyPath, "." );
+		String identifierPropertyName = persister.getIdentifierPropertyName();
+		if ( propertyName.equals( identifierPropertyName ) ) {
 			return MongoDBDialect.ID_FIELDNAME;
 		}
-
-		return getColumn( persister, propertyName);
+		String column = getColumn( persister, propertyPath );
+		if ( propertyPath.size() > 1 && propertyPath.get( 0 ).equals( identifierPropertyName ) ) {
+			column = MongoDBDialect.ID_FIELDNAME + "." + column.substring( propertyPath.get( 0 ).length() + 1 );
+		}
+		return column;
 	}
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jPredicateFactory.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jPredicateFactory.java
@@ -102,15 +102,12 @@ public class Neo4jPredicateFactory implements PredicateFactory<StringBuilder> {
 	}
 
 	private String columnName(String entityType, List<String> propertyPath) {
-		if ( propertyHelper.isEmbeddedProperty( entityType, propertyPath ) ) {
-			return propertyHelper.getEmbeddeColumnName( entityType, propertyPath );
-		}
 		return propertyHelper.getColumnName( entityType, propertyPath );
 	}
 
 	private String alias(String entityType, List<String> propertyPath) {
 		String targetEntityAlias = aliasResolver.findAliasForType( entityType );
-		if ( propertyHelper.isEmbeddedProperty( entityType, propertyPath ) ) {
+		if ( propertyHelper.isEmbeddedProperty( entityType, propertyPath ) && !propertyHelper.isIdProperty( entityType, propertyPath ) ) {
 			return aliasResolver.createAliasForEmbedded( targetEntityAlias, propertyPath, false );
 		}
 		return targetEntityAlias;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-837

This patch allows the execution of queries on MongoDB and Neo4j on the attributes of an embedded id. For example:
 `FROM News n WHERE n.newsId.title = '...'`

Hibernate Search converts the embedded id using a  FieldBridge, Therefore there is non `newsId.title` in the index at the end (only `newsId`). Maybe we should store both values. haat do you think? 
