### PR TITLE
OGM-900 adding support for "dotted" collection names

### DIFF
--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
@@ -71,7 +71,7 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 	@SuppressSubnodes
 	public Rule Collection() {
 		return Sequence( OneOrMore( TestNot( Reserved() ), ANY ), builder.setCollection( match() ) );
-		//TODO it should not be just ANY matcher as they are some restrictions in the Collection naming in Mongo
+		//TODO OGM-949 it should not be just ANY matcher as they are some restrictions in the Collection naming in Mongo
 		// cf. https://docs.mongodb.org/manual/faq/developers/#are-there-any-restrictions-on-the-names-of-collections
 	}
 
@@ -81,10 +81,7 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 	}
 
 	public Rule Reserved() {
-		return FirstOf(
-				Sequence( Find(), builder.setOperation( Operation.FIND ) ),
-				Sequence( Count(), builder.setOperation( Operation.COUNT ) )
-		);
+		return FirstOf( Find(), Count() );
 		//TODO there is many more than `find` an `count` but as this time we only support `find` and `count`
 	}
 

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/CollectionNamingValidationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/datastore/CollectionNamingValidationTest.java
@@ -14,6 +14,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.MappingException;
+import org.hibernate.ogm.OgmSessionFactory;
 import org.hibernate.ogm.utils.TestForIssue;
 import org.hibernate.ogm.utils.TestHelper;
 import org.junit.Assert;
@@ -53,6 +54,14 @@ public class CollectionNamingValidationTest {
 		assertTableCausesException( DollarNamedTable.class, "OGM001222" );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "OGM-900")
+	public void shouldSupportDotInCollectionName() {
+		OgmSessionFactory ogmSessionFactory = TestHelper.getDefaultTestSessionFactory( DottedNamedTable.class );
+		assertThat( ogmSessionFactory.getAllClassMetadata().containsKey( DottedNamedTable.class.getName() ));
+	}
+
+
 	private void assertTableCausesException(Class<?> mappedType, String expectedExceptionPrefix) {
 		try {
 			TestHelper.getDefaultTestSessionFactory( mappedType );
@@ -87,6 +96,11 @@ public class CollectionNamingValidationTest {
 	public static class InvalidColumnsTable {
 		@Id Long id;
 		@Column(name = "$DOLLARS") String field;
+	}
+
+	@Entity @Table(name = "table.with.dot")
+	public static class DottedNamedTable {
+		@Id Long id;
 	}
 
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/nativequery/NativeQueryParserTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/nativequery/NativeQueryParserTest.java
@@ -12,6 +12,7 @@ import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor.Operation;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.MongoDBQueryDescriptorBuilder;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.NativeQueryParser;
+import org.hibernate.ogm.utils.TestForIssue;
 import org.junit.Test;
 import org.parboiled.Parboiled;
 import org.parboiled.parserunners.RecoveringParseRunner;
@@ -279,4 +280,21 @@ public class NativeQueryParserTest {
 		assertThat( queryDescriptor.getProjection() ).isNull();
 		assertThat( queryDescriptor.getOrderBy() ).isNull();
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-900")
+	public void shouldSupportDotInCollectionName() {
+		NativeQueryParser parser = Parboiled.createParser( NativeQueryParser.class );
+		ParsingResult<MongoDBQueryDescriptorBuilder> run =  new RecoveringParseRunner<MongoDBQueryDescriptorBuilder>( parser.Query() )
+				.run( "db.POEM.COM.count()");
+
+		MongoDBQueryDescriptor queryDescriptor = run.resultValue.build();
+
+		assertThat( queryDescriptor.getCollectionName() ).isEqualTo( "POEM.COM" );
+		assertThat( queryDescriptor.getOperation() ).isEqualTo( Operation.COUNT );
+		assertThat( queryDescriptor.getProjection() ).isNull();
+		assertThat( queryDescriptor.getOrderBy() ).isNull();
+	}
+
+
 }


### PR DESCRIPTION
* refactored the `NativeQueryParser`  `parboiled`'s rules to look for dots as prefix of reserved keywords
* added an `OGM-900` Unit test: `NativeQueryParserTest.shouldSupportDotInCollectionName()`
* added `TODOs` and javadoc on these points:
  * the parser will fail detecting non supported API : currently we only support `find` and/or `count`
  * mongo collection names have some naming restrictions (cf. https://docs.mongodb.org/manual/faq/developers/#are-there-any-restrictions-on-the-names-of-collections) not reflected in our implementations