### PR TITLE
OGM-890 Use WildFly Netty module

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
 
         <lettuceCommonsPoolVersion>2.2</lettuceCommonsPoolVersion>
         <lettuceGuavaVersion>17.0</lettuceGuavaVersion>
-        <netty4Version>4.0.28.Final</netty4Version>
+        <netty4Version>4.0.26.Final</netty4Version>
     </properties>
 
     <inceptionYear>2010</inceptionYear>

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -137,11 +137,6 @@
              <unpack>false</unpack>
              <includes>
                  <include>com.datastax.cassandra:cassandra-driver-core</include>
-                 <include>io.netty:netty-buffer</include>
-                 <include>io.netty:netty-codec</include>
-                 <include>io.netty:netty-common</include>
-                 <include>io.netty:netty-transport</include>
-                 <include>io.netty:netty-handler</include>
                  <include>com.codahale.metrics:metrics-core</include>
                  <include>com.google.guava:guava</include>
              </includes>
@@ -162,11 +157,6 @@
              <unpack>false</unpack>
              <includes>
                  <include>biz.paluch.redis:lettuce</include>
-                 <include>io.netty:netty-buffer</include>
-                 <include>io.netty:netty-codec</include>
-                 <include>io.netty:netty-common</include>
-                 <include>io.netty:netty-transport</include>
-                 <include>io.netty:netty-handler</include>
                  <include>org.apache.commons:commons-pool2</include>
               </includes>
        </dependencySet>

--- a/modules/wildfly/src/main/modules/ogm/cassandra-driver/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/cassandra-driver/module.xml
@@ -11,15 +11,12 @@
     </properties>
     <resources>
         <resource-root path="cassandra-driver-core-${cassandraVersion}.jar" />
-        <resource-root path="netty-buffer-${netty4Version}.jar" />
-        <resource-root path="netty-codec-${netty4Version}.jar" />
-        <resource-root path="netty-common-${netty4Version}.jar" />
-        <resource-root path="netty-handler-${netty4Version}.jar" />
-        <resource-root path="netty-transport-${netty4Version}.jar" />
         <resource-root path="metrics-core-${codahaleMetricsVersion}.jar" />
         <resource-root path="guava-${cassandraGuavaVersion}.jar" />
     </resources>
     <dependencies>
+
+        <module name="io.netty" />
 
         <!-- A dependency for metrics-core -->
         <module name="org.slf4j" />

--- a/modules/wildfly/src/main/modules/ogm/redis-driver/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/redis-driver/module.xml
@@ -12,13 +12,10 @@
     <resources>
         <resource-root path="lettuce-${lettuceVersion}.jar" />
         <resource-root path="commons-pool2-${lettuceCommonsPoolVersion}.jar" />
-        <resource-root path="netty-buffer-${netty4Version}.jar" />
-        <resource-root path="netty-codec-${netty4Version}.jar" />
-        <resource-root path="netty-common-${netty4Version}.jar" />
-        <resource-root path="netty-transport-${netty4Version}.jar" />
-        <resource-root path="netty-handler-${netty4Version}.jar" />
     </resources>
     <dependencies>
+
+        <module name="io.netty" />
 
         <!-- A dependency for netty -->
         <module name="org.slf4j" />

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -50,6 +50,35 @@
         <dependency>
             <groupId>biz.paluch.redis</groupId>
             <artifactId>lettuce</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>netty-handler</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>netty-common</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>netty-transport</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <artifactId>netty-handler</artifactId>
+            <groupId>io.netty</groupId>
+            <version>${netty4Version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>netty-common</artifactId>
+            <groupId>io.netty</groupId>
+            <version>${netty4Version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>netty-transport</artifactId>
+            <groupId>io.netty</groupId>
+            <version>${netty4Version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-890

The second commit align the version of Netty for Cassandra and Redis to the one in WildFly.
It is not required but I think it's good to run the unit tests using the same version.
