### PR TITLE
OGM-555 More natural representation of maps in MongoDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/document/cfg/DocumentStoreProperties.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/cfg/DocumentStoreProperties.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.datastore.document.cfg;
 
 import org.hibernate.ogm.cfg.OgmConfiguration;
 import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 
 /**
  * Common properties for configuring document datastores such as MongoDB or CouchDB via {@code persistence.xml} or
@@ -31,4 +32,16 @@ public interface DocumentStoreProperties extends OgmProperties {
 	 * programmatic API.
 	 */
 	String ASSOCIATIONS_STORE = "hibernate.ogm.datastore.document.association_storage";
+
+	/**
+	 * Property for configuring the strategy for storing map-typed associations. Only applies to maps with a single key
+	 * column which is of type {@code String}. Valid values are the {@link MapStorageType} enumeration and the String
+	 * representation of its constants. Defaults to the {@link MapStorageType#BY_KEY} strategy. For map associations
+	 * with more than one key column or a single key column of another type than {@code String} always the list strategy
+	 * will be used regardless of this setting.
+	 * <p>
+	 * Note that any value specified via this property will be overridden by values configured via annotations or the
+	 * programmatic API.
+	 */
+	String MAP_STORAGE = "hibernate.ogm.datastore.document.map_storage";
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/MapStorage.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/MapStorage.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.document.options;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.hibernate.ogm.datastore.document.options.impl.MapStorageConverter;
+import org.hibernate.ogm.options.spi.MappingOption;
+
+/**
+ * Define the association storage type for the annotated entity or property. When given for a property which doesn't
+ * represent an association, this setting is ignored.
+ *
+ * @author Gunnar Morling
+ */
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+@MappingOption(MapStorageConverter.class)
+public @interface MapStorage {
+
+	/**
+	 * The strategy for storing map-typed associations
+	 *
+	 * @return the strategy for storing map-typed associations
+	 */
+	MapStorageType value();
+}

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/MapStorageType.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/MapStorageType.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.document.options;
+
+/**
+ * Strategies for storing the keys and values of map-typed associations.
+ *
+ * @author Gunnar Morling
+ */
+public enum MapStorageType {
+
+	/**
+	 * For map-typed associations with a single key column which is of type {@code String}, the following document
+	 * representation will be persisted:
+	 *
+	 * <pre>
+	 * ...
+	 * "addresses" : {
+	 *     "home" : 123,
+	 *     "work" : 456
+	 * }
+	 * ...
+	 * <pre>
+	 *
+	 * This setting is ignored for all other key column types,
+	 * {@link MapStorageType#AS_LIST} will be used then.
+	 */
+	BY_KEY,
+
+	/**
+	 * The entries of a map-typed association will be stored as an array with a sub-document for each map entry. All key
+	 * and value columns will be contained within the array elements:
+	 *
+	 * <pre>
+	 * ...
+	 * "addresses" : [
+	 *     { "addressType" : "home", "addressId" : 123 },
+	 *     { "addressType" : "work", "addressId" : 456 },
+	 * ]
+	 * ...
+	 * <pre>
+	 */
+	AS_LIST;
+}

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/impl/MapStorageConverter.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/impl/MapStorageConverter.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.document.options.impl;
+
+import org.hibernate.ogm.datastore.document.options.MapStorage;
+import org.hibernate.ogm.datastore.document.options.spi.MapStorageOption;
+import org.hibernate.ogm.options.spi.AnnotationConverter;
+import org.hibernate.ogm.options.spi.OptionValuePair;
+
+/**
+ * Converts {@link MapStorage} instances into an equivalent option value pair.
+ *
+ * @author Gunnar Morling
+ */
+public class MapStorageConverter implements AnnotationConverter<MapStorage> {
+
+	@Override
+	public OptionValuePair<?> convert(MapStorage annotation) {
+		return OptionValuePair.getInstance( new MapStorageOption(), annotation.value() );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStoreEntityContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStoreEntityContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.document.options.navigation;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.options.navigation.EntityContext;
 
 /**
@@ -25,4 +26,13 @@ public interface DocumentStoreEntityContext<E extends DocumentStoreEntityContext
 	 * @return this context, allowing for further fluent API invocations
 	 */
 	E associationStorage(AssociationStorageType associationStorage);
+
+	/**
+	 * Specifies how contents of map-typed associations should be persisted.
+	 *
+	 * @param mapStorage the mapStorage storage type to be used when not configured on the property level. Overrides any
+	 * settings on the global level.
+	 * @return this context, allowing for further fluent API invocations
+	 */
+	E mapStorage(MapStorageType mapStorage);
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStoreGlobalContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStoreGlobalContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.document.options.navigation;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.options.navigation.GlobalContext;
 
 /**
@@ -25,4 +26,13 @@ public interface DocumentStoreGlobalContext<G extends DocumentStoreGlobalContext
 	 * @return this context, allowing for further fluent API invocations
 	 */
 	G associationStorage(AssociationStorageType associationStorage);
+
+	/**
+	 * Specifies how contents of map-typed associations should be persisted.
+	 *
+	 * @param mapStorage the mapStorage storage type to be used when not configured on the entity or property
+	 * level
+	 * @return this context, allowing for further fluent API invocations
+	 */
+	G mapStorage(MapStorageType mapStorage);
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStorePropertyContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/DocumentStorePropertyContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.document.options.navigation;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.options.navigation.PropertyContext;
 
 /**
@@ -25,5 +26,14 @@ public interface DocumentStorePropertyContext<E extends DocumentStoreEntityConte
 	 * @return this context, allowing for further fluent API invocations
 	 */
 	P associationStorage(AssociationStorageType storage);
+
+	/**
+	 * Specifies how the contents of a map-typed association should be persisted. Only applies if the property
+	 * represents a map-typed association.
+	 *
+	 * @param mapStorage the mapStorage storage type to be used. Overrides any settings on the entity and global level.
+	 * @return this context, allowing for further fluent API invocations
+	 */
+	P mapStorage(MapStorageType mapStorage);
 
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStoreEntityContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStoreEntityContext.java
@@ -7,9 +7,11 @@
 package org.hibernate.ogm.datastore.document.options.navigation.spi;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStoreEntityContext;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStorePropertyContext;
 import org.hibernate.ogm.datastore.document.options.spi.AssociationStorageOption;
+import org.hibernate.ogm.datastore.document.options.spi.MapStorageOption;
 import org.hibernate.ogm.options.navigation.spi.BaseEntityContext;
 import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
 
@@ -28,6 +30,16 @@ public abstract class BaseDocumentStoreEntityContext<E extends DocumentStoreEnti
 	@Override
 	public E associationStorage(AssociationStorageType associationStorage) {
 		addEntityOption( new AssociationStorageOption(), associationStorage );
+
+		// ok; an error would only occur for inconsistently defined context types
+		@SuppressWarnings("unchecked")
+		E context = (E) this;
+		return context;
+	}
+
+	@Override
+	public E mapStorage(MapStorageType mapStorage) {
+		addEntityOption( new MapStorageOption(), mapStorage );
 
 		// ok; an error would only occur for inconsistently defined context types
 		@SuppressWarnings("unchecked")

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStoreGlobalContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStoreGlobalContext.java
@@ -7,9 +7,11 @@
 package org.hibernate.ogm.datastore.document.options.navigation.spi;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStoreEntityContext;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStoreGlobalContext;
 import org.hibernate.ogm.datastore.document.options.spi.AssociationStorageOption;
+import org.hibernate.ogm.datastore.document.options.spi.MapStorageOption;
 import org.hibernate.ogm.options.navigation.spi.BaseGlobalContext;
 import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
 
@@ -28,6 +30,16 @@ public abstract class BaseDocumentStoreGlobalContext<G extends DocumentStoreGlob
 	@Override
 	public G associationStorage(AssociationStorageType associationStorage) {
 		addGlobalOption( new AssociationStorageOption(), associationStorage );
+
+		// ok; an error would only occur for inconsistently defined context types
+		@SuppressWarnings("unchecked")
+		G context = (G) this;
+		return context;
+	}
+
+	@Override
+	public G mapStorage(MapStorageType mapStorage) {
+		addGlobalOption( new MapStorageOption(), mapStorage );
 
 		// ok; an error would only occur for inconsistently defined context types
 		@SuppressWarnings("unchecked")

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStorePropertyContext.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/navigation/spi/BaseDocumentStorePropertyContext.java
@@ -7,9 +7,11 @@
 package org.hibernate.ogm.datastore.document.options.navigation.spi;
 
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStoreEntityContext;
 import org.hibernate.ogm.datastore.document.options.navigation.DocumentStorePropertyContext;
 import org.hibernate.ogm.datastore.document.options.spi.AssociationStorageOption;
+import org.hibernate.ogm.datastore.document.options.spi.MapStorageOption;
 import org.hibernate.ogm.options.navigation.spi.BasePropertyContext;
 import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
 
@@ -28,6 +30,16 @@ public abstract class BaseDocumentStorePropertyContext<E extends DocumentStoreEn
 	@Override
 	public P associationStorage(AssociationStorageType storage) {
 		addPropertyOption( new AssociationStorageOption(), storage );
+
+		// ok; an error would only occur for inconsistently defined context types
+		@SuppressWarnings("unchecked")
+		P context = (P) this;
+		return context;
+	}
+
+	@Override
+	public P mapStorage(MapStorageType mapStorage) {
+		addPropertyOption( new MapStorageOption(), mapStorage );
 
 		// ok; an error would only occur for inconsistently defined context types
 		@SuppressWarnings("unchecked")

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/options/spi/MapStorageOption.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/options/spi/MapStorageOption.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.document.options.spi;
+
+import org.hibernate.ogm.datastore.document.cfg.DocumentStoreProperties;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
+import org.hibernate.ogm.options.spi.UniqueOption;
+import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+
+/**
+ * Option for specifying the strategy for storing map contents in document stores.
+ *
+ * @author Gunnar Morling
+ */
+public class MapStorageOption extends UniqueOption<MapStorageType> {
+
+	/**
+	 * The default map storage strategy.
+	 */
+	private static final MapStorageType DEFAULT_MAP_STORAGE = MapStorageType.BY_KEY;
+
+	@Override
+	public MapStorageType getDefaultValue(ConfigurationPropertyReader propertyReader) {
+		return propertyReader
+				.property( DocumentStoreProperties.MAP_STORAGE, MapStorageType.class )
+				.withDefault( DEFAULT_MAP_STORAGE )
+				.getValue();
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Department.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Department.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.collection.types;
+
+import javax.persistence.Embeddable;
+
+/**
+ * @author Gunnar Morling
+ */
+@Embeddable
+public class Department {
+
+	private String name;
+	private int headCount;
+
+	public Department() {
+	}
+
+	public Department(String name, int headCount) {
+		this.name = name;
+		this.headCount = headCount;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getHeadCount() {
+		return headCount;
+	}
+
+	public void setHeadCount(int headCount) {
+		this.headCount = headCount;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( headCount ^ ( headCount >>> 32 ) );
+		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		Department other = (Department) obj;
+		if ( headCount != other.headCount ) {
+			return false;
+		}
+		if ( name == null ) {
+			if ( other.name != null ) {
+				return false;
+			}
+		}
+		else if ( !name.equals( other.name ) ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Enterprise.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Enterprise.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.collection.types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.MapKeyColumn;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+public class Enterprise {
+
+	private String id;
+	private Map<String, Department> departments = new HashMap<>();
+
+	public Enterprise() {
+	}
+
+	public Enterprise(String id, Map<String, Department> departments) {
+		this.id = id;
+		this.departments = departments;
+	}
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@ElementCollection
+	@MapKeyColumn(name = "departmentName")
+	public Map<String, Department> getDepartments() {
+		return departments;
+	}
+
+	public void setDepartments(Map<String, Department> departments) {
+		this.departments = departments;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Enterprise.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/Enterprise.java
@@ -22,6 +22,7 @@ public class Enterprise {
 
 	private String id;
 	private Map<String, Department> departments = new HashMap<>();
+	private Map<String, Integer> revenueByDepartment = new HashMap<>();
 
 	public Enterprise() {
 	}
@@ -48,5 +49,14 @@ public class Enterprise {
 
 	public void setDepartments(Map<String, Department> departments) {
 		this.departments = departments;
+	}
+
+	@ElementCollection
+	public Map<String, Integer> getRevenueByDepartment() {
+		return revenueByDepartment;
+	}
+
+	public void setRevenueByDepartment(Map<String, Integer> revenueByDepartment) {
+		this.revenueByDepartment = revenueByDepartment;
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
@@ -98,7 +98,7 @@ public class MapContentsStoredInSeparateDocumentTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { User.class, Address.class };
+		return new Class<?>[] { User.class, Address.class, PhoneNumber.class };
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -29,9 +29,10 @@ import org.junit.Test;
 public class MapTest extends OgmTestCase {
 
 	@Test
-	public void testMapAndElementCollection() throws Exception {
+	public void testMapOfEntity() throws Exception {
 		Session session = openSession();
 		Transaction tx = session.beginTransaction();
+
 		Address home = new Address();
 		home.setCity( "Paris" );
 		Address work = new Address();
@@ -39,11 +40,49 @@ public class MapTest extends OgmTestCase {
 		User user = new User();
 		user.getAddresses().put( "home", home );
 		user.getAddresses().put( "work", work );
-		user.getNicknames().add( "idrA" );
-		user.getNicknames().add( "day[9]" );
+
 		session.persist( home );
 		session.persist( work );
 		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		if ( getCurrentDialectType().isDocumentStore() ) {
+			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.IN_ENTITY ) )
+					.describedAs( "Map contents should be stored within the entity document" )
+					.isEqualTo( 1 );
+			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.ASSOCIATION_DOCUMENT ) )
+					.describedAs( "Map contents should be stored within the entity document" )
+					.isEqualTo( 0 );
+		}
+
+		tx = session.beginTransaction();
+		user = (User) session.get( User.class, user.getId() );
+		// TODO do null value
+		assertThat( user.getAddresses() ).as( "Map should have 2 elements" ).hasSize( 2 );
+		assertThat( user.getAddresses().get( "home" ).getCity() ).as( "home address should be under home" ).isEqualTo(
+				home.getCity() );
+		session.delete( user );
+		session.delete( session.load( Address.class, home.getId() ) );
+		session.delete( session.load( Address.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testSetElementCollectionStorageAndRemoval() throws Exception {
+		Session session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		User user = new User();
+		user.getNicknames().add( "idrA" );
+		user.getNicknames().add( "day[9]" );
+		session.persist( user );
+
 		User user2 = new User();
 		user2.getNicknames().add( "idrA" );
 		user2.getNicknames().add( "day[9]" );
@@ -54,37 +93,30 @@ public class MapTest extends OgmTestCase {
 
 		if ( getCurrentDialectType().isDocumentStore() ) {
 			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.IN_ENTITY ) )
-					.describedAs( "Map contents and element collections should be stored within the entity document" )
-					.isEqualTo( 3 );
+					.describedAs( "Element collections should be stored within the entity document" )
+					.isEqualTo( 2 );
 			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.ASSOCIATION_DOCUMENT ) )
-					.describedAs( "Map contents should be stored within the entity document" )
+					.describedAs( "Element collections should be stored within the entity document" )
 					.isEqualTo( 0 );
 		}
 
 		tx = session.beginTransaction();
-		user = (User) session.get( User.class, user.getId() );
-		assertThat( user.getNicknames() ).as( "Should have 2 nick1" ).hasSize( 2 );
-		assertThat( user.getNicknames() ).as( "Should contain nicks" ).contains( "idrA", "day[9]" );
-		user.getNicknames().remove( "idrA" );
-		tx.commit();
 
+		user = (User) session.get( User.class, user.getId() );
+		assertThat( user.getNicknames() ).containsOnly( "idrA", "day[9]" );
+		user.getNicknames().remove( "idrA" );
+
+		tx.commit();
 		session.clear();
 
 		tx = session.beginTransaction();
+
 		user = (User) session.get( User.class, user.getId() );
-		// TODO do null value
-		assertThat( user.getAddresses() ).as( "Map should have 2 elements" ).hasSize( 2 );
-		assertThat( user.getAddresses().get( "home" ).getCity() ).as( "home address should be under home" ).isEqualTo(
-				home.getCity() );
-		assertThat( user.getNicknames() ).as( "Should have 1 nick1" ).hasSize( 1 );
-		assertThat( user.getNicknames() ).as( "Should contain nick" ).contains( "day[9]" );
+		assertThat( user.getNicknames() ).containsOnly( "day[9]" );
 		session.delete( user );
-		session.delete( session.load( Address.class, home.getId() ) );
-		session.delete( session.load( Address.class, work.getId() ) );
 
 		user2 = (User) session.get( User.class, user2.getId() );
-		assertThat( user2.getNicknames() ).as( "Should have 2 nicks" ).hasSize( 2 );
-		assertThat( user2.getNicknames() ).as( "Should contain nick" ).contains( "idrA", "day[9]" );
+		assertThat( user2.getNicknames() ).containsOnly( "idrA", "day[9]" );
 		session.delete( user2 );
 
 		tx.commit();

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -7,8 +7,12 @@
 package org.hibernate.ogm.backendtck.associations.collection.types;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
 import static org.hibernate.ogm.utils.TestHelper.getCurrentDialectType;
 import static org.hibernate.ogm.utils.TestHelper.getNumberOfAssociations;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -201,12 +205,42 @@ public class MapTest extends OgmTestCase {
 
 		tx.commit();
 		session.close();
+	}
+
+	public void testMapOfComponent() {
+		Session session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Map<String, Department> departments = new HashMap<>();
+		departments.put( "sawing", new Department( "Sawing", 7 ) );
+		departments.put( "sale", new Department( "Sale", 2 ) );
+		Enterprise timberTradingInc = new Enterprise( "enterprise-1", departments );
+
+		session.persist( timberTradingInc );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// assert
+		timberTradingInc = (Enterprise) session.get( Enterprise.class, "enterprise-1" );
+
+		assertThat( timberTradingInc.getDepartments() ).hasSize( 2 );
+		assertThat( timberTradingInc.getDepartments() ).includes( entry( "sawing", new Department( "Sawing", 7 ) ) );
+		assertThat( timberTradingInc.getDepartments() ).includes( entry( "sale", new Department( "Sale", 2 ) ) );
+
+		// clean up
+		session.delete( timberTradingInc );
+
+		tx.commit();
+		session.close();
 
 		checkCleanCache();
 	}
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { User.class, Address.class };
+		return new Class<?>[] { User.class, Address.class, PhoneNumber.class, Enterprise.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -239,6 +239,40 @@ public class MapTest extends OgmTestCase {
 		checkCleanCache();
 	}
 
+	@Test
+	public void testMapWithSimpleValueType() {
+		Session session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Enterprise timberTradingInc = new Enterprise( "enterprise-1", null );
+		timberTradingInc.getRevenueByDepartment().put( "sale", 1000 );
+		timberTradingInc.getRevenueByDepartment().put( "sawing", 2000 );
+		timberTradingInc.getRevenueByDepartment().put( "planting", 3000 );
+
+		session.persist( timberTradingInc );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// assert
+		timberTradingInc = (Enterprise) session.get( Enterprise.class, "enterprise-1" );
+
+		assertThat( timberTradingInc.getRevenueByDepartment() ).includes( entry( "sawing", 2000 ) );
+		assertThat( timberTradingInc.getRevenueByDepartment() ).includes( entry( "sale", 1000 ) );
+		assertThat( timberTradingInc.getRevenueByDepartment() ).includes( entry( "planting", 3000 ) );
+		assertThat( timberTradingInc.getRevenueByDepartment() ).hasSize( 3 );
+
+		// clean up
+		session.delete( timberTradingInc );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { User.class, Address.class, PhoneNumber.class, Enterprise.class };

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -48,15 +48,6 @@ public class MapTest extends OgmTestCase {
 		tx.commit();
 		session.clear();
 
-		if ( getCurrentDialectType().isDocumentStore() ) {
-			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.IN_ENTITY ) )
-					.describedAs( "Map contents should be stored within the entity document" )
-					.isEqualTo( 1 );
-			assertThat( getNumberOfAssociations( sessions, AssociationStorageType.ASSOCIATION_DOCUMENT ) )
-					.describedAs( "Map contents should be stored within the entity document" )
-					.isEqualTo( 0 );
-		}
-
 		tx = session.beginTransaction();
 		user = (User) session.get( User.class, user.getId() );
 		// TODO do null value

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/PhoneNumber.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/PhoneNumber.java
@@ -1,0 +1,118 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.collection.types;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+public class PhoneNumber {
+
+	@EmbeddedId
+	private PhoneNumberId id;
+	private String description;
+
+	public PhoneNumber() {
+	}
+
+	public PhoneNumber(PhoneNumberId id, String description) {
+		this.id = id;
+		this.description = description;
+	}
+
+	public PhoneNumberId getId() {
+		return id;
+	}
+
+	public void setId(PhoneNumberId id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Embeddable
+	public static class PhoneNumberId implements Serializable {
+		private String countryCode;
+		private int number;
+
+		public PhoneNumberId() {
+		}
+
+		public PhoneNumberId(String countryCode, int number) {
+			this.countryCode = countryCode;
+			this.number = number;
+		}
+
+		public String getCountryCode() {
+			return countryCode;
+		}
+
+		public void setCountryCode(String countryCode) {
+			this.countryCode = countryCode;
+		}
+
+		public int getNumber() {
+			return number;
+		}
+
+		public void setNumber(int number) {
+			this.number = number;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( countryCode == null ) ? 0 : countryCode.hashCode() );
+			result = prime * result + number;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			PhoneNumberId other = (PhoneNumberId) obj;
+			if ( countryCode == null ) {
+				if ( other.countryCode != null ) {
+					return false;
+				}
+			}
+			else if ( !countryCode.equals( other.countryCode ) ) {
+				return false;
+			}
+			if ( number != other.number ) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "PhoneNumberId [countryCode=" + countryCode + ", number=" + number + "]";
+		}
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
@@ -21,6 +21,8 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.ogm.datastore.document.options.MapStorage;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
@@ -31,6 +33,7 @@ public class User {
 	private Map<String, Address> addresses = new HashMap<String, Address>();
 	private Map<String, PhoneNumber> phoneNumbers = new HashMap<>();
 	private Map<Integer, PhoneNumber> phoneNumbersByPriority = new HashMap<>();
+	private Map<String, PhoneNumber> alternativePhoneNumbers = new HashMap<>();
 	private Set<String> nicknames = new HashSet<String>();
 
 	@Id
@@ -62,6 +65,17 @@ public class User {
 
 	public void setPhoneNumbers(Map<String, PhoneNumber> phoneNumbers) {
 		this.phoneNumbers = phoneNumbers;
+	}
+
+	@OneToMany
+	@MapStorage(MapStorageType.AS_LIST)
+	@MapKeyColumn(name = "phoneType")
+	public Map<String, PhoneNumber> getAlternativePhoneNumbers() {
+		return alternativePhoneNumbers;
+	}
+
+	public void setAlternativePhoneNumbers(Map<String, PhoneNumber> alternativePhoneNumbers) {
+		this.alternativePhoneNumbers = alternativePhoneNumbers;
 	}
 
 	@OneToMany

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
@@ -29,6 +29,7 @@ import org.hibernate.annotations.GenericGenerator;
 public class User {
 	private String id;
 	private Map<String, Address> addresses = new HashMap<String, Address>();
+	private Map<String, PhoneNumber> phoneNumbers = new HashMap<>();
 	private Set<String> nicknames = new HashSet<String>();
 
 	@Id
@@ -51,6 +52,15 @@ public class User {
 
 	public void setAddresses(Map<String, Address> addresses) {
 		this.addresses = addresses;
+	}
+
+	@OneToMany
+	public Map<String, PhoneNumber> getPhoneNumbers() {
+		return phoneNumbers;
+	}
+
+	public void setPhoneNumbers(Map<String, PhoneNumber> phoneNumbers) {
+		this.phoneNumbers = phoneNumbers;
 	}
 
 	@ElementCollection

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/User.java
@@ -30,6 +30,7 @@ public class User {
 	private String id;
 	private Map<String, Address> addresses = new HashMap<String, Address>();
 	private Map<String, PhoneNumber> phoneNumbers = new HashMap<>();
+	private Map<Integer, PhoneNumber> phoneNumbersByPriority = new HashMap<>();
 	private Set<String> nicknames = new HashSet<String>();
 
 	@Id
@@ -61,6 +62,16 @@ public class User {
 
 	public void setPhoneNumbers(Map<String, PhoneNumber> phoneNumbers) {
 		this.phoneNumbers = phoneNumbers;
+	}
+
+	@OneToMany
+	@MapKeyColumn(name = "priority")
+	public Map<Integer, PhoneNumber> getPhoneNumbersByPriority() {
+		return phoneNumbersByPriority;
+	}
+
+	public void setPhoneNumbersByPriority(Map<Integer, PhoneNumber> phoneNumbersByPriority) {
+		this.phoneNumbersByPriority = phoneNumbersByPriority;
 	}
 
 	@ElementCollection

--- a/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
@@ -118,6 +118,16 @@ Possible strategies are (values of the `org.hibernate.ogm.datastore.mongodb.opti
 
 * `GLOBAL_COLLECTION` (default): stores the association information in a unique MongoDB collection for all associations
 * `COLLECTION_PER_ASSOCIATION` stores the association in a dedicated MongoDB collection per association
+
+hibernate.ogm.datastore.document.map_storage::
+Defines the way OGM stores the contents of map-typed associations in MongoDB.
+The following two strategies exist (values of the `org.hibernate.ogm.datastore.document.options.MapStorageType` enum):
+
+* `BY_KEY`: map-typed associations with a single key column which is of type `String` will be stored as a sub-document,
+organized by the given key; Not applicable for other types of key columns, in which case always `AS_LIST` will be used
+* `AS_LIST`: map-typed associations will be stored as an array containing a sub-document for each map entry.
+All key and value columns will be contained within the array elements
+
 hibernate.ogm.mongodb.write_concern::
 Defines the write concern setting to be applied when issuing writes against the MongoDB datastore.
 Possible settings are (values of the `WriteConcernType` enum):
@@ -214,7 +224,9 @@ When working with the MongoDB backend, you can specify the following settings:
 * the write concern for entities and associations using the `@WriteConcern` annotation
 * the read preference for entities and associations using the `@ReadPreference` annotation
 * a strategy for storing associations using the `@AssociationStorage` and `@AssociationDocumentStorage` annotations
-(refer to <<ogm-mongodb-storage-principles>> to learn more about these options).
+* a strategy for storing the contents of map-typed associations using the `@MapStorage` annotation
+
+Refer to <<mongodb-associations> to learn more about the options related to storing associations.
 
 The following shows an example:
 
@@ -227,6 +239,7 @@ The following shows an example:
 @ReadPreference(ReadPreferenceType.PRIMARY_PREFERRED)
 @AssociationStorage(AssociationStorageType.ASSOCIATION_DOCUMENT)
 @AssociationDocumentStorage(AssociationDocumentStorageType.COLLECTION_PER_ASSOCIATION)
+@MapStorage(MapStorageType.AS_LIST)
 public class Zoo {
 
     @OneToMany
@@ -267,6 +280,7 @@ When working with MongoDB, you can currently configure the following options usi
 * read preference
 * association storage strategy
 * association document storage strategy
+* strategy for storing the contents of map-typed associations
 
 To set these options via the API, you need to create an `OptionConfigurator` implementation
 as shown in the following example:
@@ -285,6 +299,7 @@ public class MyOptionConfigurator extends OptionConfigurator {
             .entity( Zoo.class )
                 .associationStorage( AssociationStorageType.ASSOCIATION_DOCUMENT )
                 .associationDocumentStorage( AssociationDocumentStorageType.COLLECTION_PER_ASSOCIATION )
+                .mapStorage( MapStorageType.ASLIST )
                 .property( "animals", ElementType.FIELD )
                     .associationStorage( AssociationStorageType.IN_ENTITY )
             .entity( Animal.class )
@@ -1270,6 +1285,7 @@ Like crossing streams, it is bad form.
 This approach might not be supported in the future.
 ====
 
+[[mongodb-associations]]
 ==== Associations
 
 Hibernate OGM MongoDB proposes three strategies to store navigation information for associations.
@@ -1975,6 +1991,10 @@ Address collection as JSON in MongoDB
 { "_id" : "address_002", "city" : "Paris" }
 ----
 ====
+
+In case you want to enforce the list-style represention also for maps with a single key column of type `String`
+(e.g. when reading back data persisted by earlier versions of Hibernate OGM),
+you can use the option `hibernate.ogm.datastore.document.map_storage` to do so.
 
 .Unidirectional many-to-many using in entity strategy
 ====

--- a/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
@@ -1855,7 +1855,7 @@ Product collection
 ----
 ====
 
-A map can be used to represents an association,
+A map can be used to represent an association,
 in this case Hibernate OGM will store the key of the map
 and the associated id.
 
@@ -1894,12 +1894,8 @@ User collection as JSON in MongoDB
   "_id" : "user_001",
   "addresses" : [
     {
-      "addresses_KEY" : "work",
-      "addresses_id" : "address_001"
-    },
-    {
-      "addresses_KEY" : "home",
-      "addresses_id" : "address_002"
+      "work" : "address_001",
+      "home" : "address_002"
     }
   ]
 }
@@ -1914,7 +1910,15 @@ Address collection as JSON in MongoDB
 ----
 ====
 
-You can use @MapKeyColumn to rename the column containing the key of the map.
+If the map value cannot be represented by a single field (e.g. when referencing a type with a composite id
+or using an embeddable type as map value type),
+a sub-document containing all the required fields will be stored as value.
+
+If the map key either is not of type `String` or it is made up of several columns (composite map key),
+the optimized structure shown in the example above cannot be used as MongoDB only allows for Strings as field names.
+In that case the association will be represented by a list of sub-documents, also containing the map key column(s).
+You can use `@MapKeyColumn` to rename the field containing the key of the map,
+otherwise it will default to "<%COLLECTION_ROLE%>_KEY", e.g. "addresses_KEY".
 
 .Unidirectional one-to-many using maps with @MapKeyColumn
 ====
@@ -1928,7 +1932,7 @@ public class User {
 
     @OneToMany
     @MapKeyColumn(name = "addressType")
-    private Map<String, Address> addresses = new HashMap<String, Address>();
+    private Map<Long, Address> addresses = new HashMap<Long, Address>();
 
     // getters, setters ...
 }
@@ -1952,11 +1956,11 @@ User collection as JSON in MongoDB
   "_id" : "user_001",
   "addresses" : [
     {
-      "addressType" : "work",
+      "addressType" : 1,
       "addresses_id" : "address_001"
     },
     {
-      "addressType" : "home",
+      "addressType" : 2,
       "addresses_id" : "address_002"
     }
   ]
@@ -2965,7 +2969,6 @@ Associations collection
 }
 ----
 ====
-
 
 === Transactions
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -133,6 +133,11 @@
             <artifactId>takari-cpsuite</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/MapMappingTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/MapMappingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.associations;
+
+import static org.hibernate.ogm.datastore.mongodb.utils.MongoDBTestHelper.assertDbObject;
+
+import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.backendtck.associations.collection.types.Address;
+import org.hibernate.ogm.backendtck.associations.collection.types.User;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Test;
+
+/**
+ * @author Gunnar Morling
+ */
+public class MapMappingTest extends OgmTestCase {
+
+	@Test
+	public void testMapOfEntity() throws Exception {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Address home = new Address();
+		home.setCity( "Paris" );
+		Address work = new Address();
+		work.setCity( "San Francisco" );
+		User user = new User();
+		user.getAddresses().put( "home", home );
+		user.getAddresses().put( "work", work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// Then
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"{ '_id' : '" + user.getId() + "' }",
+				// expected
+				"{ " +
+					"'_id' : '" + user.getId() + "', " +
+					"'addresses' : {" +
+						"'home' : '" + home.getId() + "'," +
+						"'work' : '" + work.getId() + "'" +
+					"}" +
+				"}"
+		);
+
+		// clean-up
+		user = (User) session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( Address.class, home.getId() ) );
+		session.delete( session.load( Address.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { User.class, Address.class };
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/MapMappingTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/MapMappingTest.java
@@ -217,6 +217,48 @@ public class MapMappingTest extends OgmTestCase {
 		checkCleanCache();
 	}
 
+	@Test
+	public void testMapWithSimpleValueType() {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Enterprise timberTradingInc = new Enterprise( "enterprise-1", null );
+		timberTradingInc.getRevenueByDepartment().put( "sale", 1000 );
+		timberTradingInc.getRevenueByDepartment().put( "sawing", 2000 );
+		timberTradingInc.getRevenueByDepartment().put( "planting", 3000 );
+
+		session.persist( timberTradingInc );
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// assert
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"Enterprise",
+				// query
+				"{ '_id' : 'enterprise-1' }",
+				// expected
+				"{ " +
+					"'_id' : 'enterprise-1', " +
+					"'revenueByDepartment' : {" +
+						"'sawing' : 2000," +
+						"'sale' : 1000," +
+						"'planting' : 3000," +
+					"}" +
+				"}"
+		);
+
+		// clean up
+		session.delete( timberTradingInc );
+
+		tx.commit();
+		session.close();
+		checkCleanCache();
+	}
+
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { User.class, Address.class, PhoneNumber.class, Enterprise.class };

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
@@ -7,8 +7,6 @@
 
 package org.hibernate.ogm.datastore.mongodb.utils;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,10 +28,14 @@ import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.mongodb.options.navigation.MongoDBGlobalContext;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.exception.impl.Exceptions;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.utils.TestableGridDialect;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONCompare;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
 
-import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
@@ -273,63 +275,23 @@ public class MongoDBTestHelper implements TestableGridDialect {
 	public static void assertDbObject(OgmSessionFactory sessionFactory, String collection, String queryDbObject, String projectionDbObject, String expectedDbObject) {
 		DBObject finder = (DBObject) JSON.parse( queryDbObject );
 		DBObject fields = projectionDbObject != null ? (DBObject) JSON.parse( projectionDbObject ) : null;
-		DBObject expected = (DBObject) JSON.parse( expectedDbObject );
 
 		MongoDBDatastoreProvider provider = MongoDBTestHelper.getProvider( sessionFactory );
 		DBObject actual = provider.getDatabase().getCollection( collection ).findOne( finder, fields );
 
-		assertThat( isDBObjectAndContentEqual( actual, expected ) ).describedAs( "Expected: " + expected + " but was: " + actual ).isTrue();
+		assertJsonEquals( expectedDbObject, actual.toString() );
 	}
 
-	/*
-	 * Do a manual equals of each element in the DBObjects.
-	 * In particular, ignores the indexes of arrays and compare their content only.
-	 */
-	private static boolean isDBObjectAndContentEqual(Object left, Object right) {
-		if ( left instanceof BasicDBList ) {
-			if ( ! ( right instanceof BasicDBList ) ) {
-				return false;
-			}
-			// we don't care about the order here for now
-			BasicDBList leftAsList = (BasicDBList) left;
-			BasicDBList rightAsList = (BasicDBList) right;
-			// check that the fields names are the same
-			Set<String> leftFields = new HashSet<String>( leftAsList.keySet() );
-			Set<String> rightFields = new HashSet<String>( rightAsList.keySet() );
-			if ( ! leftFields.equals( rightFields ) ) {
-				return false;
-			}
-			// check that all left field values are in right
-			for ( String field : leftFields ) {
-				// fall back to native equals via the contains. It is out of our current tests
-				if ( ! rightAsList.contains( leftAsList.get( field ) ) ) {
-					return false;
-				}
+	private static void assertJsonEquals(String expectedJson, String actualJson) {
+		try {
+			JSONCompareResult result = JSONCompare.compareJSON( expectedJson, actualJson, JSONCompareMode.NON_EXTENSIBLE );
+
+			if ( result.failed() ) {
+				throw new AssertionError(result.getMessage() + "; Actual: " + actualJson);
 			}
 		}
-		else if ( left instanceof DBObject ) {
-			if ( ! ( right instanceof DBObject ) ) {
-				return false;
-			}
-			DBObject leftAsDBObject = (DBObject) left;
-			DBObject rightAsDBObject = (DBObject) right;
-			// check that the fields names are the same
-			Set<String> leftFields = new HashSet<String>( leftAsDBObject.keySet() );
-			Set<String> rightFields = new HashSet<String>( rightAsDBObject.keySet() );
-			if ( ! leftFields.equals( rightFields ) ) {
-				return false;
-			}
-			// check that all left fields are in right and equal
-			for ( String field : leftFields ) {
-				boolean matches = isDBObjectAndContentEqual( leftAsDBObject.get( field ), rightAsDBObject.get( field ) );
-				if ( ! matches ) {
-					return false;
-				}
-			}
+		catch (JSONException e) {
+			Exceptions.<RuntimeException>sneakyThrow( e );
 		}
-		else {
-			return left == right || ( left != null && left.equals( right ) );
-		}
-		return true;
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/MapTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/MapTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.node;
 import javax.persistence.EntityManager;
 
 import org.hibernate.ogm.backendtck.associations.collection.types.Address;
+import org.hibernate.ogm.backendtck.associations.collection.types.PhoneNumber;
 import org.hibernate.ogm.backendtck.associations.collection.types.User;
 import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
 import org.hibernate.ogm.datastore.neo4j.test.dsl.RelationshipsChainForGraphAssertions;
@@ -102,7 +103,7 @@ public class MapTest extends Neo4jJpaTestCase {
 
 	@Override
 	public Class<?>[] getEntities() {
-		return new Class<?>[] { User.class, Address.class };
+		return new Class<?>[] { User.class, Address.class, PhoneNumber.class };
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
                 <artifactId>jboss-logging-annotations</artifactId>
                 <version>${jbossLoggingProcessorVersion}</version>
             </dependency>
+            <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>1.2.3</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
For the case of map-typed associations which use a single key column of type `String`, we will use a more natural persistent mapping:

    {
      "_id" : "user_001",
      "addresses" : [
        {
          "work" : "address_001",
          "home" : "address_002"
        }
      ]
    }

For the other cases (composite map key, or single-column key of non-String type), the previous mapping is used:

    {
      "_id" : "user_001",
      "addresses" : [
        {
          "addressType" : 1,
          "addresses_id" : "address_001"
        },
        {
          "addressType" : 2,
          "addresses_id" : "address_002"
        }
      ]
    }

@emmanuelbernard I did not make it configurable but automatically enable the nicer mapping if possible. Do you see a case where it should be able to disable that?

A follow-up PR for CouchDB will follow.