### PR TITLE
OGM-1046 Commit transaction after tests

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -52,16 +52,16 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "id.name", "id.publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
 			EmptyOptionsContext.INSTANCE );
 
-	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[] { "id.name", "id.publisher" } );
+	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[]{ "id.name", "id.publisher" } );
 
-	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[] { "none", "none" } );
+	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[]{ "none", "none" } );
 	private static final BoardGame DOMINION = new BoardGame( "Rio Grande Games", "Dominion" );
 	private static final BoardGame KING_OF_TOKYO = new BoardGame( "Fantasmagoria", "King of Tokyo" );
 	private static final BoardGame SPLENDOR = new BoardGame( "Space Cowboys", "Splendor" );
 
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -94,7 +94,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -120,7 +120,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -140,7 +140,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	@Before
 	public void prepareDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				session.persist( DOMINION );
@@ -157,7 +157,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	@After
 	public void deleteDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				delete( session, DOMINION );
@@ -189,7 +189,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { BoardGame.class };
+		return new Class<?>[]{ BoardGame.class };
 	}
 
 	@Entity

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -62,22 +62,28 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ).get( "id.publisher" ) ).isEqualTo( SPLENDOR.getId().getPublisher() );
-			assertThat( tuples.get( 0 ).get( "id.name" ) ).isEqualTo( SPLENDOR.getId().getName() );
+				assertThat( tuples.get( 0 ).get( "id.publisher" ) ).isEqualTo( SPLENDOR.getId().getPublisher() );
+				assertThat( tuples.get( 0 ).get( "id.name" ) ).isEqualTo( SPLENDOR.getId().getName() );
 
-			assertThat( tuples.get( 1 ).get( "id.publisher" ) ).isEqualTo( DOMINION.getId().getPublisher() );
-			assertThat( tuples.get( 1 ).get( "id.name" ) ).isEqualTo( DOMINION.getId().getName() );
+				assertThat( tuples.get( 1 ).get( "id.publisher" ) ).isEqualTo( DOMINION.getId().getPublisher() );
+				assertThat( tuples.get( 1 ).get( "id.name" ) ).isEqualTo( DOMINION.getId().getName() );
 
-			assertThat( tuples.get( 2 ).get( "id.publisher" ) ).isEqualTo( KING_OF_TOKYO.getId().getPublisher() );
-			assertThat( tuples.get( 2 ).get( "id.name" ) ).isEqualTo( KING_OF_TOKYO.getId().getName() );
+				assertThat( tuples.get( 2 ).get( "id.publisher" ) ).isEqualTo( KING_OF_TOKYO.getId().getPublisher() );
+				assertThat( tuples.get( 2 ).get( "id.name" ) ).isEqualTo( KING_OF_TOKYO.getId().getName() );
 
-			session.getTransaction().commit();
+				session.getTransaction().commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -89,32 +95,46 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ) ).isNull();
+				assertThat( tuples.get( 0 ) ).isNull();
 
-			assertThat( tuples.get( 1 ).get( "id.publisher" ) ).isEqualTo( KING_OF_TOKYO.getId().getPublisher() );
-			assertThat( tuples.get( 1 ).get( "id.name" ) ).isEqualTo( KING_OF_TOKYO.getId().getName() );
+				assertThat( tuples.get( 1 ).get( "id.publisher" ) ).isEqualTo( KING_OF_TOKYO.getId().getPublisher() );
+				assertThat( tuples.get( 1 ).get( "id.name" ) ).isEqualTo( KING_OF_TOKYO.getId().getName() );
 
-			assertThat( tuples.get( 2 ) ).isNull();
-			assertThat( tuples.get( 3 ) ).isNull();
+				assertThat( tuples.get( 2 ) ).isNull();
+				assertThat( tuples.get( 3 ) ).isNull();
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples ).containsExactly( null, null, null, null );
+				assertThat( tuples ).containsExactly( null, null, null, null );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -122,10 +142,16 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	public void prepareDataset() {
 		try (OgmSession session = openSession()) {
 			Transaction tx = session.beginTransaction();
-			session.persist( DOMINION );
-			session.persist( KING_OF_TOKYO );
-			session.persist( SPLENDOR );
-			tx.commit();
+			try {
+				session.persist( DOMINION );
+				session.persist( KING_OF_TOKYO );
+				session.persist( SPLENDOR );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -133,10 +159,16 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	public void deleteDataset() {
 		try (OgmSession session = openSession()) {
 			Transaction tx = session.beginTransaction();
-			delete( session, DOMINION );
-			delete( session, SPLENDOR );
-			delete( session, KING_OF_TOKYO );
-			tx.commit();
+			try {
+				delete( session, DOMINION );
+				delete( session, SPLENDOR );
+				delete( session, KING_OF_TOKYO );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -147,6 +179,12 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	private MultigetGridDialect multiGetGridDialect() {
 		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
+	}
+
+	private void rollback(Transaction tx) {
+		if ( tx != null ) {
+			tx.rollback();
+		}
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
@@ -64,54 +64,76 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ).get( "publisher" ) ).isEqualTo( SPLENDOR.getPublisher() );
-			assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
+				assertThat( tuples.get( 0 ).get( "publisher" ) ).isEqualTo( SPLENDOR.getPublisher() );
+				assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
 
-			assertThat( tuples.get( 1 ).get( "publisher" ) ).isEqualTo( DOMINION.getPublisher() );
-			assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( DOMINION.getName() );
+				assertThat( tuples.get( 1 ).get( "publisher" ) ).isEqualTo( DOMINION.getPublisher() );
+				assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( DOMINION.getName() );
 
-			assertThat( tuples.get( 2 ).get( "publisher" ) ).isEqualTo( KING_OF_TOKYO.getPublisher() );
-			assertThat( tuples.get( 2 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
+				assertThat( tuples.get( 2 ).get( "publisher" ) ).isEqualTo( KING_OF_TOKYO.getPublisher() );
+				assertThat( tuples.get( 2 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
 
-			session.getTransaction().commit();
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ) ).isNull();
+				assertThat( tuples.get( 0 ) ).isNull();
 
-			assertThat( tuples.get( 1 ).get( "publisher" ) ).isEqualTo( KING_OF_TOKYO.getPublisher() );
-			assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
+				assertThat( tuples.get( 1 ).get( "publisher" ) ).isEqualTo( KING_OF_TOKYO.getPublisher() );
+				assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
 
-			assertThat( tuples.get( 2 ) ).isNull();
-			assertThat( tuples.get( 3 ) ).isNull();
+				assertThat( tuples.get( 2 ) ).isNull();
+				assertThat( tuples.get( 3 ) ).isNull();
+
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples ).containsExactly( null, null, null, null );
+				assertThat( tuples ).containsExactly( null, null, null, null );
+
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -124,10 +146,16 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	public void prepareDataset() {
 		try (OgmSession session = openSession()) {
 			Transaction tx = session.beginTransaction();
-			session.persist( DOMINION );
-			session.persist( KING_OF_TOKYO );
-			session.persist( SPLENDOR );
-			tx.commit();
+			try {
+				session.persist( DOMINION );
+				session.persist( KING_OF_TOKYO );
+				session.persist( SPLENDOR );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -135,10 +163,16 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	public void deleteDataset() {
 		try (OgmSession session = openSession()) {
 			Transaction tx = session.beginTransaction();
-			delete( session, DOMINION );
-			delete( session, SPLENDOR );
-			delete( session, KING_OF_TOKYO );
-			tx.commit();
+			try {
+				delete( session, DOMINION );
+				delete( session, SPLENDOR );
+				delete( session, KING_OF_TOKYO );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -149,6 +183,12 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	private MultigetGridDialect multiGetGridDialect() {
 		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
+	}
+
+	private void rollback(Transaction tx) {
+		if ( tx != null ) {
+			tx.rollback();
+		}
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
@@ -22,7 +22,6 @@ import javax.persistence.Table;
 
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
-import org.hibernate.ogm.backendtck.batchfetching.MultiGetEmbeddedIdTest.BoardGame;
 import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
@@ -54,16 +53,16 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "name", "publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
 			EmptyOptionsContext.INSTANCE );
 
-	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[] { "name", "publisher" } );
+	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[]{ "name", "publisher" } );
 
-	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[] { "none", "none" } );
+	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[]{ "none", "none" } );
 	private static final BoardGame DOMINION = new BoardGame( "Rio Grande Games", "Dominion" );
 	private static final BoardGame KING_OF_TOKYO = new BoardGame( "Fantasmagoria", "King of Tokyo" );
 	private static final BoardGame SPLENDOR = new BoardGame( "Space Cowboys", "Splendor" );
 
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -91,7 +90,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -118,7 +117,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -144,7 +143,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	@Before
 	public void prepareDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				session.persist( DOMINION );
@@ -161,7 +160,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	@After
 	public void deleteDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				delete( session, DOMINION );
@@ -193,7 +192,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { BoardGame.class };
+		return new Class<?>[]{ BoardGame.class };
 	}
 
 	@Entity

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
@@ -61,58 +61,76 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ).get( "id" ) ).isEqualTo( SPLENDOR.getId() );
-			assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
+				assertThat( tuples.get( 0 ).get( "id" ) ).isEqualTo( SPLENDOR.getId() );
+				assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
 
-			assertThat( tuples.get( 1 ).get( "id" ) ).isEqualTo( DOMINION.getId() );
-			assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( DOMINION.getName() );
+				assertThat( tuples.get( 1 ).get( "id" ) ).isEqualTo( DOMINION.getId() );
+				assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( DOMINION.getName() );
 
-			assertThat( tuples.get( 2 ).get( "id" ) ).isEqualTo( KING_OF_TOKYO.getId() );
-			assertThat( tuples.get( 2 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
+				assertThat( tuples.get( 2 ).get( "id" ) ).isEqualTo( KING_OF_TOKYO.getId() );
+				assertThat( tuples.get( 2 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
 
-			session.getTransaction().commit();
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples.get( 0 ) ).isNull();
+				assertThat( tuples.get( 0 ) ).isNull();
 
-			assertThat( tuples.get( 1 ).get( "id" ) ).isEqualTo( KING_OF_TOKYO.getId() );
-			assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
+				assertThat( tuples.get( 1 ).get( "id" ) ).isEqualTo( KING_OF_TOKYO.getId() );
+				assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
 
-			assertThat( tuples.get( 2 ) ).isNull();
-			assertThat( tuples.get( 3 ) ).isNull();
+				assertThat( tuples.get( 2 ) ).isNull();
+				assertThat( tuples.get( 3 ) ).isNull();
 
-			session.getTransaction().commit();
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
 		try (OgmSession session = openSession()) {
-			session.getTransaction().begin();
-			MultigetGridDialect dialect = multiGetGridDialect();
+			Transaction tx = session.beginTransaction();
+			try {
+				MultigetGridDialect dialect = multiGetGridDialect();
 
-			EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-			List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
 
-			assertThat( tuples ).containsExactly( null, null, null, null );
+				assertThat( tuples ).containsExactly( null, null, null, null );
 
-			session.getTransaction().commit();
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -124,11 +142,17 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 	@Before
 	public void prepareDataset() {
 		try (OgmSession session = openSession()) {
-			session.beginTransaction();
-			session.persist( DOMINION );
-			session.persist( KING_OF_TOKYO );
-			session.persist( SPLENDOR );
-			session.getTransaction().commit();
+			Transaction tx = session.beginTransaction();
+			try {
+				session.persist( DOMINION );
+				session.persist( KING_OF_TOKYO );
+				session.persist( SPLENDOR );
+				tx.commit();
+			}
+			catch (Exception e) {
+				rollback( tx );
+				throw e;
+			}
 		}
 	}
 
@@ -150,6 +174,12 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 	private MultigetGridDialect multiGetGridDialect() {
 		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
+	}
+
+	private void rollback(Transaction tx) {
+		if ( tx != null ) {
+			tx.rollback();
+		}
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
@@ -48,11 +48,10 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 	private static final Map<String, AssociatedEntityKeyMetadata> EMPTY_ASSOCIATION_METADATA = Collections.emptyMap();
 	private static final Map<String, String> EMPTY_ROLES = Collections.emptyMap();
 
-	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "name", "publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
-			EmptyOptionsContext.INSTANCE );
-	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[] { "id" } );
+	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "name", "publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES, EmptyOptionsContext.INSTANCE );
+	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[]{ "id" } );
 
-	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[] { -666 } );
+	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[]{ -666 } );
 
 	private static final BoardGame DOMINION = new BoardGame( 1, "Dominion" );
 	private static final BoardGame KING_OF_TOKYO = new BoardGame( 2, "King of Tokyo" );
@@ -60,7 +59,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithoutNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -88,7 +87,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -115,7 +114,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@Test
 	public void testGetTuplesWithAllNulls() throws Exception {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
@@ -141,7 +140,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@Before
 	public void prepareDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			try {
 				session.persist( DOMINION );
@@ -158,7 +157,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@After
 	public void deleteDataset() {
-		try (OgmSession session = openSession()) {
+		try ( OgmSession session = openSession() ) {
 			Transaction tx = session.beginTransaction();
 			delete( session, DOMINION );
 			delete( session, SPLENDOR );
@@ -184,7 +183,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { BoardGame.class };
+		return new Class<?>[]{ BoardGame.class };
 	}
 
 	@Entity


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1046

This patch doesn't speed up things as I initially thought, it seems the tests take a lot  of time when the EntityManagerFactory is initialized.

That said, the transaction wasn't committed in the end, and with Neo4j remote it takes longer to execute the build without this fix.