### PR TITLE
OGM-810 Switch to Java MongoDB Driver 3.x

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
         <classmateVersion>1.0.0</classmateVersion>
         <ehcacheVersion>2.6.9</ehcacheVersion>
         <infinispanVersion>7.2.1.Final</infinispanVersion>
-        <mongodbVersion>2.13.1</mongodbVersion>
+        <mongodbVersion>3.0.3</mongodbVersion>
         <fongodbVersion>1.6.2</fongodbVersion>
         <neo4jVersion>2.2.3</neo4jVersion>
         <!-- Update dependency versions accordingly when updating C*  -->

--- a/core/src/main/java/org/hibernate/ogm/cfg/spi/DocumentStoreConfiguration.java
+++ b/core/src/main/java/org/hibernate/ogm/cfg/spi/DocumentStoreConfiguration.java
@@ -23,8 +23,6 @@ public abstract class DocumentStoreConfiguration {
 	 */
 	private static final String DEFAULT_HOST = "localhost";
 
-
-
 	private final Hosts hosts;
 	private final String databaseName;
 	private final String username;

--- a/core/src/main/java/org/hibernate/ogm/type/impl/CharacterStringType.java
+++ b/core/src/main/java/org/hibernate/ogm/type/impl/CharacterStringType.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.type.descriptor.impl.StringMappedGridTypeDescriptor;
+import org.hibernate.type.descriptor.java.CharacterTypeDescriptor;
+
+/**
+ * Persist a {@link Character} as a {@link String}.
+ *
+ * Note:
+ * For example necessary in MongoDB, since the MongoDB driver 3 no longer does that for us
+ * https://jira.mongodb.org/browse/JAVA-1804
+ *
+ * @author Emmanuel Bernard emmanuel@hibernate.org
+ */
+public class CharacterStringType extends AbstractGenericBasicType<Character>  {
+
+	public static final CharacterStringType INSTANCE = new CharacterStringType();
+
+	public CharacterStringType() {
+		super( StringMappedGridTypeDescriptor.INSTANCE, CharacterTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "character_string";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/configurationreader/impl/SimplePropertyReaderContext.java
+++ b/core/src/main/java/org/hibernate/ogm/util/configurationreader/impl/SimplePropertyReaderContext.java
@@ -37,14 +37,14 @@ public class SimplePropertyReaderContext<T> extends PropertyReaderContextBase<T>
 	@Override
 	@SuppressWarnings("unchecked")
 	protected T getTypedValue() {
-		T typedValue = null;
+		T typedValue;
 		Class<T> targetType = getTargetType();
 
 		if ( targetType == String.class ) {
 			typedValue = (T) getAsString();
 		}
 		else if ( targetType == boolean.class ) {
-			typedValue = (T) getAsBoolean();
+			typedValue = (T) getAsPrimitiveBoolean();
 		}
 		else if ( targetType == int.class ) {
 			typedValue = (T) getAsInt();
@@ -58,8 +58,11 @@ public class SimplePropertyReaderContext<T> extends PropertyReaderContextBase<T>
 		else if ( targetType == URL.class ) {
 			typedValue = (T) getAsUrl();
 		}
+		else if ( targetType == Boolean.class ) {
+			typedValue = (T) getAsBoolean();
+		}
 		else {
-			throw log.unsupportedPropertyType( getPropertyName(), getConfiguredValue().toString() );
+			throw log.unsupportedPropertyType( getPropertyName(), getConfiguredValue() == null ? "null" : getConfiguredValue().toString() );
 		}
 		return typedValue;
 	}
@@ -69,11 +72,16 @@ public class SimplePropertyReaderContext<T> extends PropertyReaderContextBase<T>
 		return stringValue == null ? (String) getDefaultValue() : stringValue;
 	}
 
+	private Boolean getAsPrimitiveBoolean() {
+		Boolean value = getAsBoolean();
+		return value != null ? value : false;
+	}
+
 	private Boolean getAsBoolean() {
 		Object configuredValue = getConfiguredValue();
 
 		if ( StringHelper.isNullOrEmptyString( configuredValue ) ) {
-			return getDefaultValue() != null ? (Boolean) getDefaultValue() : false;
+			return getDefaultValue() != null ? (Boolean) getDefaultValue() : null;
 		}
 
 		return ( configuredValue instanceof Boolean ) ? (Boolean) configuredValue : Boolean.valueOf( configuredValue.toString().trim() );

--- a/core/src/test/java/org/hibernate/ogm/test/util/configurationreader/impl/ConfigurationPropertyReaderTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/util/configurationreader/impl/ConfigurationPropertyReaderTest.java
@@ -328,6 +328,26 @@ public class ConfigurationPropertyReaderTest {
 				.getValue();
 	}
 
+	@Test
+	public void unspecifiedBooleanOptionRetrievedAsBooleanWrapperTypeReturnsNull() {
+		Map<String, Object> properties = new HashMap<String, Object>();
+
+		ConfigurationPropertyReader reader = new ConfigurationPropertyReader( properties );
+
+		Boolean value = reader.property( "foo", Boolean.class ).getValue();
+		assertThat( value ).isEqualTo( null );
+	}
+
+	@Test
+	public void unspecifiedBooleanOptionRetrievedAsPrimitiveBooleanReturnsFalse() {
+		Map<String, Object> properties = new HashMap<String, Object>();
+
+		ConfigurationPropertyReader reader = new ConfigurationPropertyReader( properties );
+
+		Boolean value = reader.property( "foo", boolean.class ).getValue();
+		assertThat( value ).isEqualTo( false );
+	}
+
 	private Properties loadPropertiesFromUrl(URL value) throws IOException {
 		Properties properties = new Properties();
 		InputStream stream = null;

--- a/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
@@ -87,11 +87,10 @@ This property has no default value.
 This property is ignored if the username isn't specified.
 hibernate.ogm.error_handler::
 The fully-qualified class name, class object or an instance of `ErrorHandler` to get notified upon errors during flushes (see <<ogm-api-error-handler>>)
-hibernate.ogm.mongodb.connection_timeout::
-Defines the timeout used by the driver
-when the connection to the MongoDB instance is initiated.
-This configuration is expressed in milliseconds.
-The default value is `5000`.
+hibernate.ogm.mongodb.driver.*::
+Defines a prefix for all options which should be passed through to the MongoDB driver.
+For available options refer to the JavaDocs of link:http://api.mongodb.org/java/3.0/com/mongodb/MongoClientOptions.Builder.html[MongoClientOptions.Builder]. All `String`, `int` and `boolean` properties
+can be set, eg `hibernate.ogm.mongodb.driver.serverSelectionTimeout`.
 hibernate.ogm.mongodb.authentication_mechanism::
 Define the authentication mechanism to use. Possible values are:
 
@@ -3090,7 +3089,7 @@ when using the JP-QL query support. This includes:
 * `ORDER BY`
 * inner `JOIN` on embedded collections
 * projections of regular and embedded properties
- 
+
 Queries using these constructs will be transformed into equivalent native MongoDB queries.
 
 [NOTE]

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -45,6 +45,7 @@ import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.MongoDBQueryDescriptorBuilder;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.NativeQueryParser;
 import org.hibernate.ogm.datastore.mongodb.type.impl.ByteStringType;
+import org.hibernate.ogm.type.impl.CharacterStringType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.ObjectIdGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.StringAsObjectIdGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.StringAsObjectIdType;
@@ -672,6 +673,9 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 		else if ( type == StandardBasicTypes.BYTE ) {
 			return ByteStringType.INSTANCE;
+		}
+		else if ( type == StandardBasicTypes.CHARACTER ) {
+			return CharacterStringType.INSTANCE;
 		}
 		else if ( type.getReturnedClass() == ObjectId.class ) {
 			return ObjectIdGridType.INSTANCE;

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBProperties.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBProperties.java
@@ -6,14 +6,14 @@
  */
 package org.hibernate.ogm.datastore.mongodb;
 
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+
 import org.hibernate.ogm.cfg.OgmConfiguration;
 import org.hibernate.ogm.datastore.document.cfg.DocumentStoreProperties;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.mongodb.options.ReadPreferenceType;
 import org.hibernate.ogm.datastore.mongodb.options.WriteConcernType;
-
-import com.mongodb.ReadPreference;
-import com.mongodb.WriteConcern;
 
 /**
  * Properties for configuring the MongoDB datastore via {@code persistence.xml} or {@link OgmConfiguration}.
@@ -56,11 +56,6 @@ public final class MongoDBProperties implements DocumentStoreProperties {
 	public static final String READ_PREFERENCE = "hibernate.ogm.mongodb.read_preference";
 
 	/**
-	 * The timeout used at the connection to the MongoDB instance. This value is set in milliseconds. Defaults to 5000.
-	 */
-	public static final String TIMEOUT = "hibernate.ogm.mongodb.connection_timeout";
-
-	/**
 	 * Configuration property for specifying how to store association documents. Only applicable if
 	 * {@link DocumentStoreProperties#ASSOCIATIONS_STORE} is set to {@link AssociationStorageType#ASSOCIATION_DOCUMENT}.
 	 * Supported values are the {@link org.hibernate.ogm.datastore.mongodb.options.AssociationDocumentStorageType} enum or the String representations of its constants.
@@ -77,6 +72,13 @@ public final class MongoDBProperties implements DocumentStoreProperties {
 	 * @see com.mongodb.MongoCredential
 	 */
 	public static final String AUTHENTICATION_MECHANISM = "hibernate.ogm.mongodb.authentication_mechanism";
+
+	/**
+	 * Property prefix for MongoDB driver settings which needs to be passed on to the driver. Refer to
+	 * the options of {@link com.mongodb.MongoClientOptions.Builder} for a list of available properties.
+	 * All string, int and boolean builder methods can be configured, eg {@code hibernate.ogm.mongodb.driver.maxWaitTime = 1000}.
+	 */
+	public static final String MONGO_DRIVER_SETTINGS_PREFIX = "hibernate.ogm.mongodb.driver";
 
 	private MongoDBProperties() {
 	}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -103,4 +103,7 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 			+ " Please change name for '%s', for example by using @Column ")
 	MappingException fieldNameContainsNULCharacter(String fieldName);
 
+	@Message(id = 1225, value = "This WriteConcern has been deprecated or removed by MongoDB: %s")
+	HibernateException writeConcernDeprecated(String writeConcern);
+
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -13,7 +13,6 @@ import static org.jboss.logging.Logger.Level.WARN;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.ogm.cfg.OgmProperties;
-import org.hibernate.ogm.datastore.mongodb.MongoDBProperties;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -38,9 +37,6 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1203, value = "Unable to find or initialize a connection to the MongoDB server")
 	HibernateException unableToInitializeMongoDB(@Cause RuntimeException e);
 
-	@Message(id = 1205, value = "Could not resolve MongoDB hostname [%s]")
-	HibernateException mongoOnUnknownHost(String hostname);
-
 	@LogMessage(level = INFO)
 	@Message(id = 1206, value = "Mongo database named [%s] is not defined. Creating it!")
 	void creatingDatabase(String dbName);
@@ -56,18 +52,8 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1210, value = "Removed [%d] associations")
 	void removedAssociation(int nAffected);
 
-	@LogMessage(level = INFO)
-	@Message(id = 1211, value = "Using write concern { w : %s, wtimeout : %s, fsync : %s, journaled : %s, continueOnErrorForInsert : %s } if not explicitly configured otherwise for specific entities")
-	void usingWriteConcern(String writeStrategy, int wtimeout, boolean fsync, boolean journaled, boolean continueOnErrorForInsert);
-
-	@Message(id = 1213, value = "MongoDB authentication failed with username [%s]" )
-	HibernateException authenticationFailed(String username);
-
-	@Message(id = 1214, value = "Unable to connect to MongoDB instance %1$s" )
-	HibernateException unableToConnectToDatastore(String host, @Cause Exception e);
-
-	@Message(id = 1215, value = "The value set for the configuration property" + MongoDBProperties.TIMEOUT + " must be a number greater than 0. Found '[%s]'.")
-	HibernateException mongoDBTimeOutIllegalValue(int timeout);
+	@Message(id = 1214, value = "Unable to connect to MongoDB instance: %1$s" )
+	HibernateException unableToConnectToDatastore(String message, @Cause Exception e);
 
 	@Message(id = 1217, value = "The following native query does neither specify the collection name nor is its result type mapped to an entity: %s")
 	HibernateException unableToDetermineCollectionName(String nativeQuery);
@@ -105,5 +91,8 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 
 	@Message(id = 1225, value = "This WriteConcern has been deprecated or removed by MongoDB: %s")
 	HibernateException writeConcernDeprecated(String writeConcern);
+
+	@Message(id = 1226, value = "Unable to use reflection on invoke method '%s#%s' via reflection.")
+	HibernateException unableToInvokeMethodViaReflection(String clazz, String method);
 
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/options/WriteConcernType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/options/WriteConcernType.java
@@ -8,6 +8,9 @@ package org.hibernate.ogm.datastore.mongodb.options;
 
 import com.mongodb.WriteConcern;
 
+import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
+import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
+
 /**
  * Write concern options for MongoDB. Represents the non-deprecated constants from {@link WriteConcern}.
  *
@@ -25,7 +28,7 @@ public enum WriteConcernType {
 	 * @deprecated This WriteConcern is no longer supported by MongoDB
 	 */
 	@Deprecated
-	ERRORS_IGNORED(WriteConcern.ERRORS_IGNORED),
+	ERRORS_IGNORED(null),
 
 	/**
 	 * Write operations that use this write concern will wait for acknowledgement from the primary server before
@@ -67,9 +70,11 @@ public enum WriteConcernType {
 	 */
 	CUSTOM( null );
 
+	private static Log log = LoggerFactory.getLogger();
+
 	private final WriteConcern writeConcern;
 
-	private WriteConcernType(WriteConcern writeConcern) {
+	WriteConcernType(WriteConcern writeConcern) {
 		this.writeConcern = writeConcern;
 	}
 
@@ -79,6 +84,11 @@ public enum WriteConcernType {
 	 * @return the {@link WriteConcern} associated with this enum value; {@code null} in the case of {@link #CUSTOM}.
 	 */
 	public WriteConcern getWriteConcern() {
+		if ( this.name().equals( "ERRORS_IGNORED" ) ) {
+			// Do a hard fail as we don't have a proper replacement
+			// Looks like the nicest thing to do to the user
+			throw log.writeConcernDeprecated( "ERRORS_IGNORED" );
+		}
 		return writeConcern;
 	}
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/options/WriteConcernType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/options/WriteConcernType.java
@@ -18,18 +18,6 @@ import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
  */
 public enum WriteConcernType {
 
-
-	/**
-	 * No exceptions are raised, even for network issues.
-	 *
-	 * This write concern has been deprecated. There is no replacement for this write concern.
-	 * The closest would be to use {@link #UNACKNOWLEDGED}, then catch and ignore any exceptions of type MongoSocketException.
-	 *
-	 * @deprecated This WriteConcern is no longer supported by MongoDB
-	 */
-	@Deprecated
-	ERRORS_IGNORED(null),
-
 	/**
 	 * Write operations that use this write concern will wait for acknowledgement from the primary server before
 	 * returning. Exceptions are raised for network issues, and server errors.

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/configuration/impl/MongoDBConfigurationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/configuration/impl/MongoDBConfigurationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.configuration.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mongodb.MongoClientOptions;
+import com.mongodb.WriteConcern;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.options.navigation.impl.OptionsContextImpl;
+import org.hibernate.ogm.options.navigation.source.impl.OptionValueSources;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class MongoDBConfigurationTest {
+	private Map<String, String> configProperties;
+	private ConfigurationPropertyReader propertyReader;
+	private OptionsContext globalOptions;
+
+	@Before
+	public void setUp() {
+		configProperties = new HashMap<>();
+		configProperties.put( OgmProperties.DATABASE, "foo" );
+
+		propertyReader = new ConfigurationPropertyReader( configProperties, new ClassLoaderServiceImpl() );
+		globalOptions = OptionsContextImpl.forGlobal( OptionValueSources.getDefaultSources( propertyReader ) );
+	}
+
+	@Test
+	public void testDefaultWriteConcernGetsApplied() {
+		MongoClientOptions clientOptions = createMongoClientOptions();
+
+		assertEquals( "Unexpected write concern", WriteConcern.ACKNOWLEDGED, clientOptions.getWriteConcern() );
+	}
+
+	@Test
+	public void testDefaultServerSelectionTimeoutIsApplied() {
+		MongoClientOptions clientOptions = createMongoClientOptions();
+
+		assertEquals(
+				"Unexpected server selection timeout",
+				MongoClientOptions.builder().build().getServerSelectionTimeout(),
+				clientOptions.getServerSelectionTimeout()
+		);
+	}
+
+	@Test
+	public void testCustomServerSelectionTimeoutIsApplied() {
+		int expectedTimeout = 1000;
+		configProperties.put( "hibernate.ogm.mongodb.driver.serverSelectionTimeout", String.valueOf( expectedTimeout ) );
+		MongoClientOptions clientOptions = createMongoClientOptions();
+
+		assertEquals(
+				"Unexpected server selection timeout",
+				expectedTimeout,
+				clientOptions.getServerSelectionTimeout()
+		);
+	}
+
+	private MongoClientOptions createMongoClientOptions() {
+		MongoDBConfiguration mongoConfig = new MongoDBConfiguration(
+				propertyReader,
+				globalOptions
+		);
+		assertNotNull( mongoConfig );
+
+		MongoClientOptions clientOptions = mongoConfig.buildOptions();
+		assertNotNull( clientOptions );
+		return clientOptions;
+	}
+
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/WriteConcernTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/WriteConcernTest.java
@@ -109,7 +109,7 @@ public class WriteConcernTest {
 	public static class MultipleDataCenters extends com.mongodb.WriteConcern {
 
 		public MultipleDataCenters() {
-			super( "MultipleDataCenters", 0, false, true, false );
+			super( "MultipleDataCenters" );
 		}
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernAnnotationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernAnnotationTest.java
@@ -31,7 +31,7 @@ public class WriteConcernAnnotationTest {
 	@Test
 	public void testWriteConcernForEntity() throws Exception {
 		OptionsContainer options = source.getEntityOptions( EntityWriteConcernExample.class );
-		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( com.mongodb.WriteConcern.ERRORS_IGNORED );
+		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( com.mongodb.WriteConcern.REPLICA_ACKNOWLEDGED );
 	}
 
 	@Test
@@ -40,7 +40,7 @@ public class WriteConcernAnnotationTest {
 		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( new MultipleDataCenters() );
 	}
 
-	@WriteConcern(WriteConcernType.ERRORS_IGNORED)
+	@WriteConcern(WriteConcernType.REPLICA_ACKNOWLEDGED)
 	private static final class EntityWriteConcernExample {
 	}
 
@@ -52,7 +52,7 @@ public class WriteConcernAnnotationTest {
 	public static class MultipleDataCenters extends com.mongodb.WriteConcern {
 
 		public MultipleDataCenters() {
-			super( "MultipleDataCenters", 0, false, true, false );
+			super( "MultipleDataCenters" );
 		}
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernOptionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernOptionTest.java
@@ -43,10 +43,10 @@ public class WriteConcernOptionTest {
 	@Test
 	public void testWriteConcernGivenByTypeOnGlobalLevel() throws Exception {
 		mongoOptions
-			.writeConcern( WriteConcernType.ERRORS_IGNORED );
+			.writeConcern( WriteConcernType.REPLICA_ACKNOWLEDGED );
 
 		OptionsContainer options = getSource().getGlobalOptions();
-		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( WriteConcern.ERRORS_IGNORED );
+		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( WriteConcern.REPLICA_ACKNOWLEDGED );
 	}
 
 	@Test
@@ -62,14 +62,14 @@ public class WriteConcernOptionTest {
 	@Test
 	public void testWriteConcernGivenByTypePriority() throws Exception {
 		mongoOptions
-			.writeConcern( WriteConcernType.ERRORS_IGNORED )
+			.writeConcern( WriteConcernType.REPLICA_ACKNOWLEDGED )
 			.entity( ExampleForMongoDBMapping.class )
 				.writeConcern( WriteConcernType.MAJORITY )
 				.property( "content", ElementType.FIELD )
 					.writeConcern( WriteConcernType.FSYNCED );
 
 		OptionsContainer options = getSource().getGlobalOptions();
-		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( WriteConcern.ERRORS_IGNORED );
+		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( WriteConcern.REPLICA_ACKNOWLEDGED );
 
 		options = getSource().getEntityOptions( ExampleForMongoDBMapping.class );
 		assertThat( options.getUnique( WriteConcernOption.class ) ).isEqualTo( WriteConcern.MAJORITY );
@@ -135,7 +135,7 @@ public class WriteConcernOptionTest {
 	private static class ReplicaConfigurableWriteConcern extends WriteConcern {
 
 		public ReplicaConfigurableWriteConcern(int numberOfRequiredReplicas) {
-			super( numberOfRequiredReplicas, 0, false, true, false );
+			super( numberOfRequiredReplicas, 0, false, true );
 		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
                 <plugin>
                     <groupId>com.github.joelittlejohn.embedmongo</groupId>
                     <artifactId>embedmongo-maven-plugin</artifactId>
-                    <version>0.1.12</version>
+                    <version>0.1.13</version>
                     <configuration>
                         <port>${embeddedMongoDbPort}</port>
                         <logging>file</logging>
@@ -565,7 +565,7 @@
                         <dependency>
                             <groupId>de.flapdoodle.embed</groupId>
                             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-                            <version>1.47.2</version>
+                            <version>1.48.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
This is only the first step of the switch. At the moment we are still using the deprecated classes `DB`, `DBCollection` and `DBObject`. They should be used in a second step of this driver migration. I suggest to open a new follow up issue for that, so that this initial work can already be integrated (work on the deprecation removal is in progress, but not ready yet)