### PR TITLE
OGM-880 Keep connection alive between tests

### DIFF
--- a/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
+++ b/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
@@ -7,9 +7,16 @@
 package org.hibernate.ogm.test.integration.jboss;
 
 import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.redis.Redis;
+import org.hibernate.ogm.datastore.redis.RedisDialect;
+import org.hibernate.ogm.datastore.redis.RedisProperties;
+import org.hibernate.ogm.datastore.redis.impl.RedisDatastoreProvider;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.jpa.impl.OgmEntityManagerFactory;
 import org.hibernate.ogm.test.integration.jboss.model.Member;
 import org.hibernate.ogm.test.integration.jboss.model.PhoneNumber;
 import org.hibernate.ogm.test.integration.jboss.service.PhoneNumberService;
@@ -26,7 +33,10 @@ import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceUnit;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.Properties;
 
-import static org.junit.Assert.assertEquals;
+import com.lambdaworks.redis.RedisConnection;
+
+import static org.junit.Assert.assertTrue;
+
 
 /**
  * Test for the Hibernate OGM module in WildFly using Redis
@@ -34,19 +44,25 @@ import static org.junit.Assert.assertEquals;
  * @author Mark Paluch
  */
 @RunWith(Arquillian.class)
-public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationScenario {
+public class RedisModuleMemberRegistrationWithTTLConfiguredIT extends ModuleMemberRegistrationScenario {
 
 	@Inject
 	private PhoneNumberService phoneNumberService;
 
+	@javax.persistence.PersistenceUnit
+	private EntityManagerFactory entityManagerFactory;
+
+	@Inject
+	private EntityManager entityManager;
+
 	@Deployment
 	public static Archive<?> createTestArchive() {
 		return new ModuleMemberRegistrationDeployment
-				.Builder( RedisModuleMemberRegistrationIT.class )
+				.Builder( RedisModuleMemberRegistrationWithTTLConfiguredIT.class )
 				.addClasses( PhoneNumber.class, PhoneNumberService.class )
 				.persistenceXml( persistenceXml() )
 				.manifestDependencies(
-						"org.hibernate:ogm services, org.hibernate.ogm.redis services, org.hibernate.search.orm:${hibernate-search.module.slot} services"
+						"org.hibernate:ogm services, org.hibernate.ogm.redis services,  org.hibernate.ogm.redis.driver services, org.hibernate.search.orm:${hibernate-search.module.slot} services"
 				)
 				.createDeployment();
 	}
@@ -72,6 +88,7 @@ public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationSce
 		return propertiesContext
 				.createProperty().name( OgmProperties.DATASTORE_PROVIDER ).value( Redis.DATASTORE_PROVIDER_NAME ).up()
 				.createProperty().name( OgmProperties.DATABASE ).value( "0" ).up()
+				.createProperty().name( RedisProperties.TTL ).value( "3600" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.up().up();
 	}
@@ -81,15 +98,43 @@ public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationSce
 	}
 
 	@Test
-	public void shouldPersistAndFindEntityUsingId() {
-		phoneNumberService.createPhoneNumber( "Bob", "123-456" );
-		phoneNumberService.createPhoneNumber( "Mortimer", "789-123" );
+	public void testTtlIsSet() throws InterruptedException {
+		// given
+		phoneNumberService.createPhoneNumber( "Michael", "123-456" );
 
-		assertEquals( "123-456", phoneNumberService.getPhoneNumber( "Bob" ).getValue() );
-		assertEquals( "789-123", phoneNumberService.getPhoneNumber( "Mortimer" ).getValue() );
+		RedisDatastoreProvider provider = getProvider();
+		RedisDialect dialect = getDialect( provider );
 
-		phoneNumberService.deletePhoneNumber( "Bob" );
-		phoneNumberService.deletePhoneNumber( "Mortimer" );
+		// when
+		byte[] key = dialect.toBytes( "PhoneNumber:Michael" );
+		RedisConnection<byte[], byte[]> connection = provider.getConnection();
+		Boolean exists = connection.exists( key );
+		byte[] value = connection.get( key );
+		Long pttl = connection.pttl( key );
+
+		// then
+		assertTrue( exists );
+		assertTrue( value.length > 10 );
+		assertTrue( pttl.longValue() > 3500 );
+	}
+
+
+	private RedisDatastoreProvider getProvider() {
+
+		OgmEntityManagerFactory ogmEntityManagerFactory = (OgmEntityManagerFactory) entityManagerFactory;
+
+		DatastoreProvider provider = ogmEntityManagerFactory.getSessionFactory().getServiceRegistry().getService(
+				DatastoreProvider.class
+		);
+		if ( !( RedisDatastoreProvider.class.isInstance( provider ) ) ) {
+			throw new RuntimeException( "Not testing with RedisDatastoreProvider, cannot extract underlying instance." );
+		}
+
+		return RedisDatastoreProvider.class.cast( provider );
+	}
+
+	public static RedisDialect getDialect(DatastoreProvider datastoreProvider) {
+		return new RedisDialect( (RedisDatastoreProvider) datastoreProvider );
 	}
 
 }

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/impl/TestRedisDatastoreProvider.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/impl/TestRedisDatastoreProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.redis.impl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.hibernate.ogm.cfg.spi.Hosts;
+
+import com.lambdaworks.redis.RedisClient;
+
+/**
+ * Data store provider that reused the {@link com.lambdaworks.redis.RedisClient} throughout the test run.
+ *
+ * @author Mark Paluch
+ */
+public class TestRedisDatastoreProvider extends RedisDatastoreProvider {
+
+	private static volatile RedisClient staticInstance;
+
+	@Override
+	protected RedisClient createClient(Hosts.HostAndPort hostAndPort) {
+		if ( staticInstance == null ) {
+			final RedisClient redisClient = super.createClient( hostAndPort );
+
+			Runtime.getRuntime().addShutdownHook(
+					new Thread( "RedisClient shutdown hook" ) {
+						@Override
+						public void run() {
+							redisClient.shutdown( 100, 100, TimeUnit.MILLISECONDS );
+						}
+					}
+			);
+			staticInstance = redisClient;
+		}
+
+		return staticInstance;
+
+	}
+
+	@Override
+	protected void shutdownClient() {
+		// noop. Client is closed using a ShutdownHook
+	}
+}

--- a/redis/src/test/resources/hibernate.properties
+++ b/redis/src/test/resources/hibernate.properties
@@ -6,4 +6,4 @@
 #
 
 #@author Mark Paluch
-hibernate.ogm.datastore.provider=REDIS_EXPERIMENTAL
+hibernate.ogm.datastore.provider=org.hibernate.ogm.datastore.redis.impl.TestRedisDatastoreProvider


### PR DESCRIPTION
Use TestRedisDatastoreProvider for unit tests to operate on a static held RedisClient instance that is closed using a shutdown hook.