### PR TITLE
OGM-904 Use more natural format to store map-typed properties in CouchDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
@@ -133,6 +133,13 @@ public class DotPatternMapHelpers {
 		return associationContext.getAssociationTypeContext().getOptionsContext().getUnique( MapStorageOption.class );
 	}
 
+	/**
+	 * Returns the shared prefix with a trailing dot (.) of the association columns or {@literal null} if there is no shared prefix.
+	 *
+	 * @param associationKey the association key
+	 *
+	 * @return the shared prefix with a trailing dot (.) of the association columns or {@literal null}
+	 */
 	public static String getColumnSharedPrefixOfAssociatedEntityLink(AssociationKey associationKey) {
 		String[] associationKeyColumns = associationKey.getMetadata()
 				.getAssociatedEntityKeyMetadata()

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/impl/DotPatternMapHelpers.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.datastore.document.impl;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.hibernate.ogm.datastore.document.association.spi.impl.DocumentHelpers;
 import org.hibernate.ogm.datastore.document.options.MapStorageType;
 import org.hibernate.ogm.datastore.document.options.spi.MapStorageOption;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
@@ -93,6 +94,7 @@ public class DotPatternMapHelpers {
 	 *
 	 * @param left one field name
 	 * @param right the other field name
+	 *
 	 * @return left.right or right if left is an empty string
 	 */
 	public static String flatten(String left, String right) {
@@ -129,5 +131,16 @@ public class DotPatternMapHelpers {
 
 	private static MapStorageType getMapStorage(AssociationContext associationContext) {
 		return associationContext.getAssociationTypeContext().getOptionsContext().getUnique( MapStorageOption.class );
+	}
+
+	public static String getColumnSharedPrefixOfAssociatedEntityLink(AssociationKey associationKey) {
+		String[] associationKeyColumns = associationKey.getMetadata()
+				.getAssociatedEntityKeyMetadata()
+				.getAssociationKeyColumns();
+		// we used to check that columns are the same (in an ordered fashion)
+		// but to handle List and Map and store indexes / keys at the same level as the id columns
+		// this check is removed
+		String prefix = DocumentHelpers.getColumnSharedPrefix( associationKeyColumns );
+		return prefix == null ? "" : prefix + ".";
 	}
 }

--- a/couchdb/pom.xml
+++ b/couchdb/pom.xml
@@ -112,6 +112,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -182,7 +182,10 @@ public class CouchDBDialect extends BaseGridDialect {
 				associationContext
 		);
 
-		if ( organizeByRowKey ) {
+		if ( isStoredInEntityStructure(
+				associationKey.getMetadata(),
+				associationContext.getAssociationTypeContext()
+		) && organizeByRowKey ) {
 			String rowKeyColumn = organizeByRowKey ? associationKey.getMetadata().getRowKeyIndexColumnNames()[0] : null;
 			Map<String, Object> rows = new HashMap<>();
 

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/impl/EntityDocument.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/impl/EntityDocument.java
@@ -7,11 +7,14 @@
 package org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.hibernate.ogm.datastore.couchdb.util.impl.Identifier;
+import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.spi.Tuple;
 
@@ -77,7 +80,7 @@ public class EntityDocument extends Document {
 	 */
 	private final Map<String, Object> properties = new HashMap<String, Object>();
 
-	EntityDocument() {
+	public EntityDocument() {
 	}
 
 	public EntityDocument(EntityKey key) {
@@ -221,6 +224,18 @@ public class EntityDocument extends Document {
 
 	@JsonIgnore
 	public void removeAssociation(String name) {
-		properties.remove( name );
+		if ( properties.containsKey( name ) ) {
+			properties.remove( name );
+		}
+		else {
+			Set<String> keys = new HashSet<String>( properties.keySet() );
+			for ( String key : keys ) {
+				if ( key.startsWith( name + "." ) ) {
+					removeAssociation( key );
+				}
+			}
+
+			DotPatternMapHelpers.resetValue( properties, name );
+		}
 	}
 }

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociation.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociation.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 
-import java.util.List;
-
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.AssociationDocument;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.Document;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
@@ -48,16 +46,16 @@ public abstract class CouchDBAssociation {
 	/**
 	 * Get all the rows of this association. Does not contain columns which are part of the association
 	 * key.
-	 * @return a list with all the rows for this association
+	 * @return an object with all the rows for this association
 	 */
-	public abstract List<Object> getRows();
+	public abstract Object getRows();
 
 	/**
 	 * Sets the rows of this association. The given list must not contain columns which are part of the association key.
 	 *
 	 * @param rows the rows of the association
 	 */
-	public abstract void setRows(List<Object> rows);
+	public abstract void setRows(Object rows);
 
 	/**
 	 * Returns the CouchDB document which owns this association, either an {@link AssociationDocument} or an

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociationSnapshot.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociationSnapshot.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 
 import org.hibernate.ogm.datastore.document.association.spi.AssociationRows;
+import org.hibernate.ogm.datastore.document.impl.MapAssociationRowsHelpers;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.spi.AssociationSnapshot;
 
@@ -25,7 +26,7 @@ public class CouchDBAssociationSnapshot extends AssociationRows {
 	private final CouchDBAssociation couchDbAssociation;
 
 	public CouchDBAssociationSnapshot(CouchDBAssociation association, AssociationKey key) {
-		super( key, association.getRows(), CouchDBAssociationRowFactory.INSTANCE );
+		super( key, MapAssociationRowsHelpers.getRows( association.getRows(), key ), CouchDBAssociationRowFactory.INSTANCE );
 		this.couchDbAssociation = association;
 	}
 

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/DocumentBasedAssociation.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/DocumentBasedAssociation.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.AssociationDocument;
@@ -25,13 +26,18 @@ class DocumentBasedAssociation extends CouchDBAssociation {
 	}
 
 	@Override
-	public List<Object> getRows() {
+	public Object getRows() {
 		return document.getRows();
 	}
 
 	@Override
-	public void setRows(List<Object> rows) {
-		document.setRows( rows );
+	public void setRows(Object rows) {
+		if ( rows instanceof List ) {
+			document.setRows( (List) rows );
+		}
+		else {
+			document.setRows( Collections.singletonList( rows ) );
+		}
 	}
 
 	@Override

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/EmbeddedAssociation.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/EmbeddedAssociation.java
@@ -6,12 +6,13 @@
  */
 package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.Document;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
+import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 
 /**
@@ -31,33 +32,58 @@ class EmbeddedAssociation extends CouchDBAssociation {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public List<Object> getRows() {
-		List<Object> rows;
-		Object fieldValue = entity.getProperties().get( associationKeyMetadata.getCollectionRole() );
+	public Object getRows() {
+		Object rows;
+		Object fieldValue = DotPatternMapHelpers.getValueOrNull(
+				entity.getPropertiesAsHierarchy(), associationKeyMetadata.getCollectionRole()
+		);
 
 		if ( fieldValue == null ) {
 			rows = Collections.emptyList();
 		}
 		else if ( associationKeyMetadata.isOneToOne() ) {
-			rows = new ArrayList<Object>( 1 );
-			rows.add( fieldValue );
+			rows = fieldValue;
 		}
 		else {
-			rows = (List<Object>) fieldValue;
+			rows = fieldValue;
 		}
 
 		return rows;
 	}
 
 	@Override
-	public void setRows(List<Object> rows) {
-		if ( rows.isEmpty() ) {
+	public void setRows(Object rows) {
+		if ( isEmpty( rows ) ) {
 			entity.removeAssociation( associationKeyMetadata.getCollectionRole() );
 		}
 		else {
-			Object value = associationKeyMetadata.isOneToOne() ? rows.iterator().next() : rows;
-			entity.set( associationKeyMetadata.getCollectionRole(), value );
+
+			entity.removeAssociation( associationKeyMetadata.getCollectionRole() );
+			if ( associationKeyMetadata.isOneToOne() && rows instanceof Collection ) {
+				Object value = ( (Collection) rows ).iterator().next();
+				entity.set( associationKeyMetadata.getCollectionRole(), value );
+			}
+			else {
+				entity.set( associationKeyMetadata.getCollectionRole(), rows );
+			}
 		}
+	}
+
+	protected boolean isEmpty(Object rows) {
+
+		if ( rows == null ) {
+			return true;
+		}
+
+		if ( rows instanceof Collection<?> && ( (Collection<?>) rows ).isEmpty() ) {
+			return true;
+		}
+
+		if ( rows instanceof Map<?, ?> && ( (Map<?, ?>) rows ).isEmpty() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/associations/MapMappingTest.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/associations/MapMappingTest.java
@@ -1,0 +1,374 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.couchdb.test.associations;
+
+import java.lang.annotation.ElementType;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.OgmSessionFactory;
+import org.hibernate.ogm.backendtck.associations.collection.types.Address;
+import org.hibernate.ogm.backendtck.associations.collection.types.Department;
+import org.hibernate.ogm.backendtck.associations.collection.types.Enterprise;
+import org.hibernate.ogm.backendtck.associations.collection.types.PhoneNumber;
+import org.hibernate.ogm.backendtck.associations.collection.types.PhoneNumber.PhoneNumberId;
+import org.hibernate.ogm.backendtck.associations.collection.types.User;
+import org.hibernate.ogm.datastore.couchdb.CouchDB;
+import org.hibernate.ogm.datastore.document.options.MapStorageType;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.TestHelper;
+
+import org.junit.Test;
+
+import static org.hibernate.ogm.datastore.couchdb.utils.CouchDBTestHelper.assertDbObject;
+
+/**
+ * @author Gunnar Morling
+ * @author Mark Paluch
+ */
+public class MapMappingTest extends OgmTestCase {
+
+	@Test
+	public void testMapOfEntity() throws Exception {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Address home = new Address();
+		home.setCity( "Paris" );
+		Address work = new Address();
+		work.setCity( "San Francisco" );
+		User user = new User();
+		user.getAddresses().put( "home", home );
+		user.getAddresses().put( "work", work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// Then
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"User:id_:" + user.getId() + "_",
+				// expected
+				"{ " +
+					"'addresses' : {" +
+						"'home' : '" + home.getId() + "'," +
+						"'work' : '" + work.getId() + "'" +
+					"}" +
+				"}"
+		);
+
+		// clean-up
+		user = session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( Address.class, home.getId() ) );
+		session.delete( session.load( Address.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapOfEntityUsingListStrategy() throws Exception {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		PhoneNumber home = new PhoneNumber( new PhoneNumberId( "DE", 123 ), "Home Phone" );
+		PhoneNumber work = new PhoneNumber( new PhoneNumberId( "EN", 456 ), "Work Phone" );
+		User user = new User();
+		user.getAlternativePhoneNumbers().put( "home", home );
+		user.getAlternativePhoneNumbers().put( "work", work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// Then
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"User:id_:" + user.getId() + "_",
+				// expected
+				"{ " +
+					"'alternativePhoneNumbers' : [" +
+						"{ 'phoneType' : 'home', 'countryCode' : 'DE', 'number'  : 123 }," +
+						"{ 'phoneType' : 'work', 'countryCode' : 'EN', 'number'  : 456 }" +
+					"]" +
+				"}"
+		);
+
+		// clean-up
+		user = session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( PhoneNumber.class, home.getId() ) );
+		session.delete( session.load( PhoneNumber.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapOfEntityUsingListStrategyConfiguredViaOptionApi() throws Exception {
+		Map<String, Object> settings = new HashMap<String, Object>();
+
+		TestHelper.configureOptionsFor( settings, CouchDB.class )
+			.entity( User.class )
+				.property( "addresses", ElementType.METHOD )
+					.mapStorage( MapStorageType.AS_LIST );
+
+		OgmSessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings, getAnnotatedClasses() );
+		OgmSession session = sessionFactory.openSession();
+		Transaction tx = session.beginTransaction();
+
+		Address home = new Address();
+		home.setCity( "Paris" );
+		Address work = new Address();
+		work.setCity( "San Francisco" );
+		User user = new User();
+		user.getAddresses().put( "home", home );
+		user.getAddresses().put( "work", work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"User:id_:" + user.getId() + "_",
+				// expected
+				"{ " +
+					"'addresses' : [" +
+						"{ 'addressType' : 'home', 'addresses_id' : '" + home.getId() + "' }," +
+						"{ 'addressType' : 'work', 'addresses_id' : '" + work.getId() + "' }" +
+					"]" +
+				"}"
+		);
+
+		// clean-up
+		user = session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( Address.class, home.getId() ) );
+		session.delete( session.load( Address.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+		sessionFactory.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapOfEntityWithCompositeId() throws Exception {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		PhoneNumber home = new PhoneNumber( new PhoneNumberId( "DE", 123 ), "Home Phone" );
+		PhoneNumber work = new PhoneNumber( new PhoneNumberId( "EN", 456 ), "Work Phone" );
+		User user = new User();
+		user.getPhoneNumbers().put( "home", home );
+		user.getPhoneNumbers().put( "work", work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// Then
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"User:id_:" + user.getId() + "_",
+				// expected
+				"{ " +
+					"'phoneNumbers' : {" +
+						"'home' : { 'countryCode' : 'DE', 'number'  : 123 }," +
+						"'work' : { 'countryCode' : 'EN', 'number'  : 456 }" +
+					"}" +
+				"}"
+		);
+
+		// clean-up
+		user = session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( PhoneNumber.class, home.getId() ) );
+		session.delete( session.load( PhoneNumber.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapWithNonStringKey() throws Exception {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		PhoneNumber home = new PhoneNumber( new PhoneNumberId( "DE", 123 ), "Home Phone" );
+		PhoneNumber work = new PhoneNumber( new PhoneNumberId( "EN", 456 ), "Work Phone" );
+		User user = new User();
+		user.getPhoneNumbersByPriority().put( 1, home );
+		user.getPhoneNumbersByPriority().put( 2, work );
+
+		session.persist( home );
+		session.persist( work );
+		session.persist( user );
+
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// Then
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"User",
+				// query
+				"User:id_:" + user.getId() + "_",
+				// expected
+				"{ " +
+					"'phoneNumbersByPriority' : [" +
+						"{ 'priority' : 1, 'countryCode' : 'DE', 'number'  : 123 }," +
+						"{ 'priority' : 2, 'countryCode' : 'EN', 'number'  : 456 }" +
+					"]" +
+				"}"
+		);
+
+		// clean-up
+		user = session.get( User.class, user.getId() );
+		session.delete( user );
+		session.delete( session.load( PhoneNumber.class, home.getId() ) );
+		session.delete( session.load( PhoneNumber.class, work.getId() ) );
+
+		tx.commit();
+		session.close();
+
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapOfComponent() {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Map<String, Department> departments = new HashMap<>();
+		departments.put( "sawing", new Department( "Sawing", 7 ) );
+		departments.put( "sale", new Department( "Sale", 2 ) );
+		Enterprise timberTradingInc = new Enterprise( "enterprise-1", departments );
+
+		session.persist( timberTradingInc );
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// assert
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"Enterprise",
+				// query
+				"Enterprise:id_:enterprise-1_",
+				// expected
+				"{ " +
+					"'departments' : {" +
+						"'sawing' : { 'name' : 'Sawing', 'headCount'  : 7 }," +
+						"'sale' : { 'name' : 'Sale', 'headCount'  : 2 }," +
+					"}" +
+				"}"
+		);
+
+		// clean up
+		session.delete( timberTradingInc );
+
+		tx.commit();
+		session.close();
+		checkCleanCache();
+	}
+
+	@Test
+	public void testMapWithSimpleValueType() {
+		OgmSession session = openSession();
+		Transaction tx = session.beginTransaction();
+
+		Enterprise timberTradingInc = new Enterprise( "enterprise-1", null );
+		timberTradingInc.getRevenueByDepartment().put( "sale", 1000 );
+		timberTradingInc.getRevenueByDepartment().put( "sawing", 2000 );
+		timberTradingInc.getRevenueByDepartment().put( "planting", 3000 );
+
+		session.persist( timberTradingInc );
+		tx.commit();
+		session.clear();
+
+		tx = session.beginTransaction();
+
+		// assert
+		assertDbObject(
+				session.getSessionFactory(),
+				// collection
+				"Enterprise",
+				// query
+				"Enterprise:id_:enterprise-1_",
+				// expected
+				"{ " +
+					"'revenueByDepartment' : {" +
+						"'sawing' : 2000," +
+						"'sale' : 1000," +
+						"'planting' : 3000," +
+					"}" +
+				"}"
+		);
+
+		// clean up
+		session.delete( timberTradingInc );
+
+		tx.commit();
+		session.close();
+		checkCleanCache();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { User.class, Address.class, PhoneNumber.class, Enterprise.class };
+	}
+}

--- a/documentation/manual/src/main/asciidoc/en-US/modules/couchdb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/couchdb.asciidoc
@@ -32,10 +32,13 @@ so there is no need to include any of the Java client libraries for CouchDB in y
 The following properties are available to configure CouchDB support in Hibernate OGM:
 
 .CouchDB datastore configuration properties
+
 hibernate.ogm.datastore.provider::
 To use CouchDB as a datastore provider, this property must be set to `couchdb_experimental`
+
 hibernate.ogm.option.configurator::
 The fully-qualified class name or an instance of a programmatic option configurator (see <<ogm-couchdb-programmatic-configuration>>)
+
 hibernate.ogm.datastore.host::
 The hostname and port of the CouchDB instance.
 The optional port is concatenated to the host and separated by a colon.
@@ -48,35 +51,52 @@ Let's see a few valid examples:
 +
 Listing multiple initial hosts for fault tolerance is not supported.
 The default value is `127.0.0.1:5984`. If left undefined, the default port is `5984`.
+
 hibernate.ogm.datastore.port::
 Deprecated: use `hibernate.ogm.datastore.host`.
 The port used by the CouchDB instance.
 The default value is `5984`.
+
 hibernate.ogm.datastore.database::
 The database to connect to. This property has no default value.
 hibernate.ogm.datastore.create_database::
 Whether to create the specified database in case it does not exist or not.
 Can be `true` or `false` (default). Note that the specified user must have the right to
 create databases if set to `true`.
+
 hibernate.ogm.datastore.username::
 The username used when connecting to the CouchDB server.
 Note that this user must have the right to create design documents in the chosen database.
 This property has no default value.
 Hibernate OGM currently does not support accessing CouchDB via HTTPS;
 if you're interested in such functionality, let us know.
+
 hibernate.ogm.datastore.password::
 The password used to connect to the CouchDB server.
 This property has no default value.
 This property is ignored if the username isn't specified.
+
 hibernate.ogm.error_handler::
 The fully-qualified class name, class object or an instance of `ErrorHandler` to get notified upon errors during flushes (see <<ogm-api-error-handler>>)
+
 hibernate.ogm.datastore.document.association_storage::
 Defines the way OGM stores association information in CouchDB.
+
 The following two strategies exist (values of the `org.hibernate.ogm.datastore.document.options.AssociationStorageType` enum):
 `IN_ENTITY` (store association information within the entity) and
 `ASSOCIATION_DOCUMENT` (store association information in a dedicated document per association).
+
 `IN_ENTITY` is the default and recommended option
 unless the association navigation data is much bigger than the core of the document and leads to performance degradation.
+
+hibernate.ogm.datastore.document.map_storage::
+Defines the way OGM stores the contents of map-typed associations in CouchDB.
+The following two strategies exist (values of the `org.hibernate.ogm.datastore.document.options.MapStorageType` enum):
+
+* `BY_KEY`: map-typed associations with a single key column which is of type `String` will be stored as a sub-document,
+organized by the given key; Not applicable for other types of key columns, in which case always `AS_LIST` will be used
+* `AS_LIST`: map-typed associations will be stored as an array containing a sub-document for each map entry.
+All key and value columns will be contained within the array elements
 
 [NOTE]
 ====
@@ -91,9 +111,13 @@ To ease migration between stores, it is recommended to reference these constants
 ==== Annotation based configuration
 
 Hibernate OGM allows to configure store-specific options via Java annotations.
-When working with the CouchDB backend, you can specify how associations should be stored
-using the `AssociationStorage` annotation
-(refer to <<ogm-couchdb-storage-principles>> to learn more about association storage strategies in general).
+
+When working with the CouchDB backend, you can specify the following settings:
+
+* a strategy for storing associations using the `@AssociationStorage` and `@AssociationDocumentStorage` annotations
+* a strategy for storing the contents of map-typed associations using the `@MapStorage` annotation
+
+Refer to <<ogm-couchdb-storage-principles> to learn more about the options related to storing associations.
 
 The following shows an example:
 
@@ -103,6 +127,7 @@ The following shows an example:
 ----
 @Entity
 @AssociationStorage(AssociationStorageType.ASSOCIATION_DOCUMENT)
+@MapStorage(MapStorageType.AS_LIST)
 public class Zoo {
 
     @OneToMany
@@ -138,6 +163,7 @@ The API allows set options in a type-safe fashion on the global, entity and prop
 When working with CouchDB, you can currently configure the following options using the API:
 
 * association storage strategy (on the global, entity and property level)
+* strategy for storing the contents of map-typed associations
 
 To set this option via the API, you need to create an `OptionConfigurator` implementation
 as shown in the following example:
@@ -155,6 +181,7 @@ public class MyOptionConfigurator extends OptionConfigurator {
             .entity( Zoo.class )
                 .property( "visitors", ElementType.FIELD )
                     .associationStorage( AssociationStorageType.IN_ENTITY )
+                    .mapStorage( MapStorageType.ASLIST )
             .entity( Animal.class )
                 .associationStorage( AssociationStorageType.ASSOCIATION_DOCUMENT );
     }
@@ -1331,16 +1358,10 @@ public class Address {
   "$type": "entity",
   "$table": "User",
   "id" : "user_001",
-  "addresses" : [
-    { 
-      "addresses_KEY" : "work",
-      "addresses_id" : "address_001"
-    },
-    {
-      "addresses_KEY" : "home",
-      "addresses_id" : "address_002"
-    }
-  ]
+  "addresses" : {
+    "work" : "address_001",
+    "home" : "address_002"
+  }
 }
 ----
 
@@ -1369,7 +1390,18 @@ public class Address {
 ----
 ====
 
-You can use @MapKeyColumn to rename the column containing the key of the map.
+If the map value cannot be represented by a single field (e.g. when referencing a type with a composite id
+or using an embeddable type as map value type),
+a sub-document containing all the required fields will be stored as value.
+
+If the map key either is not of type `String` or it is made up of several columns (composite map key),
+the optimized structure shown in the example above cannot be used.
+In that case the association will be represented by a list of sub-documents, also containing the map key column(s).
+You can use `@MapKeyColumn` to rename the field containing the key of the map,
+otherwise it will default to "<%COLLECTION_ROLE%>_KEY", e.g. "addresses_KEY".
+
+In case you want to enforce the list-style represention also for maps with a single key column of type `String`
+you can use the option `hibernate.ogm.datastore.document.map_storage` to do so.
 
 .Unidirectional one-to-many using maps with @MapKeyColumn
 ====

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.mongodb;
 
+import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
 import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot.SnapshotType.INSERT;
 import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot.SnapshotType.UPDATE;
 import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers.hasField;
@@ -589,17 +590,6 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 			}
 			return rowObject;
 		}
-	}
-
-	private String getColumnSharedPrefixOfAssociatedEntityLink(AssociationKey associationKey) {
-		String[] associationKeyColumns = associationKey.getMetadata()
-				.getAssociatedEntityKeyMetadata()
-				.getAssociationKeyColumns();
-		// we used to check that columns are the same (in an ordered fashion)
-		// but to handle List and Map and store indexes / keys at the same level as the id columns
-		// this check is removed
-		String prefix = DocumentHelpers.getColumnSharedPrefix( associationKeyColumns );
-		return prefix == null ? "" : prefix + ".";
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisDialect.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.hibernate.ogm.datastore.document.association.spi.impl.DocumentHelpers;
 import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.document.options.spi.AssociationStorageOption;
@@ -54,6 +53,8 @@ import com.lambdaworks.redis.KeyScanCursor;
 import com.lambdaworks.redis.RedisConnection;
 import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.protocol.LettuceCharsets;
+
+import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
 
 /**
  * Stores tuples and associations inside Redis.
@@ -349,7 +350,11 @@ public class RedisDialect extends BaseGridDialect implements MultigetGridDialect
 			AssociationContext associationContext) {
 
 
-		boolean organizeByRowKey = DotPatternMapHelpers.organizeAssociationMapByRowKey( association, key, associationContext );
+		boolean organizeByRowKey = DotPatternMapHelpers.organizeAssociationMapByRowKey(
+				association,
+				key,
+				associationContext
+		);
 
 		// only in-entity maps can be mapped by row key to prevent huge external association maps
 		if ( isStoredInEntityStructure(
@@ -403,17 +408,6 @@ public class RedisDialect extends BaseGridDialect implements MultigetGridDialect
 		}
 
 		return rowObject.getPropertiesAsHierarchy();
-	}
-
-	private String getColumnSharedPrefixOfAssociatedEntityLink(AssociationKey associationKey) {
-		String[] associationKeyColumns = associationKey.getMetadata()
-				.getAssociatedEntityKeyMetadata()
-				.getAssociationKeyColumns();
-		// we used to check that columns are the same (in an ordered fashion)
-		// but to handle List and Map and store indexes / keys at the same level as the id columns
-		// this check is removed
-		String prefix = DocumentHelpers.getColumnSharedPrefix( associationKeyColumns );
-		return prefix == null ? "" : prefix + ".";
 	}
 
 	@Override


### PR DESCRIPTION
- Fix properties with dot path names of embedded documents by converting those to nested objects
- Extract common parts from RedisDialect to DotPatternMapHelpers
- Adjust docs

Hint: I wasn't able to run the full test suite successfully even before the change. Need your advice then.