### PR TITLE
OGM-886 Ship own netty jars to omit connection-refused-bug

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,6 +68,7 @@
 
         <lettuceCommonsPoolVersion>2.2</lettuceCommonsPoolVersion>
         <lettuceGuavaVersion>17.0</lettuceGuavaVersion>
+        <netty4Version>4.0.28.Final</netty4Version>
     </properties>
 
     <inceptionYear>2010</inceptionYear>

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -158,6 +158,11 @@
              <unpack>false</unpack>
              <includes>
                  <include>biz.paluch.redis:lettuce</include>
+                 <include>io.netty:netty-buffer</include>
+                 <include>io.netty:netty-codec</include>
+                 <include>io.netty:netty-common</include>
+                 <include>io.netty:netty-transport</include>
+                 <include>io.netty:netty-handler</include>
                  <include>org.apache.commons:commons-pool2</include>
               </includes>
        </dependencySet>

--- a/modules/wildfly/src/main/modules/ogm/redis-driver/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/redis-driver/module.xml
@@ -12,19 +12,24 @@
     <resources>
         <resource-root path="lettuce-${lettuceVersion}.jar" />
         <resource-root path="commons-pool2-${lettuceCommonsPoolVersion}.jar" />
+        <resource-root path="netty-buffer-${netty4Version}.jar" />
+        <resource-root path="netty-codec-${netty4Version}.jar" />
+        <resource-root path="netty-common-${netty4Version}.jar" />
+        <resource-root path="netty-transport-${netty4Version}.jar" />
+        <resource-root path="netty-handler-${netty4Version}.jar" />
     </resources>
     <dependencies>
 
         <!-- A dependency for netty -->
         <module name="org.slf4j" />
 
+        <!-- The driver needs to access sun.misc.Unsafe ...-->
+        <module name="sun.jdk" />
+
         <!-- ... and to management API -->
         <module name="javax.api" />
 
         <!-- use Guava from WildFly, that's nice, because WF9 ships with Guava 18 -->
         <module name="com.google.guava" />
-
-        <!-- use netty from WildFly, minimum version is 4.0.26-->
-        <module name="io.netty" />
     </dependencies>
 </module>


### PR DESCRIPTION
Using lettuce 3.2.Final with netty 4.0.26 runs into a deadlock/infinite wait when the connection runs into a connection refused. Ship own netty jars until then.