### PR TITLE
OGM-931 Allowing to persist association to unmanaged entity on inverse side

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
@@ -158,6 +158,10 @@ class EntityAssociationUpdater {
 		}
 		associationPersister.getAssociation().put( rowKey, associationRow );
 
+		if ( associationPersister.getAssociationContext().getEntityTuple() == null ) {
+			throw log.entityTupleNotFound( associationPersister.getAssociationKey().getEntityKey() );
+		}
+
 		associationPersister.flushToDatastore();
 	}
 

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -35,6 +35,8 @@ import org.hibernate.persister.entity.EntityPersister;
  * @author Gunnar Morling
  */
 public class AssociationPersister {
+	private static final Log log = LoggerFactory.make();
+
 	private GridType keyGridType;
 	private Object key;
 	private SessionImplementor session;
@@ -220,7 +222,7 @@ public class AssociationPersister {
 	 * Returns an {@link AssociationContext} to be passed to {@link GridDialect} operations targeting the association
 	 * managed by this persister.
 	 */
-	private AssociationContext getAssociationContext() {
+	public AssociationContext getAssociationContext() {
 		if ( associationContext == null ) {
 			associationContext = new AssociationContextImpl(
 					associationTypeContext,

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -22,6 +22,7 @@ import org.hibernate.TransactionException;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.exception.EntityAlreadyExistsException;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.options.spi.AnnotationConverter;
 import org.hibernate.service.spi.ServiceException;
 import org.jboss.logging.BasicLogger;
@@ -274,4 +275,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 81, value = "The value set for the configuration property '%1$s' must be a long number. Found '%2$s'.")
 	HibernateException notALong(String propertyName, String value);
+
+	@Message(id = 82, value = "The owner of the association cannot be found in the session: %s")
+	HibernateException entityTupleNotFound(EntityKey entityKey);
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -276,6 +276,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 81, value = "The value set for the configuration property '%1$s' must be a long number. Found '%2$s'.")
 	HibernateException notALong(String propertyName, String value);
 
-	@Message(id = 82, value = "The owner of the association cannot be found in the session: %s")
-	HibernateException entityTupleNotFound(EntityKey entityKey);
+	@Message(id = 82, value = "The entity at the inverse side of the association '%1$s' cannot be found in the session: %2$s")
+	HibernateException entityTupleNotFound(String collectionRole, EntityKey entityKey);
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employee.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employee.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.manytoone;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "Employee")
+public class Employee implements Serializable {
+
+	private static final long serialVersionUID = -8732345803771451030L;
+	private String id;
+	private String name;
+	private Employeer employeer;
+
+	@Id
+	@GeneratedValue(generator = "uuid")
+	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@ManyToOne
+	@Cascade(value = { CascadeType.MERGE })
+	@JoinColumn(insertable = true, updatable = true, name = "EmployerID")
+	public Employeer getEmployeer() {
+		return employeer;
+	}
+
+	public void setEmployeer(Employeer employeer) {
+		this.employeer = employeer;
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employee.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employee.java
@@ -9,7 +9,6 @@ package org.hibernate.ogm.backendtck.associations.manytoone;
 import java.io.Serializable;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -17,7 +16,6 @@ import javax.persistence.Table;
 
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "Employee")
@@ -26,11 +24,9 @@ public class Employee implements Serializable {
 	private static final long serialVersionUID = -8732345803771451030L;
 	private String id;
 	private String name;
-	private Employeer employeer;
+	private Employer employer;
 
 	@Id
-	@GeneratedValue(generator = "uuid")
-	@GenericGenerator(name = "uuid", strategy = "uuid2")
 	public String getId() {
 		return id;
 	}
@@ -50,12 +46,12 @@ public class Employee implements Serializable {
 	@ManyToOne
 	@Cascade(value = { CascadeType.MERGE })
 	@JoinColumn(insertable = true, updatable = true, name = "EmployerID")
-	public Employeer getEmployeer() {
-		return employeer;
+	public Employer getEmployer() {
+		return employer;
 	}
 
-	public void setEmployeer(Employeer employeer) {
-		this.employeer = employeer;
+	public void setEmployer(Employer employer) {
+		this.employer = employer;
 	}
 
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employeer.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employeer.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.associations.manytoone;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "Employer")
+public class Employeer implements Serializable {
+
+	private static final long serialVersionUID = -8732345803771451030L;
+	private String id;
+	private String name;
+
+	private Set<Employee> employees = new HashSet<>();
+
+	@Id
+	@GeneratedValue(generator = "uuid")
+	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@OneToMany(fetch = FetchType.EAGER, mappedBy = "employeer")
+	@Cascade({ CascadeType.PERSIST, CascadeType.SAVE_UPDATE, CascadeType.DELETE })
+	public Set<Employee> getEmployees() {
+		return employees;
+	}
+
+	public void setEmployees(Set<Employee> employees) {
+		this.employees = employees;
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employer.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/Employer.java
@@ -12,18 +12,14 @@ import java.util.Set;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import javax.persistence.Table;
 
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
-@Table(name = "Employer")
-public class Employeer implements Serializable {
+public class Employer implements Serializable {
 
 	private static final long serialVersionUID = -8732345803771451030L;
 	private String id;
@@ -32,8 +28,6 @@ public class Employeer implements Serializable {
 	private Set<Employee> employees = new HashSet<>();
 
 	@Id
-	@GeneratedValue(generator = "uuid")
-	@GenericGenerator(name = "uuid", strategy = "uuid2")
 	public String getId() {
 		return id;
 	}
@@ -50,7 +44,7 @@ public class Employeer implements Serializable {
 		this.name = name;
 	}
 
-	@OneToMany(fetch = FetchType.EAGER, mappedBy = "employeer")
+	@OneToMany(fetch = FetchType.EAGER, mappedBy = "employer")
 	@Cascade({ CascadeType.PERSIST, CascadeType.SAVE_UPDATE, CascadeType.DELETE })
 	public Set<Employee> getEmployees() {
 		return employees;

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
@@ -56,10 +56,10 @@ public class ManyToOneTest extends OgmTestCase {
 		session.clear();
 
 		transaction = session.beginTransaction();
-		emmanuel = (Member) session.get( Member.class, emmanuel.getId() );
+		emmanuel = session.get( Member.class, emmanuel.getId() );
 		jug = emmanuel.getMemberOf();
 		session.delete( emmanuel );
-		jerome = (Member) session.get( Member.class, jerome.getId() );
+		jerome = session.get( Member.class, jerome.getId() );
 		session.delete( jerome );
 		session.delete( jug );
 		transaction.commit();
@@ -76,20 +76,22 @@ public class ManyToOneTest extends OgmTestCase {
 		thrown.expect( HibernateException.class );
 		thrown.expectMessage( "OGM000082" );
 
-		Employeer employeer = new Employeer();
-		employeer.setName( "Hibernate" );
+		Employer employer = new Employer();
+		employer.setId( "employer-1" );
+		employer.setName( "Hibernate" );
 
 		Session session = openSession();
 		Transaction transaction = session.beginTransaction();
-		session.save( employeer );
+		session.save( employer );
 		session.flush();
 		transaction.commit();
 		session.clear();
 
 		// Create Employee and Map it with Employeer.
 		Employee employee = new Employee();
+		employee.setId( "employee-1" );
 		employee.setName( "DNadar" );
-		employee.setEmployeer( employeer );
+		employee.setEmployer( employer );
 
 		try {
 			transaction = session.beginTransaction();
@@ -106,7 +108,7 @@ public class ManyToOneTest extends OgmTestCase {
 
 			session = openSession();
 			transaction = session.beginTransaction();
-			session.delete( session.get( Employeer.class, employeer.getId() ) );
+			session.delete( session.get( Employer.class, employer.getId() ) );
 			Employee saved = session.get( Employee.class, employee.getId() );
 			if ( saved != null ) {
 				session.delete( saved );
@@ -145,10 +147,10 @@ public class ManyToOneTest extends OgmTestCase {
 		session.clear();
 
 		transaction = session.beginTransaction();
-		force = (SalesForce) session.get( SalesForce.class, force.getId() );
+		force = session.get( SalesForce.class, force.getId() );
 		assertNotNull( force.getSalesGuys() );
 		assertEquals( 2, force.getSalesGuys().size() );
-		simon = (SalesGuy) session.get( SalesGuy.class, simon.getId() );
+		simon = session.get( SalesGuy.class, simon.getId() );
 		// purposely faulty
 		// force.getSalesGuys().remove( simon );
 		session.delete( simon );
@@ -156,7 +158,7 @@ public class ManyToOneTest extends OgmTestCase {
 		session.clear();
 
 		transaction = session.beginTransaction();
-		force = (SalesForce) session.get( SalesForce.class, force.getId() );
+		force = session.get( SalesForce.class, force.getId() );
 		assertNotNull( force.getSalesGuys() );
 		assertEquals( 1, force.getSalesGuys().size() );
 		session.delete( force.getSalesGuys().iterator().next() );
@@ -190,16 +192,16 @@ public class ManyToOneTest extends OgmTestCase {
 
 		// removing one sales guy, leaving the other in place
 		transaction = session.beginTransaction();
-		force = (SalesForce) session.get( SalesForce.class, force.getId() );
+		force = session.get( SalesForce.class, force.getId() );
 		assertEquals( 2, force.getSalesGuys().size() );
-		SalesGuy salesGuy = (SalesGuy) session.get( SalesGuy.class, eric.getId() );
+		SalesGuy salesGuy = session.get( SalesGuy.class, eric.getId() );
 		salesGuy.setSalesForce( null );
 		force.getSalesGuys().remove( salesGuy );
 		transaction.commit();
 		session.clear();
 
 		transaction = session.beginTransaction();
-		force = (SalesForce) session.get( SalesForce.class, force.getId() );
+		force = session.get( SalesForce.class, force.getId() );
 		assertEquals( 1, force.getSalesGuys().size() );
 		salesGuy = force.getSalesGuys().iterator().next();
 		assertThat( salesGuy.getName() ).isEqualTo( "Simon" );
@@ -293,11 +295,11 @@ public class ManyToOneTest extends OgmTestCase {
 
 		transaction = session.beginTransaction();
 
-		SalesGuy salesGuy = (SalesGuy) session.get( SalesGuy.class, "eric" );
+		SalesGuy salesGuy = session.get( SalesGuy.class, "eric" );
 		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
 		session.delete( salesGuy );
 
-		salesGuy = (SalesGuy) session.get( SalesGuy.class, "simon" );
+		salesGuy = session.get( SalesGuy.class, "simon" );
 		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
 		session.delete( salesGuy );
 
@@ -337,7 +339,7 @@ public class ManyToOneTest extends OgmTestCase {
 		session.clear();
 
 		transaction = session.beginTransaction();
-		Court localCourt = (Court) session.get( Court.class, new Court.CourtId( "DE", 123 ) );
+		Court localCourt = session.get( Court.class, new Court.CourtId( "DE", 123 ) );
 		assertThat( localCourt.getGames() ).hasSize( 2 );
 		for ( Game game : localCourt.getGames() ) {
 			session.delete( game );
@@ -361,7 +363,7 @@ public class ManyToOneTest extends OgmTestCase {
 				Game.class,
 				Court.class,
 				Employee.class,
-				Employeer.class
+				Employer.class
 		};
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -173,7 +173,6 @@ public class TestHelper {
 		return helper.backendSupportsTransactions();
 	}
 
-	@SuppressWarnings("unchecked")
 	public static <T> T get(Session session, Class<T> clazz, Serializable id) {
 		return session.get( clazz, id );
 	}


### PR DESCRIPTION
Supersedes #597: No exception anymore, instead the associated entity is loaded to make the same flow of execution work as in ORM.