### PR TITLE
OGM-962 Fix Yes/No and True/False type mapping in Cassandra

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -132,6 +132,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.takari.junit</groupId>
             <artifactId>takari-cpsuite</artifactId>
             <scope>test</scope>

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/model/impl/ResultSetTupleIterator.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/model/impl/ResultSetTupleIterator.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.ogm.datastore.cassandra.model.impl;
 
-import com.datastax.driver.core.ResultSet;
-
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.model.spi.Tuple;
+
+import com.datastax.driver.core.ResultSet;
 
 /**
  * Wraps Cassandra java-driver ResultSet.
@@ -48,5 +48,10 @@ public class ResultSetTupleIterator implements ClosableIterator<Tuple> {
 	public Tuple next() {
 		count++;
 		return new Tuple( new ResultSetTupleSnapshot( resultSet.one() ) );
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CassandraTrueFalseType.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CassandraTrueFalseType.java
@@ -8,7 +8,6 @@ package org.hibernate.ogm.datastore.cassandra.type.impl;
 
 import org.hibernate.MappingException;
 import org.hibernate.engine.spi.Mapping;
-import org.hibernate.ogm.type.descriptor.impl.StringMappedGridTypeDescriptor;
 import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
 
 /**
@@ -21,7 +20,7 @@ public class CassandraTrueFalseType extends AbstractGenericBasicType<Boolean> {
 	public static final CassandraTrueFalseType INSTANCE = new CassandraTrueFalseType();
 
 	public CassandraTrueFalseType() {
-		super( StringMappedGridTypeDescriptor.INSTANCE, org.hibernate.type.TrueFalseType.INSTANCE.getJavaTypeDescriptor() );
+		super( CharacterStringGridTypeDescriptor.INSTANCE, org.hibernate.type.TrueFalseType.INSTANCE.getJavaTypeDescriptor() );
 	}
 
 	@Override

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CassandraYesNoType.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CassandraYesNoType.java
@@ -8,7 +8,6 @@ package org.hibernate.ogm.datastore.cassandra.type.impl;
 
 import org.hibernate.MappingException;
 import org.hibernate.engine.spi.Mapping;
-import org.hibernate.ogm.type.descriptor.impl.StringMappedGridTypeDescriptor;
 import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
 
 /**
@@ -21,7 +20,7 @@ public class CassandraYesNoType extends AbstractGenericBasicType<Boolean> {
 	public static final CassandraYesNoType INSTANCE = new CassandraYesNoType();
 
 	public CassandraYesNoType() {
-		super( StringMappedGridTypeDescriptor.INSTANCE, org.hibernate.type.YesNoType.INSTANCE.getJavaTypeDescriptor() );
+		super( CharacterStringGridTypeDescriptor.INSTANCE, org.hibernate.type.YesNoType.INSTANCE.getJavaTypeDescriptor() );
 	}
 
 	@Override

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CharacterStringGridTypeDescriptor.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/type/impl/CharacterStringGridTypeDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.cassandra.type.impl;
+
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.type.descriptor.impl.BasicGridBinder;
+import org.hibernate.ogm.type.descriptor.impl.GridTypeDescriptor;
+import org.hibernate.ogm.type.descriptor.impl.GridValueBinder;
+import org.hibernate.ogm.type.descriptor.impl.GridValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
+/**
+ * Cassandra doesn't support the {@code Character} type natively,
+ * so we wrap characters into strings.
+ *
+ * @author Nicola Ferraro
+ */
+public class CharacterStringGridTypeDescriptor implements GridTypeDescriptor {
+	public static final CharacterStringGridTypeDescriptor INSTANCE = new CharacterStringGridTypeDescriptor();
+
+	@Override
+	public <X> GridValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new BasicGridBinder<X>( javaTypeDescriptor, this ) {
+
+			@Override
+			protected void doBind(Tuple resultset, X value, String[] names, WrapperOptions options) {
+				Character ch = javaTypeDescriptor.unwrap( value, Character.class, options );
+				resultset.put( names[0], String.valueOf( ch ) );
+			}
+		};
+	}
+
+	@Override
+	public <X> GridValueExtractor<X> getExtractor(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new GridValueExtractor<X>() {
+
+			@Override
+			public X extract(Tuple resultset, String name) {
+
+				X result = (X) resultset.get( name );
+
+				if ( result == null ) {
+					return null;
+				}
+				else {
+					String chString = (String) result;
+					Character ch = chString.charAt( 0 );
+					return javaTypeDescriptor.wrap( ch, null );
+				}
+			}
+		};
+	}
+
+}

--- a/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/mapping/CassandraBooleanCharacterTypeTest.java
+++ b/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/mapping/CassandraBooleanCharacterTypeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.cassandra.test.mapping;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.ogm.datastore.cassandra.type.impl.CassandraTrueFalseType;
+import org.hibernate.ogm.datastore.cassandra.type.impl.CassandraYesNoType;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.type.descriptor.impl.GridValueBinder;
+import org.hibernate.ogm.type.descriptor.impl.GridValueExtractor;
+import org.junit.Test;
+
+/**
+ * Tests that 'yes_no' and 'true_false' types are correctly mapped to single-character strings.
+ *
+ * @author Nicola Ferraro
+ */
+public class CassandraBooleanCharacterTypeTest {
+
+	@Test
+	public void testYesNoTypeMapping() {
+
+		CassandraYesNoType type = new CassandraYesNoType();
+		GridValueBinder<Boolean> binder = type.getGridTypeDescriptor().getBinder( type.getJavaTypeDescriptor() );
+		GridValueExtractor<Boolean> extractor = type.getGridTypeDescriptor().getExtractor( type.getJavaTypeDescriptor() );
+
+		Tuple resultSet = mock( Tuple.class );
+
+		binder.bind( resultSet, true, new String[]{ "column" } );
+		verify( resultSet ).put( "column", "Y" );
+
+		binder.bind( resultSet, false, new String[]{ "column" } );
+		verify( resultSet ).put( "column", "N" );
+
+		when( resultSet.get( anyString() ) ).thenReturn( "Y" );
+		assertTrue( extractor.extract( resultSet, "column" ) );
+
+		when( resultSet.get( anyString() ) ).thenReturn( "N" );
+		assertFalse( extractor.extract( resultSet, "column" ) );
+	}
+
+	@Test
+	public void testTrueFalseTypeMapping() {
+
+		CassandraTrueFalseType type = new CassandraTrueFalseType();
+		GridValueBinder<Boolean> binder = type.getGridTypeDescriptor().getBinder( type.getJavaTypeDescriptor() );
+		GridValueExtractor<Boolean> extractor = type.getGridTypeDescriptor().getExtractor( type.getJavaTypeDescriptor() );
+
+		Tuple resultSet = mock( Tuple.class );
+
+		binder.bind( resultSet, true, new String[]{ "column" } );
+		verify( resultSet ).put( "column", "T" );
+
+		binder.bind( resultSet, false, new String[]{ "column" } );
+		verify( resultSet ).put( "column", "F" );
+
+		when( resultSet.get( anyString() ) ).thenReturn( "T" );
+		assertTrue( extractor.extract( resultSet, "column" ) );
+
+		when( resultSet.get( anyString() ) ).thenReturn( "F" );
+		assertFalse( extractor.extract( resultSet, "column" ) );
+	}
+
+}


### PR DESCRIPTION
Boolean types mapped to Yes/No or True/False should be mapped to 'Y'/'N' or 'T'/'F' characters. Since Cassandra does not currently support the character data type, they should be single character strings. 
There is evidence in the code that this was the expected mapping, anyway, that fields are incorrectly mapped to "true" or "false" (strings).

I've implemented the change to fix the behavior and written unit tests. I added mockito to the pom test dependencies.

As suggested by @gunnarmorling, I've tried using the TranslatingGridTypeDescriptor to fix the issue, without success.