### PR TITLE
OGM-887 Don't map elements within embeddable collections using dot names

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.ogm.dialect.impl;
+package org.hibernate.ogm.datastore.document.impl;
 
 import java.util.Map;
 import java.util.regex.Pattern;

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/DotPatternMapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/DotPatternMapHelpers.java
@@ -1,0 +1,95 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Provides functionality for dealing with (nested) fields of Map documents.
+ *
+ * @author Alan Fitton &lt;alan at eth0.org.uk&gt;
+ * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
+ * @author Gunnar Morling
+ */
+public class DotPatternMapHelpers {
+
+	private static final Pattern DOT_SEPARATOR_PATTERN = Pattern.compile( "\\." );
+
+	/**
+	 * Remove a column from the Map
+	 *
+	 * @param entity the {@link Map} with the column
+	 * @param column the column to remove
+	 */
+	public static void resetValue(Map<?,?> entity, String column) {
+		// fast path for non-embedded case
+		if ( !column.contains( "." ) ) {
+			entity.remove( column );
+		}
+		else {
+			String[] path = DOT_SEPARATOR_PATTERN.split( column );
+			Object field = entity;
+			int size = path.length;
+			for (int index = 0 ; index < size ; index++) {
+				String node = path[index];
+				Map parent = (Map) field;
+				field = parent.get( node );
+				if ( field == null && index < size - 1 ) {
+					//TODO clean up the hierarchy of empty containers
+					// no way to reach the leaf, nothing to do
+					return;
+				}
+				if ( index == size - 1 ) {
+					parent.remove( node );
+				}
+			}
+		}
+	}
+
+	public static boolean hasField(Map entity, String dotPath) {
+		return getValueOrNull( entity, dotPath ) != null;
+	}
+
+	public static <T> T getValueOrNull(Map entity, String dotPath, Class<T> type) {
+		Object value = getValueOrNull( entity, dotPath );
+		return type.isInstance( value ) ? type.cast( value ) : null;
+	}
+
+	public static Object getValueOrNull(Map entity, String dotPath) {
+		// fast path for simple properties
+		if ( !dotPath.contains( "." ) ) {
+			return entity.get( dotPath );
+		}
+
+		String[] path = DOT_SEPARATOR_PATTERN.split( dotPath );
+		int size = path.length;
+
+		for (int index = 0 ; index < size - 1; index++) {
+			Object next = entity.get( path[index] );
+			if ( next == null || !( next instanceof Map ) ) {
+				return null;
+			}
+			entity = (Map) next;
+		}
+
+		String field = path[size - 1];
+		return entity.get( field );
+	}
+
+	/**
+	 * Links the two field names into a single left.right field name.
+	 * If the left field is empty, right is returned
+	 *
+	 * @param left one field name
+	 * @param right the other field name
+	 * @return left.right or right if left is an empty string
+	 */
+	public static String flatten(String left, String right) {
+		return left == null || left.isEmpty() ? right : left + "." + right;
+	}
+}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociationRowFactory.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociationRowFactory.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import org.hibernate.ogm.datastore.document.association.spi.AssociationRow.AssociationRowAccessor;
 import org.hibernate.ogm.datastore.document.association.spi.AssociationRowFactory;
 import org.hibernate.ogm.datastore.document.association.spi.StructureOptimizerAssociationRowFactory;
-import org.hibernate.ogm.dialect.impl.DotPatternMapHelpers;
+import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 
 /**
  * {@link AssociationRowFactory} which creates association rows based on the map based representation used in Redis.

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
-import org.hibernate.ogm.dialect.impl.DotPatternMapHelpers;
+import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.model.spi.Tuple;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
+import org.hibernate.ogm.dialect.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.model.spi.Tuple;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -160,6 +161,11 @@ public class Entity extends StructuredValue {
 
 	@JsonIgnore
 	public void removeAssociation(String name) {
-		properties.remove( name );
+		if ( properties.containsKey( name ) ) {
+			properties.remove( name );
+		}
+		else {
+			DotPatternMapHelpers.resetValue( properties, name );
+		}
 	}
 }

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/ManyToOneInEntityJsonRepresentationTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/ManyToOneInEntityJsonRepresentationTest.java
@@ -80,8 +80,8 @@ public class ManyToOneInEntityJsonRepresentationTest extends OgmTestCase {
 
 		// then
 		JSONAssert.assertEquals(
-				"{\"games\":[{\"id.gameSequenceNo\":456,\"id.category\":\"primary\"}," +
-						"{\"id.gameSequenceNo\":457,\"id.category\":\"primary\"}]," +
+				"{\"games\":[{\"gameSequenceNo\":456,\"category\":\"primary\"}," +
+						"{\"gameSequenceNo\":457,\"category\":\"primary\"}]," +
 						"\"name\":\"Hamburg Court\"}",
 				representation,
 				JSONCompareMode.NON_EXTENSIBLE

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/embeddable/EmbeddableMappingTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/embeddable/EmbeddableMappingTest.java
@@ -20,7 +20,6 @@ import org.hibernate.ogm.backendtck.queries.OptionalStoryBranch;
 import org.hibernate.ogm.backendtck.queries.StoryBranch;
 import org.hibernate.ogm.backendtck.queries.StoryGame;
 import org.hibernate.ogm.utils.OgmTestCase;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -195,7 +194,6 @@ public class EmbeddableMappingTest extends OgmTestCase {
 	}
 
 	@Test
-	@Ignore("TODO OGM-887: Fix created and expected mapping")
 	public void testEmbeddableCollection() throws Exception {
 		OgmSession session = openSession();
 		Transaction transaction = session.beginTransaction();


### PR DESCRIPTION
* Don't map elements within embeddable collections using dot names
* Remove the common prefixes from the JSON representation
* Refactor parts of MongoHelpers into DotPatternMapHelpers