### PR TITLE
OGM-929 Refactor test runners for skip by provider and skip by dialect

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
@@ -17,46 +17,34 @@ package org.hibernate.ogm.utils;
 */
 public enum GridDialectType {
 
-	HASHMAP( "org.hibernate.ogm.utils.HashMapTestHelper", false, false ) {
-		@Override public Class<TestableGridDialect> loadTestableGridDialectClass() {
-			return null; //this one is special, we want it only as fallback when all others fail
-		}
-	},
+	HASHMAP( "org.hibernate.ogm.datastore.map.impl.MapDialect", false, false ),
 
-	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.utils.InfinispanTestHelper", false, false ),
+	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.InfinispanDialect", false, false),
 
-	EHCACHE( "org.hibernate.ogm.datastore.ehcache.utils.EhcacheTestHelper", false, false ),
+	EHCACHE( "org.hibernate.ogm.datastore.ehcache.EhcacheDialect", false, false ),
 
-	MONGODB( "org.hibernate.ogm.datastore.mongodb.utils.MongoDBTestHelper", true, true ),
+	MONGODB( "org.hibernate.ogm.datastore.mongodb.MongoDBDialect", true, true ),
 
-	NEO4J( "org.hibernate.ogm.datastore.neo4j.utils.Neo4jTestHelper", false, true ),
+	NEO4J( "org.hibernate.ogm.datastore.neo4j.Neo4jDialect", false, true),
 
-	COUCHDB( "org.hibernate.ogm.datastore.couchdb.utils.CouchDBTestHelper", true, false ),
+	COUCHDB( "org.hibernate.ogm.datastore.couchdb.CouchDBDialect", true, false ),
 
-	CASSANDRA( "org.hibernate.ogm.datastore.cassandra.utils.CassandraTestHelper", false, false ),
+	CASSANDRA( "org.hibernate.ogm.datastore.cassandra.CassandraDialect", false, false  ),
 
-	REDIS( "org.hibernate.ogm.datastore.redis.utils.RedisTestHelper", false, false );
+	REDIS( "org.hibernate.ogm.datastore.redis.RedisDialect", false, false );
 
-	private final String testHelperClassName;
+	private final String dialectClassName;
 	private final boolean isDocumentStore;
 	private final boolean supportsQueries;
 
-	GridDialectType(String testHelperClassName, boolean isDocumentStore, boolean supportsQueries) {
-		this.testHelperClassName = testHelperClassName;
+	GridDialectType(String dialectClassName, boolean isDocumentStore, boolean supportsQueries) {
+		this.dialectClassName = dialectClassName;
 		this.isDocumentStore = isDocumentStore;
 		this.supportsQueries = supportsQueries;
 	}
 
-	@SuppressWarnings("unchecked")
-	public Class<TestableGridDialect> loadTestableGridDialectClass() {
-		Class<TestableGridDialect> classForName = null;
-		try {
-			classForName = (Class<TestableGridDialect>) Class.forName( testHelperClassName );
-		}
-		catch (ClassNotFoundException e) {
-			//ignore this: might not be available
-		}
-		return classForName;
+	public Class<TestableGridDialect> loadGridDialectClass() {
+		return TestHelper.loadClass( dialectClassName );
 	}
 
 	/**

--- a/core/src/test/java/org/hibernate/ogm/utils/GridModule.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridModule.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils;
+
+
+import org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider;
+
+/**
+ * The testsuite needs some knowledge on all NoSQL stores it is meant to support.
+ * We mainly need the name of it's TestableGridDialect implementation, but this
+ * is also used to disable some tests for a specific GridModule.
+ * This class is a registry for the known testable dialects and providers.
+ *
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt;
+ * @author Gunnar Morling
+ */
+public enum GridModule {
+
+	HASHMAP( "org.hibernate.ogm.utils.HashMapTestHelper", false, false ) {
+
+		@Override
+		public Class<TestableGridDialect> loadTestableGridDialectClass() {
+			return null; //this one is special, we want it only as fallback when all others fail
+		}
+
+		public GridDialectType dialect() {
+			return GridDialectType.HASHMAP;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.MAP;
+		}
+	},
+
+	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.utils.InfinispanTestHelper", false, false ) {
+		public GridDialectType dialect() {
+			return GridDialectType.INFINISPAN;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.INFINISPAN;
+		}
+	},
+
+	EHCACHE( "org.hibernate.ogm.datastore.ehcache.utils.EhcacheTestHelper", false, false ) {
+		public GridDialectType dialect() {
+			return GridDialectType.EHCACHE;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.EHCACHE;
+		}
+	},
+
+	MONGODB( "org.hibernate.ogm.datastore.mongodb.utils.MongoDBTestHelper", true, true ) {
+		public GridDialectType dialect() {
+			return GridDialectType.MONGODB;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.MONGODB;
+		}
+
+		public AvailableDatastoreProvider fongoProvider() {
+			return AvailableDatastoreProvider.FONGO;
+		}
+	},
+
+	NEO4J( "org.hibernate.ogm.datastore.neo4j.utils.Neo4jTestHelper", false, true ) {
+		public GridDialectType dialect() {
+			return GridDialectType.NEO4J;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.NEO4J_EMBEDDED;
+		}
+	},
+
+	COUCHDB( "org.hibernate.ogm.datastore.couchdb.utils.CouchDBTestHelper", true, false ) {
+		public GridDialectType dialect() {
+			return GridDialectType.COUCHDB;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.COUCHDB_EXPERIMENTAL;
+		}
+	},
+
+	CASSANDRA( "org.hibernate.ogm.datastore.cassandra.utils.CassandraTestHelper", false, false ) {
+		public GridDialectType dialect() {
+			return GridDialectType.CASSANDRA;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.CASSANDRA_EXPERIMENTAL;
+		}
+	},
+
+	REDIS( "org.hibernate.ogm.datastore.redis.utils.RedisTestHelper", false, false ) {
+		public GridDialectType dialect() {
+			return GridDialectType.REDIS;
+		}
+
+		public AvailableDatastoreProvider provider() {
+			return AvailableDatastoreProvider.REDIS_EXPERIMENTAL;
+		}
+	};
+
+	private final String testHelperClassName;
+	private final boolean isDocumentStore;
+	private final boolean supportsQueries;
+
+	GridModule(String testHelperClassName, boolean isDocumentStore, boolean supportsQueries) {
+		this.testHelperClassName = testHelperClassName;
+		this.isDocumentStore = isDocumentStore;
+		this.supportsQueries = supportsQueries;
+	}
+
+	public Class<TestableGridDialect> loadTestableGridDialectClass() {
+		return TestHelper.loadClass( testHelperClassName );
+	}
+
+	/**
+	 * Whether this store is a document store or not.
+	 *
+	 * @return {@code true} if this is a document store, {@code false} otherwise.
+	 */
+	public boolean isDocumentStore() {
+		return isDocumentStore;
+	}
+
+	/**
+	 * Whether this store supports the execution of queries or not.
+	 *
+	 * @return {@code true} if this store has its own query backend, {@code false} if it uses Hibernate Search for query
+	 * execution.
+	 */
+	public boolean supportsQueries() {
+		return supportsQueries;
+	}
+
+	/**
+	 * @return the default provider type for this grid module.
+	 */
+	public abstract AvailableDatastoreProvider provider();
+
+	/**
+	 * @return the default dialect type for this module.
+	 */
+	public abstract GridDialectType dialect();
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/SkipByDatastoreProvider.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/SkipByDatastoreProvider.java
@@ -24,12 +24,12 @@ import org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider;
 public @interface SkipByDatastoreProvider {
 
 	/**
-	 * The datastore provider(s) on which to skip the test
+	 * The datastore provider(s) on which to skip the test.
 	 */
 	AvailableDatastoreProvider[] value();
 
 	/**
-	 * Optional comment describing the reason for skipping the test
+	 * Optional comment describing the reason for skipping the test.
 	 */
 	String comment() default "";
 

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderClassLevelSelfTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderClassLevelSelfTest.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils.test;
+
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.CASSANDRA_EXPERIMENTAL;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.COUCHDB_EXPERIMENTAL;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.EHCACHE;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.INFINISPAN;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.MAP;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.MONGODB;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.NEO4J_EMBEDDED;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.REDIS_EXPERIMENTAL;
+import static org.junit.Assert.fail;
+
+import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByDatastoreProvider;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link @SkipByDatastoreProvider} given on the class-level is applied.
+ *
+ * @author Mark Paluch
+ */
+@SkipByDatastoreProvider({
+		MAP, INFINISPAN, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
+	})
+public class SkipByDatastoreProviderClassLevelSelfTest extends OgmTestCase {
+
+	@Test
+	public void testWhichAlwaysFails() {
+		fail( "This should never be executed" );
+	}
+
+	@BeforeClass
+	public static void beforeClass() {
+		fail( "This should never be executed" );
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		fail( "This should never be executed" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Hypothesis.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils.test;
+
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.CASSANDRA_EXPERIMENTAL;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.COUCHDB_EXPERIMENTAL;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.INFINISPAN;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.MAP;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.EHCACHE;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.REDIS_EXPERIMENTAL;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.NEO4J_EMBEDDED;
+import static org.hibernate.ogm.datastore.impl.AvailableDatastoreProvider.MONGODB;
+import static org.junit.Assert.fail;
+
+import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
+import org.hibernate.ogm.utils.SkipByDatastoreProvider;
+import org.hibernate.ogm.utils.jpa.JpaTestCase;
+
+import org.junit.Test;
+
+/**
+ * Test {@link SkipByDatastoreProvider} is working with {@link JpaTestCase}
+ *
+ * @author Mark Paluch
+ */
+public class SkipByDatastoreProviderSelfJpaTest extends JpaTestCase {
+
+	@Test
+	@SkipByDatastoreProvider({
+		MAP, INFINISPAN, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
+	})
+	public void testWhichAlwaysFails() {
+		fail( "This should never be executed" );
+	}
+
+	@Test
+	public void testCorrect() {
+		// all fine
+	}
+
+	@Override
+	public Class<?>[] getEntities() {
+		return new Class<?>[] { Hypothesis.class };
+	}
+
+}


### PR DESCRIPTION
* Refactor annotations and testrunner
* Adjust datastore provider lookup within the test to support class names/short names and to deal with type hierarchies
* Add SkipByGridDialect annotation that evaluates the dialect from the configuration