### PR TITLE
[PREVIEW] OGM-366 Transaction context 

### DIFF
--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -44,6 +44,7 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
@@ -493,7 +494,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 
 	@Override
 	public ClosableIterator<Tuple> executeBackendQuery(
-			BackendQuery<String> query, QueryParameters queryParameters) {
+			BackendQuery<String> query, QueryParameters queryParameters, QueryContext queryContext) {
 
 		Object[] parameters = new Object[queryParameters.getPositionalParameters().size()];
 		int i = 0;
@@ -524,7 +525,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters) {
+	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters, QueryContext queryContext) {
 		// TODO implement. org.hibernate.ogm.datastore.mongodb.MongoDBDialect.executeBackendUpdateQuery(BackendQuery<MongoDBQueryDescriptor>, QueryParameters) might be helpful as a reference.
 		throw new UnsupportedOperationException("Not yet implemented.");
 	}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
@@ -10,6 +10,7 @@ import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.util.impl.Contracts;
@@ -25,21 +26,26 @@ public class AssociationContextImpl implements AssociationContext {
 	private final AssociationTypeContext associationTypeContext;
 	private final OperationsQueue operationsQueue;
 	private final Tuple entityTuple;
+	private final TransactionContext transactionContext;
 
-	public AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple) {
-		this( associationTypeContext, entityTuple, null );
+	public AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple, TransactionContext transactionContext) {
+		this( associationTypeContext, entityTuple, null, transactionContext );
 	}
 
 	public AssociationContextImpl(AssociationContextImpl original, OperationsQueue operationsQueue) {
-		this( original.associationTypeContext, original.entityTuple, operationsQueue );
+		this( original.associationTypeContext, original.entityTuple, operationsQueue, original.transactionContext );
 	}
 
-	private AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple, OperationsQueue operationsQueue) {
+	private AssociationContextImpl(AssociationTypeContext associationTypeContext,
+			Tuple entityTuple,
+			OperationsQueue operationsQueue,
+			TransactionContext transactionContext) {
 		Contracts.assertParameterNotNull( associationTypeContext, "associationTypeContext" );
 
 		this.associationTypeContext = associationTypeContext;
 		this.entityTuple = entityTuple;
 		this.operationsQueue = operationsQueue;
+		this.transactionContext = transactionContext;
 	}
 
 	@Override
@@ -50,6 +56,11 @@ public class AssociationContextImpl implements AssociationContext {
 	@Override
 	public OperationsQueue getOperationsQueue() {
 		return operationsQueue;
+	}
+
+	@Override
+	public TransactionContext getTransactionContext() {
+		return transactionContext;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -29,6 +29,7 @@ import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
@@ -181,13 +182,13 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	 */
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters) {
-		return queryableGridDialect.executeBackendQuery( query, queryParameters );
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters, QueryContext queryContext) {
+		return queryableGridDialect.executeBackendQuery( query, queryParameters, queryContext );
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters) {
-		return queryableGridDialect.executeBackendUpdateQuery( query, queryParameters );
+	public int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters, QueryContext queryContext) {
+		return queryableGridDialect.executeBackendUpdateQuery( query, queryParameters, queryContext );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
@@ -18,6 +18,7 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
@@ -139,8 +140,8 @@ public class GridDialectLogger extends ForwardingGridDialect<Serializable> {
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters) {
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters, QueryContext queryContext) {
 		log.tracef( "Executing backend query: %1$s", query.getQuery() );
-		return super.executeBackendQuery( query, queryParameters );
+		return super.executeBackendQuery( query, queryParameters, queryContext );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/IdentifiableDriver.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/IdentifiableDriver.java
@@ -4,12 +4,14 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.ogm.dialect.spi;
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
 
 /**
  * @author Davide D'Alto
  */
-public interface TransactionContext {
+public interface IdentifiableDriver extends TransactionDriver {
 
 	Long getTransactionId();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/QueryContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/QueryContextImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.ogm.dialect.spi.QueryContext;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+
+/**
+ * @author Davide D'Alto
+ */
+public class QueryContextImpl implements QueryContext {
+
+	private final TransactionContext transactionContext;
+
+	public QueryContextImpl(TransactionContext transactionContext) {
+		this.transactionContext = transactionContext;
+	}
+
+	@Override
+	public TransactionContext getTransactionContext() {
+		return transactionContext;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
+
+/**
+ * @author Davide D'Alto
+ */
+public class TransactionContextImpl implements TransactionContext {
+
+	private final TransactionDriver driver;
+
+	public TransactionContextImpl(TransactionDriver driver) {
+		this.driver = driver;
+	}
+
+	@Override
+	public TransactionDriver getTransactionDriver() {
+		return driver;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
@@ -7,21 +7,20 @@
 package org.hibernate.ogm.dialect.impl;
 
 import org.hibernate.ogm.dialect.spi.TransactionContext;
-import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
 
 /**
  * @author Davide D'Alto
  */
 public class TransactionContextImpl implements TransactionContext {
 
-	private final TransactionDriver driver;
+	private final IdentifiableDriver driver;
 
-	public TransactionContextImpl(TransactionDriver driver) {
+	public TransactionContextImpl(IdentifiableDriver driver) {
 		this.driver = driver;
 	}
 
 	@Override
-	public TransactionDriver getTransactionDriver() {
-		return driver;
+	public Long getTransactionId() {
+		return driver.getTransactionId();
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.options.spi.OptionsContext;
@@ -27,6 +28,7 @@ public class TupleContextImpl implements TupleContext {
 	private final List<String> selectableColumns;
 	private final OptionsContext optionsContext;
 	private final OperationsQueue operationsQueue;
+	private final TransactionContext transactionContext;
 
 	/**
 	 * Information of the associated entity stored per foreign key column names
@@ -36,19 +38,30 @@ public class TupleContextImpl implements TupleContext {
 	private final Map<String, String> roles;
 
 	public TupleContextImpl(TupleContextImpl original, OperationsQueue operationsQueue) {
-		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, operationsQueue );
+		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, operationsQueue, original.transactionContext );
 	}
 
-	public TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext) {
-		this( selectableColumns, associatedEntityMetadata, roles, optionsContext, null );
+	public TupleContextImpl(TupleContextImpl original, TransactionContext transactionContext) {
+		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, original.operationsQueue, transactionContext );
 	}
 
-	private TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext, OperationsQueue operationsQueue) {
+	public TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext, TransactionContext transactionContext) {
+		this( selectableColumns, associatedEntityMetadata, roles, optionsContext, null, transactionContext );
+	}
+
+	private TupleContextImpl(List<String> selectableColumns,
+			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
+			Map<String, String> roles,
+			OptionsContext optionsContext,
+			OperationsQueue operationsQueue,
+			TransactionContext transactionContext) {
+
 		this.selectableColumns = selectableColumns;
 		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
 		this.roles = Collections.unmodifiableMap( roles );
 		this.optionsContext = optionsContext;
 		this.operationsQueue = operationsQueue;
+		this.transactionContext = transactionContext;
 	}
 
 	@Override
@@ -59,6 +72,11 @@ public class TupleContextImpl implements TupleContext {
 	@Override
 	public OptionsContext getOptionsContext() {
 		return optionsContext;
+	}
+
+	@Override
+	public TransactionContext getTransactionContext() {
+		return transactionContext;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/BackendQuery.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/BackendQuery.java
@@ -10,7 +10,7 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 
 /**
  * Represents a NoSQL query as to be executed via
- * {@link QueryableGridDialect#executeBackendQuery(BackendQuery, QueryParameters)}.
+ * {@link QueryableGridDialect#executeBackendQuery(BackendQuery, QueryParameters, org.hibernate.ogm.dialect.spi.QueryContext)}
  * <p>
  * The wrapped query object generally represents the query in the native form supported by a given datastore, e.g. a
  * String in a native query syntax or an object-based query representation such as the {@code DBObject}-based query

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryableGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryableGridDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.dialect.query.spi;
 import java.io.Serializable;
 
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.model.spi.Tuple;
 
 /**
@@ -29,7 +30,7 @@ public interface QueryableGridDialect<T extends Serializable> extends GridDialec
 	 * @param queryParameters parameters passed for this query
 	 * @return an {@link ClosableIterator} with the result of the query
 	 */
-	ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters);
+	ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters, QueryContext queryContext);
 
 	/**
 	 * Returns the result of a native update query executed on the backend.
@@ -45,7 +46,7 @@ public interface QueryableGridDialect<T extends Serializable> extends GridDialec
 	 * @param queryParameters parameters passed for this query
 	 * @return the number of elements that have been updated.
 	 */
-	int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters);
+	int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters, QueryContext queryContext);
 
 	/**
 	 * Returns a builder for retrieving parameter meta-data from native queries in this datastore's format.

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
@@ -40,4 +40,11 @@ public interface AssociationContext {
 	 * @return A tuple representing the entity on the current side of the association
 	 */
 	Tuple getEntityTuple();
+
+	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/QueryContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/QueryContext.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.spi;
+
+/**
+ * Provides information to {@link GridDialect}s related to a query.
+ *
+ * @author Davide D'Alto
+ */
+public interface QueryContext {
+
+	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TransactionContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TransactionContext.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.spi;
+
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
+
+/**
+ * @author Davide D'Alto
+ */
+public interface TransactionContext {
+
+	TransactionDriver getTransactionDriver();
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
@@ -29,6 +29,13 @@ public interface TupleContext {
 	OptionsContext getOptionsContext();
 
 	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
+
+	/**
 	 * Returns the mapped columns of the given entity. May be used by a dialect to only load those columns instead of
 	 * the complete document/record. If the dialect supports the embedded storage of element collections and
 	 * associations, the respective columns will be part of the returned list as well.

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/BackendCustomLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/BackendCustomLoader.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.hibernatecore.impl;
 
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -21,6 +23,7 @@ import org.hibernate.loader.custom.CustomQuery;
 import org.hibernate.loader.custom.Return;
 import org.hibernate.loader.custom.RootReturn;
 import org.hibernate.loader.custom.ScalarReturn;
+import org.hibernate.ogm.dialect.impl.QueryContextImpl;
 import org.hibernate.ogm.dialect.query.spi.BackendQuery;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
@@ -83,7 +86,7 @@ public class BackendCustomLoader extends CustomLoader {
 
 	@Override
 	protected List<?> list(SessionImplementor session, org.hibernate.engine.spi.QueryParameters queryParameters, Set querySpaces, Type[] resultTypes) throws HibernateException {
-		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
+		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( session, QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
 		try {
 			if ( isEntityQuery() ) {
 				return listOfEntities( session, resultTypes, tuples );
@@ -182,8 +185,8 @@ public class BackendCustomLoader extends CustomLoader {
 			);
 		}
 
-		public ClosableIterator<Tuple> executeQuery(QueryParameters queryParameters) {
-			return gridDialect.executeBackendQuery( query, queryParameters );
+		public ClosableIterator<Tuple> executeQuery(SessionImplementor session, QueryParameters queryParameters) {
+			return gridDialect.executeBackendQuery( query, queryParameters, new QueryContextImpl( transactionContext( session ) ) );
 		}
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -568,7 +568,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 					keys[index] = EntityKeyBuilder.fromPersister( persister, (Serializable) qp.getPositionalParameterValues()[index], session );
 				}
 				if ( multigetGridDialect != null ) {
-					for ( Tuple tuple : multigetGridDialect.getTuples( keys, persister.getTupleContext() ) ) {
+					for ( Tuple tuple : multigetGridDialect.getTuples( keys, persister.getTupleContext( session ) ) ) {
 						if ( tuple != null ) {
 							resultset.addTuple( tuple );
 						}
@@ -576,7 +576,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				}
 				else {
 					for ( EntityKey entityKey : keys ) {
-						Tuple entry = gridDialect.getTuple( entityKey, persister.getTupleContext() );
+						Tuple entry = gridDialect.getTuple( entityKey, persister.getTupleContext( session ) );
 						if ( entry != null ) {
 							resultset.addTuple( entry );
 						}
@@ -585,7 +585,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 			}
 			else {
 				final EntityKey key = EntityKeyBuilder.fromPersister( persister, id, session );
-				Tuple entry = gridDialect.getTuple( key, persister.getTupleContext() );
+				Tuple entry = gridDialect.getTuple( key, persister.getTupleContext( session ) );
 				if ( entry != null ) {
 					resultset.addTuple( entry );
 				}

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -621,7 +621,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			OgmEntityPersister persister = (OgmEntityPersister) getElementPersister();
 			final EntityKey entityKey = EntityKeyBuilder.fromPersister( persister, entityId, session );
 
-			final Tuple entityTuple = gridDialect.getTuple( entityKey, persister.getTupleContext() );
+			final Tuple entityTuple = gridDialect.getTuple( entityKey, persister.getTupleContext( session ) );
 			// the entity tuple could already be gone (not 100% sure this can happen but that feels right)
 			if ( entityTuple == null ) {
 				return;
@@ -640,7 +640,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			else {
 				throw new AssertionFailure( "Unknown action type: " + action );
 			}
-			gridDialect.insertOrUpdateTuple( entityKey, entityTuple, persister.getTupleContext() );
+			gridDialect.insertOrUpdateTuple( entityKey, entityTuple, persister.getTupleContext( session ) );
 		}
 		else if ( associationType == AssociationType.ASSOCIATION_TABLE_TO_ENTITY ) {
 			String[] elementColumnNames = getElementColumnNames();

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -77,6 +77,7 @@ import org.hibernate.ogm.util.impl.ArrayHelper;
 import org.hibernate.ogm.util.impl.AssociationPersister;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
+import org.hibernate.ogm.util.impl.TransactionContextHelper;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.Joinable;
@@ -84,6 +85,7 @@ import org.hibernate.persister.entity.Loadable;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
+import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tuple.GenerationTiming;
 import org.hibernate.tuple.NonIdentifierAttribute;
@@ -188,7 +190,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 	 * A context with additional meta-data to be passed to grid dialect operations relating to the entity type
 	 * represented by this persister.
 	 */
-	private TupleContext tupleContext;
+	private TupleContextImpl tupleContext;
 
 	OgmEntityPersister(
 			final PersistentClass persistentClass,
@@ -527,7 +529,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		tupleContext = createTupleContext();
 	}
 
-	private TupleContext createTupleContext() {
+	private TupleContextImpl createTupleContext() {
 		Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata = newHashMap();
 		Map<String, String> roles = newHashMap();
 
@@ -548,7 +550,8 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				selectableColumnNames( discriminator ),
 				associatedEntityKeyMetadata,
 				roles,
-				optionsService.context().getEntityOptions( getMappedClass() )
+				optionsService.context().getEntityOptions( getMappedClass() ),
+				null
 		);
 	}
 
@@ -599,7 +602,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 	private Tuple getResultsetById(Serializable id, SessionImplementor session) {
 		final EntityKey key = EntityKeyBuilder.fromPersister( this, id, session );
-		final Tuple resultset = gridDialect.getTuple( key, this.getTupleContext() );
+		final Tuple resultset = gridDialect.getTuple( key, getTupleContext( session ) );
 		return resultset;
 	}
 
@@ -705,10 +708,10 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		 * TODO should we use cache.replace() it seems more expensive to pass the resultset around "just" the atomicity of the operation
 		 */
 		final EntityKey key = EntityKeyBuilder.fromPersister( this, id, session );
-		final Tuple resultset = gridDialect.getTuple( key, getTupleContext() );
+		final Tuple resultset = gridDialect.getTuple( key, getTupleContext( session ) );
 		checkVersionAndRaiseSOSE( id, currentVersion, session, resultset );
 		gridVersionType.nullSafeSet( resultset, nextVersion, new String[] { getVersionColumnName() }, session );
-		gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext() );
+		gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext( session ) );
 		return nextVersion;
 	}
 
@@ -1129,7 +1132,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				Tuple resultset = null;
 
 				if ( mightRequireInverseAssociationManagement || usesNonAtomicOptimisticLocking ) {
-					resultset = gridDialect.getTuple( key, getTupleContext() );
+					resultset = gridDialect.getTuple( key, getTupleContext( session ) );
 				}
 				else {
 					OgmEntityEntryState extraState = entry.getExtraState( OgmEntityEntryState.class );
@@ -1137,7 +1140,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 						resultset = extraState.getTuple();
 					}
 					if ( resultset == null ) {
-						resultset = gridDialect.getTuple( key, getTupleContext() );
+						resultset = gridDialect.getTuple( key, getTupleContext( session ) );
 					}
 				}
 
@@ -1193,7 +1196,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 					Tuple oldVersionTuple = new Tuple();
 					oldVersionTuple.put( getVersionColumnName(), oldVersion );
 
-					boolean success = optimisticLockingAwareGridDialect.updateTupleWithOptimisticLock( key, oldVersionTuple, resultset, getTupleContext() );
+					boolean success = optimisticLockingAwareGridDialect.updateTupleWithOptimisticLock( key, oldVersionTuple, resultset, getTupleContext( session ) );
 
 					// If there is an error handler registered, pass the applied/failed operation to it as needed
 					if ( success ) {
@@ -1216,7 +1219,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 					}
 				}
 				else {
-					gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext() );
+					gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext( session ) );
 				}
 
 				if ( mightRequireInverseAssociationManagement ) {
@@ -1323,7 +1326,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		//insert operations are always dynamic in OGM
 		boolean[] propertiesToInsert = getPropertiesToInsert( fields );
 
-		Tuple tuple = identityColumnAwareGridDialect.createTuple( entityKeyMetadata, getTupleContext() );
+		Tuple tuple = identityColumnAwareGridDialect.createTuple( entityKeyMetadata, getTupleContext( session ) );
 
 		// add the discriminator
 		if ( discriminator.isNeeded() ) {
@@ -1332,7 +1335,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 		// dehydrate
 		dehydrate( tuple, fields, propertiesToInsert, 0, null, session );
-		identityColumnAwareGridDialect.insertTuple( entityKeyMetadata, tuple, getTupleContext() );
+		identityColumnAwareGridDialect.insertTuple( entityKeyMetadata, tuple, getTupleContext( session ) );
 		Serializable id = (Serializable) getGridIdentifierType().hydrate( tuple, getIdentifierColumnNames(), session, object );
 		addToInverseAssociations( tuple, 0, id, session );
 
@@ -1377,7 +1380,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			Tuple resultset = null;
 
 			if ( duplicateInsertPreventionStrategy == DuplicateInsertPreventionStrategy.LOOK_UP ) {
-				resultset = gridDialect.getTuple( key, this.getTupleContext() );
+				resultset = gridDialect.getTuple( key, this.getTupleContext( session ) );
 
 				if ( j == 0 && resultset != null ) {
 					if ( invocationCollectingGridDialect == null ) {
@@ -1404,7 +1407,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			dehydrate( resultset, fields, propertiesToInsert, j, id, session );
 
 			try {
-				gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext() );
+				gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext( session ) );
 			}
 			catch ( TupleAlreadyExistsException taee ) {
 				throw log.mustNotInsertSameEntityTwice( MessageHelper.infoString( this, id, getFactory() ), taee );
@@ -1432,7 +1435,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			Serializable id,
 			SessionImplementor session) {
 		if (resultset == null) {
-			resultset = gridDialect.createTuple( key, getTupleContext() );
+			resultset = gridDialect.createTuple( key, getTupleContext( session ) );
 			gridIdentifierType.nullSafeSet( resultset, id, getIdentifierColumnNames(), session );
 		}
 		return resultset;
@@ -1461,7 +1464,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		Tuple currentState = null;
 
 		if ( mightRequireInverseAssociationManagement || usesNonAtomicOptimisticLocking ) {
-			currentState = gridDialect.getTuple( key, getTupleContext() );
+			currentState = gridDialect.getTuple( key, getTupleContext( session ) );
 		}
 
 		if ( usesNonAtomicOptimisticLocking ) {
@@ -1495,7 +1498,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				Tuple versionTuple = new Tuple();
 				versionTuple.put( getVersionColumnName(), version );
 
-				boolean success = optimisticLockingAwareGridDialect.removeTupleWithOptimisticLock( key, versionTuple, getTupleContext() );
+				boolean success = optimisticLockingAwareGridDialect.removeTupleWithOptimisticLock( key, versionTuple, getTupleContext( session ) );
 
 				// If there is an error handler registered, pass the applied/failed operation to it as needed
 				if ( success ) {
@@ -1518,7 +1521,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				}
 			}
 			else {
-				gridDialect.removeTuple( key, getTupleContext() );
+				gridDialect.removeTuple( key, getTupleContext( session ) );
 			}
 		}
 	}
@@ -1741,8 +1744,17 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		return spaces;
 	}
 
-	public TupleContext getTupleContext() {
-		return tupleContext;
+	/**
+	 * Returns the {@link TupleContext}.
+	 *
+	 * @param session the current session, if null the {@link TupleContext#getTransactionContext()} will be null.
+	 * @return the tupleContext for the session
+	 */
+	public TupleContext getTupleContext( SessionImplementor session ) {
+		if ( session == null ) {
+			return tupleContext;
+		}
+		return new TupleContextImpl( tupleContext, TransactionContextHelper.transactionContext( session ) );
 	}
 
 	public String getJpaEntityName() {

--- a/core/src/main/java/org/hibernate/ogm/query/impl/OgmQueryLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/query/impl/OgmQueryLoader.java
@@ -5,6 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.ogm.query.impl;
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.hql.internal.ast.QueryTranslatorImpl;
 import org.hibernate.hql.internal.ast.tree.SelectClause;
 import org.hibernate.loader.hql.QueryLoader;
+import org.hibernate.ogm.dialect.impl.QueryContextImpl;
 import org.hibernate.ogm.dialect.query.spi.BackendQuery;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
@@ -67,7 +69,7 @@ public class OgmQueryLoader extends QueryLoader {
 	protected List<?> list(SessionImplementor session, org.hibernate.engine.spi.QueryParameters queryParameters, Set<Serializable> querySpaces, Type[] resultTypes)
 			throws HibernateException {
 
-		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
+		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( session, QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
 		try {
 			if ( hasScalars ) {
 				return listOfArrays( session, tuples );
@@ -143,8 +145,8 @@ public class OgmQueryLoader extends QueryLoader {
 			this.query = query;
 		}
 
-		public ClosableIterator<Tuple> executeQuery(QueryParameters queryParameters) {
-			return gridDialect.executeBackendQuery( query, queryParameters );
+		public ClosableIterator<Tuple> executeQuery(SessionImplementor session, QueryParameters queryParameters) {
+			return gridDialect.executeBackendQuery( query, queryParameters, new QueryContextImpl( transactionContext( session ) ) );
 		}
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.util.impl;
 
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
+
 import java.io.Serializable;
 
 import org.hibernate.SessionFactory;
@@ -226,7 +228,8 @@ public class AssociationPersister {
 		if ( associationContext == null ) {
 			associationContext = new AssociationContextImpl(
 					associationTypeContext,
-					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuple() : null
+					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuple() : null,
+					transactionContext( session )
 			);
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.util.impl;
+
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.dialect.impl.TransactionContextImpl;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+import org.hibernate.resource.transaction.TransactionCoordinator;
+
+/**
+ * @author Davide D'Alto
+ */
+public final class TransactionContextHelper {
+
+	private TransactionContextHelper() {
+	}
+
+	public static TransactionContext transactionContext(Session session) {
+		return transactionContext( (SessionImplementor) session );
+	}
+
+	public static TransactionContext transactionContext(SessionImplementor session) {
+		TransactionCoordinator transactionCoordinator = session.getTransactionCoordinator();
+		if ( transactionCoordinator != null && transactionCoordinator.getTransactionDriverControl() != null ) {
+			return new TransactionContextImpl( transactionCoordinator.getTransactionDriverControl() );
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
@@ -8,9 +8,11 @@ package org.hibernate.ogm.util.impl;
 
 import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.dialect.impl.IdentifiableDriver;
 import org.hibernate.ogm.dialect.impl.TransactionContextImpl;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.resource.transaction.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
 
 /**
  * @author Davide D'Alto
@@ -27,7 +29,10 @@ public final class TransactionContextHelper {
 	public static TransactionContext transactionContext(SessionImplementor session) {
 		TransactionCoordinator transactionCoordinator = session.getTransactionCoordinator();
 		if ( transactionCoordinator != null && transactionCoordinator.getTransactionDriverControl() != null ) {
-			return new TransactionContextImpl( transactionCoordinator.getTransactionDriverControl() );
+			TransactionDriver driver = transactionCoordinator.getTransactionDriverControl();
+			if ( driver instanceof IdentifiableDriver ) {
+				return new TransactionContextImpl( (IdentifiableDriver) driver );
+			}
 		}
 		return null;
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/unidirectional/CollectionUnidirectionalTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/unidirectional/CollectionUnidirectionalTest.java
@@ -38,8 +38,8 @@ public class CollectionUnidirectionalTest extends OgmTestCase {
 		cloud.getProducedSnowFlakes().add( sf2 );
 		session.persist( cloud );
 		session.flush();
-		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 3 );
-		assertThat( getNumberOfAssociations( sessions ) ).isEqualTo( 1 );
+		assertThat( getNumberOfEntities( session ) ).isEqualTo( 3 );
+		assertThat( getNumberOfAssociations( session ) ).isEqualTo( 1 );
 		transaction.commit();
 
 		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 3 );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
@@ -42,8 +42,8 @@ public class ManyToOneTest extends OgmTestCase {
 		session.persist( emmanuel );
 		session.persist( jerome );
 		session.flush();
-		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 3 );
-		assertThat( getNumberOfAssociations( sessions ) ).isEqualTo( expectedAssociations() );
+		assertThat( getNumberOfEntities( session ) ).isEqualTo( 3 );
+		assertThat( getNumberOfAssociations( session ) ).isEqualTo( expectedAssociations() );
 		transaction.commit();
 		assertThat( getNumberOfEntities( sessions ) ).isEqualTo( 3 );
 		assertThat( getNumberOfAssociations( sessions ) ).isEqualTo( expectedAssociations() );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -9,27 +9,23 @@ package org.hibernate.ogm.backendtck.batchfetching;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
+import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
-import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.utils.EmptyOptionsContext;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.ogm.utils.SkipByGridDialect;
@@ -46,12 +42,6 @@ import org.junit.Test;
 @SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.INFINISPAN, GridDialectType.EHCACHE, GridDialectType.REDIS_HASH })
 public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
-	private static final Map<String, AssociatedEntityKeyMetadata> EMPTY_ASSOCIATION_METADATA = Collections.emptyMap();
-	private static final Map<String, String> EMPTY_ROLES = Collections.emptyMap();
-
-	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "id.name", "id.publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
-			EmptyOptionsContext.INSTANCE );
-
 	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[] { "id.name", "id.publisher" } );
 
 	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[] { "none", "none" } );
@@ -66,7 +56,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples.get( 0 ).get( "id.publisher" ) ).isEqualTo( SPLENDOR.getId().getPublisher() );
 			assertThat( tuples.get( 0 ).get( "id.name" ) ).isEqualTo( SPLENDOR.getId().getName() );
@@ -93,7 +83,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples.get( 0 ) ).isNull();
 
@@ -112,7 +102,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples ).containsExactly( null, null, null, null );
 		}
@@ -138,6 +128,13 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 			delete( session, KING_OF_TOKYO );
 			tx.commit();
 		}
+	}
+
+	private TupleContext tupleContext(Session session) {
+		return new GridDialectOperationContexts.TupleContextBuilder()
+				.selectableColumns( METADATA.getColumnNames() )
+				.transactionContext( session )
+				.buildTupleContext();
 	}
 
 	private void delete(OgmSession session, BoardGame boardGame) {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
@@ -9,26 +9,22 @@ package org.hibernate.ogm.backendtck.batchfetching;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
-import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.utils.EmptyOptionsContext;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.ogm.utils.SkipByGridDialect;
@@ -45,11 +41,6 @@ import org.junit.Test;
 @SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.INFINISPAN, GridDialectType.EHCACHE, GridDialectType.REDIS_HASH })
 public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
-	private static final Map<String, AssociatedEntityKeyMetadata> EMPTY_ASSOCIATION_METADATA = Collections.emptyMap();
-	private static final Map<String, String> EMPTY_ROLES = Collections.emptyMap();
-
-	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "name", "publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
-			EmptyOptionsContext.INSTANCE );
 	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[] { "id" } );
 
 	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[] { -666 } );
@@ -65,7 +56,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples.get( 0 ).get( "id" ) ).isEqualTo( SPLENDOR.getId() );
 			assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
@@ -87,7 +78,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples.get( 0 ) ).isNull();
 
@@ -108,12 +99,19 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 			MultigetGridDialect dialect = multiGetGridDialect();
 
 			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+			List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 			assertThat( tuples ).containsExactly( null, null, null, null );
 
 			session.getTransaction().commit();
 		}
+	}
+
+	private TupleContext tupleContext(Session session) {
+		return new GridDialectOperationContexts.TupleContextBuilder()
+				.selectableColumns( "name", "publisher" )
+				.transactionContext( session )
+				.buildTupleContext();
 	}
 
 	private EntityKey key(BoardGame boardGame) {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/loader/LoaderFromTupleTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/loader/LoaderFromTupleTest.java
@@ -47,7 +47,7 @@ public class LoaderFromTupleTest extends OgmTestCase {
 
 		transaction = session.beginTransaction();
 		EntityKey key = new EntityKey( new DefaultEntityKeyMetadata( "Feeling", new String[] { "UUID" } ), new Object[] { feeling.getUUID() } );
-		Map<String, Object> entityTuple = extractEntityTuple( sessions, key );
+		Map<String, Object> entityTuple = extractEntityTuple( session, key );
 		final Tuple tuple = new Tuple( new MapTupleSnapshot( entityTuple ) );
 
 		EntityPersister persister = ( (SessionFactoryImplementor) session.getSessionFactory() )

--- a/core/src/test/java/org/hibernate/ogm/backendtck/type/converter/JpaAttributeConverterTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/type/converter/JpaAttributeConverterTest.java
@@ -50,7 +50,7 @@ public class JpaAttributeConverterTest extends OgmTestCase {
 		session.getTransaction().begin();
 		// Make sure the converter has actually been applied
 		Map<String, Object> persistedTuple = TestHelper.extractEntityTuple(
-				sessions,
+				session,
 				getPrinterEntityKey( printer.id )
 		);
 		String persistedPrinterName = (String) persistedTuple.get( "name" );
@@ -85,7 +85,7 @@ public class JpaAttributeConverterTest extends OgmTestCase {
 		session.getTransaction().begin();
 		// Make sure the converter has actually been applied
 		Map<String, Object> persistedTuple = TestHelper.extractEntityTuple(
-				sessions,
+				session,
 				getPrinterEntityKey( printer.id )
 		);
 		String persistedPrinterName = (String) persistedTuple.get( "brand" );

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.datastore.document.impl.EmbeddableStateFinder;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
@@ -92,6 +93,11 @@ public class EmbeddableStateFinderTest {
 
 			@Override
 			public OperationsQueue getOperationsQueue() {
+				return null;
+			}
+
+			@Override
+			public TransactionContext getTransactionContext() {
 				return null;
 			}
 		};

--- a/core/src/test/java/org/hibernate/ogm/test/type/StringMappedTypeSerialisationTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/type/StringMappedTypeSerialisationTest.java
@@ -63,7 +63,7 @@ public class StringMappedTypeSerialisationTest extends OgmTestCase {
 		//Check directly in the cache the values stored
 		EntityKeyMetadata keyMetadata = new DefaultEntityKeyMetadata( "Bookmark", new String[] { "id" } );
 		EntityKey key = new EntityKey( keyMetadata, new Object[] { b.getId() } );
-		Map<String, Object> entity = extractEntityTuple( sessions, key );
+		Map<String, Object> entity = extractEntityTuple( session, key );
 
 		assertEquals( "String-mapped BigInteger incorrect", entity.get( "visitCount" ), "444" );
 		assertEquals( "String-mapped UUID incorrect", entity.get( "serialNumber" ), serialNumber.toString() );

--- a/core/src/test/java/org/hibernate/ogm/test/type/converter/JpaAttributeConverterGridTypeApplicationTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/type/converter/JpaAttributeConverterGridTypeApplicationTest.java
@@ -50,7 +50,7 @@ public class JpaAttributeConverterGridTypeApplicationTest extends OgmTestCase {
 
 		// Make sure the converter has actually been applied
 		Map<String, Object> persistedTuple = TestHelper.extractEntityTuple(
-				sessions,
+				session,
 				getPrinterEntityKey( printer.id )
 		);
 		byte[] persistedPrinterName = (byte[]) persistedTuple.get( "description" );

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -6,16 +6,22 @@
  */
 package org.hibernate.ogm.utils;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
+import org.hibernate.Session;
 import org.hibernate.ogm.dialect.impl.AssociationContextImpl;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
 import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
-import org.hibernate.ogm.options.navigation.impl.OptionsContextImpl;
-import org.hibernate.ogm.options.navigation.source.impl.OptionValueSource;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.impl.TransactionContextHelper;
 
 /**
  * Useful functionality around {@link GridDialectOperationContext}s.
@@ -24,26 +30,72 @@ import org.hibernate.ogm.options.navigation.source.impl.OptionValueSource;
  */
 public class GridDialectOperationContexts {
 
+	public static class TupleContextBuilder {
+
+		private List<String> selectableColumns = Collections.<String>emptyList();
+		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = Collections.<String, AssociatedEntityKeyMetadata>emptyMap();
+		private Map<String, String> roles = Collections.<String, String>emptyMap();
+		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
+		private TransactionContext transactionContext = null;
+
+		public TupleContextBuilder selectableColumns(String... columns) {
+			this.selectableColumns = Arrays.asList( columns );
+			return this;
+		}
+
+		public TupleContextBuilder selectableColumns(List<String> columns) {
+			this.selectableColumns = columns;
+			return this;
+		}
+
+		public TupleContextBuilder transactionContext(Session session) {
+			this.transactionContext = TransactionContextHelper.transactionContext( session );
+			return this;
+		}
+
+		public TupleContextBuilder optionContext(OptionsContext optionsContext) {
+			this.optionsContext = optionsContext;
+			return this;
+		}
+
+		public TupleContext buildTupleContext() {
+			return new TupleContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
+					Collections.unmodifiableMap( roles ), optionsContext, transactionContext );
+		}
+	}
+
+	public static class AssociationContextBuilder {
+
+		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
+		private AssociatedEntityKeyMetadata associatedEntityKeyMetadata = null;
+		private String roleOnMainSide = null;
+		private TransactionContext transactionContext = null;
+		private Tuple tuple = null;
+
+		public AssociationContextBuilder optionContext(OptionsContext optionsContext) {
+			this.optionsContext = optionsContext;
+			return this;
+		}
+
+		public AssociationContextBuilder transactionContext(Session session) {
+			this.transactionContext = TransactionContextHelper.transactionContext( session );
+			return this;
+		}
+
+		public AssociationContext buildAssociationContext() {
+			return new AssociationContextImpl( new AssociationTypeContextImpl( optionsContext, associatedEntityKeyMetadata, roleOnMainSide ), tuple,
+					transactionContext );
+		}
+	}
+
 	private GridDialectOperationContexts() {
 	}
 
 	public static TupleContext emptyTupleContext() {
-		return new TupleContextImpl(
-				Collections.<String>emptyList(),
-				Collections.<String, AssociatedEntityKeyMetadata>emptyMap(),
-				Collections.<String, String>emptyMap(),
-				EmptyOptionsContext.INSTANCE
-		);
+		return new TupleContextBuilder().buildTupleContext();
 	}
 
 	public static AssociationContext emptyAssociationContext() {
-		return new AssociationContextImpl(
-				new AssociationTypeContextImpl(
-						OptionsContextImpl.forProperty( Collections.<OptionValueSource>emptyList(), Object.class, "" ),
-						null,
-						null
-				),
-				null
-		);
+		return new AssociationContextBuilder().buildAssociationContext();
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/HashMapTestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/HashMapTestHelper.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.utils;
 
 import java.util.Map;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
@@ -26,8 +27,18 @@ import org.hibernate.ogm.model.key.spi.RowKey;
 public class HashMapTestHelper implements TestableGridDialect {
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		return getEntityMap( sessionFactory ).size();
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override
@@ -36,8 +47,8 @@ public class HashMapTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
-		return getEntityMap( sessionFactory ).get( key );
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		return getEntityMap( session.getSessionFactory() ).get( key );
 	}
 
 	private static Map<EntityKey, Map<String, Object>> getEntityMap(SessionFactory sessionFactory) {

--- a/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
@@ -31,6 +31,7 @@ import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -166,8 +167,8 @@ public class InvokedOperationsLoggingDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters) {
-		ClosableIterator<Tuple> result = super.executeBackendQuery( query, queryParameters );
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters, QueryContext queryContext) {
+		ClosableIterator<Tuple> result = super.executeBackendQuery( query, queryParameters, queryContext );
 		log( "executeBackendQuery", query.toString() + ", " + queryParameters.toString(), "tbd." );
 		return result;
 	}

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -144,16 +144,20 @@ public class TestHelper {
 		return configurationType;
 	}
 
-	public static long getNumberOfEntities( Session session) {
-		return getNumberOfEntities( session.getSessionFactory() );
+	public static long getNumberOfEntities( Session session ) {
+		return helper.getNumberOfEntities( session );
 	}
 
 	public static long getNumberOfEntities(SessionFactory sessionFactory) {
 		return helper.getNumberOfEntities( sessionFactory );
 	}
 
-	public static Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
-		return helper.extractEntityTuple( sessionFactory, key );
+	public static Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		return helper.extractEntityTuple( session, key );
+	}
+
+	public static long getNumberOfAssociations(Session session) {
+		return helper.getNumberOfAssociations( session );
 	}
 
 	public static long getNumberOfAssociations(SessionFactory sessionFactory) {

--- a/core/src/test/java/org/hibernate/ogm/utils/TestableGridDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestableGridDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.utils;
 
 import java.util.Map;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.spi.DatastoreConfiguration;
@@ -27,9 +28,23 @@ public interface TestableGridDialect {
 	/**
 	 * Returns the number of entities in the datastore
 	 *
+	 * @param session
+	 */
+	long getNumberOfEntities(Session session);
+
+	/**
+	 * Returns the number of entities in the datastore
+	 *
 	 * @param sessionFactory
 	 */
 	long getNumberOfEntities(SessionFactory sessionFactory);
+
+	/**
+	 * Returns the number of associations in the datastore
+	 *
+	 * @param session
+	 */
+	long getNumberOfAssociations(Session session);
 
 	/**
 	 * Returns the number of associations in the datastore
@@ -50,11 +65,11 @@ public interface TestableGridDialect {
 	/**
 	 * Loads a specific entity tuple directly from the data store by entity key
 	 *
-	 * @param sessionFactory
+	 * @param session
 	 * @param key
 	 * @return the loaded tuple, or null of nothing was found
 	 */
-	Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key);
+	Map<String, Object> extractEntityTuple(Session session, EntityKey key);
 
 	/**
 	 * Returning false will disable all tests which verify transaction isolation or rollback capabilities.

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
@@ -15,6 +15,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.OgmSessionFactory;
@@ -81,6 +82,11 @@ public class CouchDBTestHelper implements TestableGridDialect {
 	}
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		return getNumberOfEntities( getDataStore( sessionFactory ) );
 	}
@@ -115,6 +121,11 @@ public class CouchDBTestHelper implements TestableGridDialect {
 		DatabaseTestClient databaseTestClient = getDatabaseTestClient( getDataStore( sessionFactory ) );
 		Long count = getNumberOfAssociations( databaseTestClient ).get( type );
 		return count != null ? count : 0;
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override
@@ -167,9 +178,9 @@ public class CouchDBTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
 		Map<String, Object> tupleMap = new HashMap<String, Object>();
-		CouchDBDatastore dataStore = getDataStore( sessionFactory );
+		CouchDBDatastore dataStore = getDataStore( session.getSessionFactory() );
 		EntityDocument entity = dataStore.getEntity( Identifier.createEntityId( key ) );
 		CouchDBTupleSnapshot snapshot = new CouchDBTupleSnapshot( entity.getProperties() );
 		Set<String> columnNames = snapshot.getColumnNames();

--- a/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/utils/EhcacheTestHelper.java
+++ b/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/utils/EhcacheTestHelper.java
@@ -11,6 +11,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
@@ -37,6 +38,11 @@ import org.hibernate.persister.entity.EntityPersister;
 public class EhcacheTestHelper implements TestableGridDialect {
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		int entityCount = 0;
 		Set<Cache<?>> processedCaches = Collections.newSetFromMap( new IdentityHashMap<Cache<?>, Boolean>() );
@@ -55,6 +61,11 @@ public class EhcacheTestHelper implements TestableGridDialect {
 	public static Cache<?> getEntityCache(SessionFactory sessionFactory, EntityKeyMetadata entityKeyMetadata) {
 		EhcacheDatastoreProvider castProvider = getProvider( sessionFactory );
 		return castProvider.getCacheManager().getEntityCache( entityKeyMetadata );
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override
@@ -84,7 +95,8 @@ public class EhcacheTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String,Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
+	public Map<String,Object> extractEntityTuple(Session session, EntityKey key) {
+		SessionFactory sessionFactory = session.getSessionFactory();
 		Cache cache = getEntityCache( sessionFactory, key.getMetadata() );
 		Object cacheKey = getProvider( sessionFactory ).getKeyProvider().getEntityCacheKey( key );
 

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
@@ -11,6 +11,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
@@ -36,6 +37,11 @@ import org.infinispan.Cache;
 public class InfinispanTestHelper implements TestableGridDialect {
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		int entityCount = 0;
 		Set<Cache<?, ?>> processedCaches = Collections.newSetFromMap( new IdentityHashMap<Cache<?, ?>, Boolean>() );
@@ -49,6 +55,11 @@ public class InfinispanTestHelper implements TestableGridDialect {
 		}
 
 		return entityCount;
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override
@@ -68,9 +79,9 @@ public class InfinispanTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
-		InfinispanDatastoreProvider provider = getProvider( sessionFactory );
-		return getEntityCache( sessionFactory, key.getMetadata() ).get( provider.getKeyProvider().getEntityCacheKey( key ) );
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		InfinispanDatastoreProvider provider = getProvider( session.getSessionFactory() );
+		return getEntityCache( session.getSessionFactory(), key.getMetadata() ).get( provider.getKeyProvider().getEntityCacheKey( key ) );
 	}
 
 	private static Cache<?, Map<String, Object>> getEntityCache(SessionFactory sessionFactory, EntityKeyMetadata entityKeyMetadata) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -76,6 +76,7 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
@@ -792,7 +793,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<MongoDBQueryDescriptor> backendQuery, QueryParameters queryParameters) {
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<MongoDBQueryDescriptor> backendQuery, QueryParameters queryParameters, QueryContext queryContext) {
 		MongoDBQueryDescriptor queryDescriptor = backendQuery.getQuery();
 
 		EntityKeyMetadata entityKeyMetadata = backendQuery.getSingleEntityKeyMetadataOrNull();
@@ -824,7 +825,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(final BackendQuery<MongoDBQueryDescriptor> backendQuery, final QueryParameters queryParameters) {
+	public int executeBackendUpdateQuery(final BackendQuery<MongoDBQueryDescriptor> backendQuery, final QueryParameters queryParameters, final QueryContext queryContext) {
 		MongoDBQueryDescriptor queryDescriptor = backendQuery.getQuery();
 
 		EntityKeyMetadata entityKeyMetadata = backendQuery.getSingleEntityKeyMetadataOrNull();

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.mongodb.test.loading;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -32,14 +33,12 @@ import org.hibernate.ogm.datastore.mongodb.options.AssociationDocumentStorageTyp
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.impl.AssociationContextImpl;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
-import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.impl.DefaultAssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -53,6 +52,7 @@ import org.hibernate.ogm.options.spi.Option;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.options.spi.UniqueOption;
 import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.service.Service;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -156,7 +156,8 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 						new DefaultAssociatedEntityKeyMetadata( null, null ),
 						null
 				),
-				new Tuple( new MongoDBTupleSnapshot( null, null, null ) )
+				new Tuple( new MongoDBTupleSnapshot( null, null, null ) ),
+				transactionContext( session )
 		);
 
 		final Association association = getService( GridDialect.class ).getAssociation( associationKey, associationContext );
@@ -175,12 +176,10 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 				new DefaultEntityKeyMetadata( collectionName, new String[] { MongoDBDialect.ID_FIELDNAME } ),
 				new Object[] { id }
 		);
-		TupleContext tupleContext = new TupleContextImpl(
-				selectedColumns,
-				Collections.<String, AssociatedEntityKeyMetadata>emptyMap(),
-				Collections.<String, String>emptyMap(),
-				TestOptionContext.INSTANCE
-		);
+		TupleContext tupleContext = new GridDialectOperationContexts.TupleContextBuilder()
+				.selectableColumns( selectedColumns )
+				.optionContext( TestOptionContext.INSTANCE )
+				.buildTupleContext();
 
 		return getService( GridDialect.class ).getTuple( key, tupleContext );
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.OgmSessionFactory;
@@ -68,6 +69,11 @@ public class MongoDBTestHelper implements TestableGridDialect {
 	}
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		MongoDBDatastoreProvider provider = MongoDBTestHelper.getProvider( sessionFactory );
 		DB db = provider.getDatabase();
@@ -82,6 +88,12 @@ public class MongoDBTestHelper implements TestableGridDialect {
 
 	private boolean isSystemCollection(String collectionName) {
 		return collectionName.startsWith( "system." );
+	}
+
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override
@@ -183,8 +195,8 @@ public class MongoDBTestHelper implements TestableGridDialect {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
-		MongoDBDatastoreProvider provider = MongoDBTestHelper.getProvider( sessionFactory );
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		MongoDBDatastoreProvider provider = MongoDBTestHelper.getProvider( session.getSessionFactory() );
 		DBObject finder = new BasicDBObject( MongoDBDialect.ID_FIELDNAME, key.getColumnValues()[0] );
 		DBObject result = provider.getDatabase().getCollection( key.getTable() ).findOne( finder );
 		replaceIdentifierColumnName( result, key );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/Neo4jDialect.java
@@ -52,6 +52,7 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.QueryContext;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
@@ -612,7 +613,7 @@ public class Neo4jDialect extends BaseGridDialect implements MultigetGridDialect
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<String> backendQuery, QueryParameters queryParameters) {
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<String> backendQuery, QueryParameters queryParameters, QueryContext queryContext) {
 		Map<String, Object> parameters = getNamedParameterValuesConvertedByGridType( queryParameters );
 		String nativeQuery = buildNativeQuery( backendQuery, queryParameters );
 		Result result = dataBase.execute( nativeQuery, parameters );
@@ -624,7 +625,7 @@ public class Neo4jDialect extends BaseGridDialect implements MultigetGridDialect
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters) {
+	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters, QueryContext queryContex) {
 		// TODO implement. org.hibernate.ogm.datastore.mongodb.MongoDBDialect.executeBackendUpdateQuery(BackendQuery<MongoDBQueryDescriptor>, QueryParameters) might be helpful as a reference.
 		throw new UnsupportedOperationException("Not yet implemented.");
 	}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.fest.util.Files;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
@@ -49,6 +50,16 @@ public class Neo4jTestHelper implements TestableGridDialect {
 	private static final String ROOT_FOLDER = hibProperties.get( Neo4jProperties.DATABASE_PATH ) + File.separator + "NEO4J";
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		GraphDatabaseService graphDb = getProvider( sessionFactory ).getDataBase();
 		ResourceIterator<Long> result = graphDb.execute( ENTITY_COUNT_QUERY ).columnAs( "count" );
@@ -67,9 +78,9 @@ public class Neo4jTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
 		Map<String, Object> tuple = new HashMap<String, Object>();
-		GridDialect dialect = getDialect( sessionFactory );
+		GridDialect dialect = getDialect( session.getSessionFactory() );
 		TupleSnapshot snapshot = dialect.getTuple( key, GridDialectOperationContexts.emptyTupleContext() ).getSnapshot();
 		for ( String column : snapshot.getColumnNames() ) {
 			tuple.put( column, snapshot.get( column ) );

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/utils/RedisTestHelper.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/utils/RedisTestHelper.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.OgmSessionFactory;
@@ -57,8 +58,8 @@ public class RedisTestHelper implements TestableGridDialect {
 	}
 
 	@Override
-	public Map<String, Object> extractEntityTuple(SessionFactory sessionFactory, EntityKey key) {
-		RedisDatastoreProvider castProvider = getProvider( sessionFactory );
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		RedisDatastoreProvider castProvider = getProvider( session.getSessionFactory() );
 		AbstractRedisDialect gridDialect = getGridDialect( castProvider );
 
 		if ( gridDialect instanceof RedisJsonDialect ) {
@@ -66,7 +67,7 @@ public class RedisTestHelper implements TestableGridDialect {
 		}
 
 		if ( gridDialect instanceof RedisHashDialect ) {
-			return extractFromHashDialect( sessionFactory, key, (RedisHashDialect) gridDialect );
+			return extractFromHashDialect( session.getSessionFactory(), key, (RedisHashDialect) gridDialect );
 		}
 
 		throw new IllegalStateException( "Unsupported dialect " + gridDialect );
@@ -162,6 +163,11 @@ public class RedisTestHelper implements TestableGridDialect {
 	}
 
 	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	@Override
 	public long getNumberOfEntities(SessionFactory sessionFactory) {
 		RedisCommands<String, String> connection = getConnection( sessionFactory );
 		List<String> keys = connection.keys( "*" );
@@ -196,6 +202,11 @@ public class RedisTestHelper implements TestableGridDialect {
 		catch (JSONException e) {
 			throw new IllegalStateException( e );
 		}
+	}
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-366
Previous pull request: https://github.com/hibernate/hibernate-ogm/pull/623

This is a first step towards the *Neo4j Remote*, I need to get the transaction id and use it with the Rest API on each call.
Following the previous remarks I've added the `TransactionContext` to the `TupleContext` and `AssociationContext` and I've added a `QueryContext` for the dialect methods to execute queries.

@gunnarmorling For now I prefer to pass the `TransactionDirver` with the TransactionContext
I'm not completely sold on the idea of using the `get(TransactionId.class)` as it seems to add complexity that we don't need at the moment. Also I'm not ure how to pass the transctionId to the context since the TransactionDriver does not have a method to obtain it.
@emmanuelbernard Any opinion about passing the TransactionDriver around? You can see the starting of the conversation  here: https://github.com/hibernate/hibernate-ogm/pull/623#discussion-diff-50811891R16

An example of how this will be used is:
```
Long txId = transactionId( tupleContext.getTransactionContext());
        ...
private Long transactionId(TransactionContext context) {
    return ( (Neo4jTransactionDriver) context.getTransactionDriver() ).getTransactionId();
}
	
```
