### PR TITLE
OGM-711 Avoid exporting module org.jboss.jts to user classpath

### DIFF
--- a/integrationtest/couchdb/src/test/java/org/hibernate/ogm/test/integration/jboss/CouchDBModuleMemberRegistrationIT.java
+++ b/integrationtest/couchdb/src/test/java/org/hibernate/ogm/test/integration/jboss/CouchDBModuleMemberRegistrationIT.java
@@ -77,6 +77,7 @@ public class CouchDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 							.createProperty().name( "hibernate.ogm.datastore.database" ).value( "ogm_test_database" ).up()
 							.createProperty().name( "hibernate.ogm.datastore.create_database" ).value( "true" ).up()
 							.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+							.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 					.up().up();
 	}
 

--- a/integrationtest/mongodb/src/test/java/org/hibernate/ogm/test/integration/jboss/MongoDBModuleMemberRegistrationIT.java
+++ b/integrationtest/mongodb/src/test/java/org/hibernate/ogm/test/integration/jboss/MongoDBModuleMemberRegistrationIT.java
@@ -97,6 +97,7 @@ public class MongoDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 					.createProperty().name( OgmProperties.CREATE_DATABASE ).value( "true" ).up()
 					.createProperty().name( OgmProperties.ERROR_HANDLER ).value( TestErrorHandler.class.getName() ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/neo4j/src/test/java/org/hibernate/ogm/test/integration/jboss/Neo4jJtaModuleMemberRegistrationIT.java
+++ b/integrationtest/neo4j/src/test/java/org/hibernate/ogm/test/integration/jboss/Neo4jJtaModuleMemberRegistrationIT.java
@@ -62,6 +62,7 @@ public class Neo4jJtaModuleMemberRegistrationIT extends ModuleMemberRegistration
 				.value( neo4jFolder() )
 				.up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 		return persistenceDescriptor;
 	}

--- a/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationIT.java
+++ b/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationIT.java
@@ -67,6 +67,7 @@ public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationSce
 				.createProperty().name( OgmProperties.DATASTORE_PROVIDER ).value( Redis.DATASTORE_PROVIDER_NAME ).up()
 				.createProperty().name( OgmProperties.DATABASE ).value( "0" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
+++ b/integrationtest/redis/src/test/java/org/hibernate/ogm/test/integration/jboss/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
@@ -79,6 +79,7 @@ public class RedisModuleMemberRegistrationWithTTLConfiguredIT extends ModuleMemb
 				.createProperty().name( OgmProperties.DATABASE ).value( "0" ).up()
 				.createProperty().name( RedisProperties.TTL ).value( "3600" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/EhcacheModuleMemberRegistrationIT.java
+++ b/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/EhcacheModuleMemberRegistrationIT.java
@@ -42,6 +42,7 @@ public class EhcacheModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 				.getOrCreateProperties()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
+++ b/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
@@ -44,6 +44,7 @@ public class EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT exte
 				.getOrCreateProperties()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtest/testcase/src/test/java/org/hibernate/ogm/test/integration/jboss/InfinispanModuleMemberRegistrationIT.java
@@ -43,6 +43,7 @@ public class InfinispanModuleMemberRegistrationIT extends ModuleMemberRegistrati
 				.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
 				.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 			.up().up();
 	}
 

--- a/modules/wildfly/src/main/modules/ogm/core/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/core/module.xml
@@ -21,8 +21,5 @@
 
         <!-- Needed for Iso8601StringDateType -->
         <module name="javax.xml.bind.api"/>
-
-        <!-- Allow Hibernate ORM to load com.arjuna.ats.jta.TransactionManager -->
-        <module name="org.jboss.jts" export="true" />
     </dependencies>
 </module>


### PR DESCRIPTION
The JTS module is no longer required, provided the correct JTA platform is configured in the integration tests.

It turns out the documentation already pointed out the need for this JTA platform to be set, so that was done already.