### PR TITLE
[5.1] OGM-982 - Upgrade to ORM 5.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
         <neo4jCypherCompiler22Version>2.2.6</neo4jCypherCompiler22Version>
         <!-- Neo4j does not support Lucene 4 currently-->
         <neo4jLuceneVersion>3.6.2</neo4jLuceneVersion>
-        <hibernateVersion>5.0.9.Final</hibernateVersion>
+        <hibernateVersion>5.1.0.Final</hibernateVersion>
         <hibernateSearchVersion>5.5.3.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.2.0.Final</hibernateParserVersion>
         <hibernateCommonsAnnotationsVersion>5.0.1.Final</hibernateCommonsAnnotationsVersion>
@@ -228,6 +228,11 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-infinispan</artifactId>
+                <version>${hibernateVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-java8</artifactId>
                 <version>${hibernateVersion}</version>
             </dependency>
 

--- a/core/src/main/java/org/hibernate/ogm/boot/impl/OgmSessionFactoryBuilderImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/boot/impl/OgmSessionFactoryBuilderImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.ogm.OgmSessionFactory;
 import org.hibernate.ogm.boot.OgmSessionFactoryBuilder;
 import org.hibernate.ogm.hibernatecore.impl.OgmSessionFactoryImpl;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 
 /**
  * {@link SessionFactoryBuilder} building tge {@link OgmSessionFactory}.
@@ -52,5 +53,10 @@ public class OgmSessionFactoryBuilderImpl extends AbstractDelegatingSessionFacto
 		OgmSessionFactoryOptions options = new OgmSessionFactoryOptions( delegate.buildSessionFactoryOptions() );
 
 		return new OgmSessionFactoryImpl( new SessionFactoryImpl( metadata, options ) );
+	}
+
+	@Override
+	public SessionFactoryBuilder applyConnectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
+		return delegate.applyConnectionHandlingMode( connectionHandlingMode );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
@@ -440,4 +440,9 @@ public class OgmSessionFactoryImpl implements OgmSessionFactoryImplementor {
 	public DeserializationResolver getDeserializationResolver() {
 		return delegate.getDeserializationResolver();
 	}
+
+	@Override
+	public String getUuid() {
+		return delegate.getUuid();
+	}
 }

--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -1135,7 +1135,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 
 		//FIXME figure out what that means and what value should be set
 		//boolean eagerPropertyFetch = isEagerPropertyFetchEnabled(i);
-		boolean eagerPropertyFetch = true;
+		boolean fetchAllPropertiesRequested = true;
 
 		// add temp entry so that the next step is circular-reference
 		// safe - only needed because some types don't take proper
@@ -1145,7 +1145,6 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				object,
 				persister,
 				lockMode,
-				!eagerPropertyFetch,
 				session
 		);
 
@@ -1161,7 +1160,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				object,
 				rootPersister,
 				//cols,
-				eagerPropertyFetch,
+				fetchAllPropertiesRequested,
 				session
 			);
 
@@ -1201,7 +1200,6 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				rowId,
 				object,
 				lockMode,
-				!eagerPropertyFetch,
 				session
 			);
 

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -23,7 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
 import org.hibernate.StaleObjectStateException;
-import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -607,6 +607,10 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 	public Object initializeLazyProperty(String fieldName, Object entity, SessionImplementor session)
 			throws HibernateException {
 
+		if ( true ) {
+			throw new RuntimeException( "BOOM" );
+		}
+
 		final Serializable id = session.getContextEntityIdentifier( entity );
 
 		final EntityEntry entry = session.getPersistenceContext().getEntry( entity );
@@ -627,10 +631,10 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			Object ce = getCacheAccessStrategy().get( session, cacheKey, session.getTimestamp() );
 			if ( ce != null ) {
 				CacheEntry cacheEntry = (CacheEntry) getCacheEntryStructure().destructure( ce, getFactory() );
-				if ( !cacheEntry.areLazyPropertiesUnfetched() ) {
-					// note early exit here:
-					return initializeLazyPropertiesFromCache( fieldName, entity, session, entry, cacheEntry );
-				}
+				final Object initializedValue = initializeLazyPropertiesFromCache( fieldName, entity, session, entry, cacheEntry );
+
+				// NOTE EARLY EXIT!!!
+				return initializedValue;
 			}
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/transaction/emulated/impl/EmulatedLocalTransactionCoordinatorBuilder.java
+++ b/core/src/main/java/org/hibernate/ogm/transaction/emulated/impl/EmulatedLocalTransactionCoordinatorBuilder.java
@@ -48,7 +48,7 @@ public class EmulatedLocalTransactionCoordinatorBuilder implements TransactionCo
 
 	@Override
 	public ConnectionAcquisitionMode getDefaultConnectionAcquisitionMode() {
-		return ConnectionAcquisitionMode.DEFAULT;
+		return ConnectionAcquisitionMode.IMMEDIATELY;
 	}
 
 	/**

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -147,6 +147,15 @@
                                         <overWrite>false</overWrite>
                                         <outputDirectory>${jboss.home}/modules</outputDirectory>
                                     </artifactItem>
+                                    <artifactItem>
+                                        <groupId>org.hibernate</groupId>
+                                        <artifactId>hibernate-search-modules</artifactId>
+                                        <version>${hibernateSearchVersion}</version>
+                                        <classifier>wildfly-10-dist</classifier>
+                                        <type>zip</type>
+                                        <overWrite>false</overWrite>
+                                        <outputDirectory>${jboss.home}/modules</outputDirectory>
+                                    </artifactItem>
                                 </artifactItems>
                             </configuration>
                         </execution>

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/cassandra/ModulesMagicDeckIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/cassandra/ModulesMagicDeckIT.java
@@ -43,6 +43,7 @@ public class ModulesMagicDeckIT extends MagiccardsDatabaseScenario {
 				.create( WebArchive.class, "modules-magic-cassandra.war" )
 				.addClasses( MagicCard.class, MagicCardsCollectionBean.class, ModulesMagicDeckIT.class, MagiccardsDatabaseScenario.class );
 		String persistenceXml = persistenceXml().exportAsString();
+		persistenceXml = ModulesHelper.injectVariables( persistenceXml );
 		webArchive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 		ModulesHelper.addModulesDependencyDeclaration( webArchive, "org.hibernate.ogm:${hibernate-ogm.module.slot} services, org.hibernate.ogm.cassandra:${hibernate-ogm.module.slot} services" );
 		return webArchive;
@@ -61,7 +62,8 @@ public class ModulesMagicDeckIT extends MagiccardsDatabaseScenario {
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.ogm.datastore.database" ).value( "ogm_test_database" ).up()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "cassandra_experimental" ).up()
-					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up();
+					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up();
 
 		setCassandraHostName( properties );
 		setCassandraPort( properties );

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/couchdb/CouchDBModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/couchdb/CouchDBModuleMemberRegistrationIT.java
@@ -80,6 +80,7 @@ public class CouchDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 							.createProperty().name( "hibernate.ogm.datastore.create_database" ).value( "true" ).up()
 							.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 							.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+							.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 					.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationIT.java
@@ -45,6 +45,7 @@ public class EhcacheModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
@@ -47,6 +47,7 @@ public class EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT exte
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
@@ -46,6 +46,7 @@ public class InfinispanModuleMemberRegistrationIT extends ModuleMemberRegistrati
 				.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 			.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
@@ -36,6 +36,7 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 				.create( WebArchive.class, "modules-magic-searchit.war" )
 				.addClasses( MagicCard.class, MagicCardsCollectionBean.class, SearchIntegrationIT.class, MagiccardsDatabaseScenario.class );
 		String persistenceXml = persistenceXml().exportAsString();
+		persistenceXml = ModulesHelper.injectVariables( persistenceXml );
 		webArchive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 		ModulesHelper.addModulesDependencyDeclaration( webArchive, "org.hibernate.ogm:${hibernate-ogm.module.slot} services, org.hibernate.ogm.infinispan:${hibernate-ogm.module.slot} services" );
 		return webArchive;
@@ -54,7 +55,8 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
 					.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
-					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up();
+					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up();
 		return descriptor;
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
@@ -100,6 +100,7 @@ public class MongoDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 					.createProperty().name( "jboss.as.jpa.providerModule" ).value( "application" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/Neo4jJtaModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/Neo4jJtaModuleMemberRegistrationIT.java
@@ -65,6 +65,7 @@ public class Neo4jJtaModuleMemberRegistrationIT extends ModuleMemberRegistration
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.createProperty().name( "jboss.as.jpa.providerModule" ).value( "application" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 		return persistenceDescriptor;
 	}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/Neo4jResourceLocalModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/Neo4jResourceLocalModuleMemberRegistrationIT.java
@@ -61,6 +61,7 @@ public class Neo4jResourceLocalModuleMemberRegistrationIT extends ModuleMemberRe
 				.up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "jboss.as.jpa.providerModule" ).value( "application" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 		return persistenceDescriptor;
 	}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationIT.java
@@ -70,6 +70,7 @@ public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationSce
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.createProperty().name( "jboss.as.jpa.providerModule" ).value( "application" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
@@ -83,6 +83,7 @@ public class RedisModuleMemberRegistrationWithTTLConfiguredIT extends ModuleMemb
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "hibernate.transaction.jta.platform" ).value( "JBossAS" ).up()
 				.createProperty().name( "jboss.as.jpa.providerModule" ).value( "application" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModuleMemberRegistrationDeployment.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModuleMemberRegistrationDeployment.java
@@ -48,6 +48,7 @@ public class ModuleMemberRegistrationDeployment {
 		public Builder persistenceXml(PersistenceDescriptor descriptor) {
 			resourceLocal = descriptor.getOrCreatePersistenceUnit().getTransactionType() == PersistenceUnitTransactionType._RESOURCE_LOCAL;
 			String persistenceXml = descriptor.exportAsString();
+			persistenceXml = ModulesHelper.injectVariables( persistenceXml );
 			archive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 			return this;
 		}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModulesHelper.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModulesHelper.java
@@ -58,7 +58,7 @@ public class ModulesHelper {
 		return new StringAsset( manifest );
 	}
 
-	private static String injectVariables(String dependencies) {
+	public static String injectVariables(String dependencies) {
 		String variablesFromProperties = injectVariablesFromProperties( dependencies );
 		//The OGM module slot is "hardcoded" as a special case:
 		return applyPropertyReplacement( variablesFromProperties, "hibernate-ogm.module.slot", getModuleSlotString() );

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>hibernate-envers</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-java8</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- This is to satisfy Neo4J's custom Lucene,
           not to be confused with the one used by Hibernate Search -->
         <dependency>

--- a/modules/wildfly/src/main/aliases/org/hibernate/search/engine/module.xml
+++ b/modules/wildfly/src/main/aliases/org/hibernate/search/engine/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module-alias xmlns="urn:jboss:module:1.1"
+    name="org.hibernate.search.engine" slot="${hibernate-search.module.slot}"
+    target-name="org.hibernate.search.engine" target-slot="${hibernateSearchVersion}" />

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -119,6 +119,30 @@
             <outputDirectory>/org/hibernate/ogm/internal/parboiled/${hibernate.ogm.module.slot}</outputDirectory>
             <filtered>true</filtered>
         </file>
+
+        <!-- ORM 5.1 -->
+        <file>
+            <source>${module.xml.basedir}/org/hibernate/module.xml</source>
+            <outputDirectory>/org/hibernate/${hibernate-orm.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>${module.xml.basedir}/org/hibernate/infinispan/module.xml</source>
+            <outputDirectory>/org/hibernate/infinispan/${hibernate-orm.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+
+        <!-- HSEARCH 5.5 using ORM 5.1 -->
+        <file>
+            <source>${module.xml.basedir}/org/hibernate/search/orm/module.xml</source>
+            <outputDirectory>/org/hibernate/search/orm/${hibernate-search.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>${module.xml.aliases.basedir}/org/hibernate/search/engine/module.xml</source>
+            <outputDirectory>/org/hibernate/search/engine/${hibernate-search.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
     </files>
 
     <dependencySets>

--- a/modules/wildfly/src/main/modules/ogm/core/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/core/module.xml
@@ -10,7 +10,7 @@
         <resource-root path="hibernate-ogm-core-${project.version}.jar" />
     </resources>
     <dependencies>
-        <module name="org.hibernate" export="true" />
+        <module name="org.hibernate" export="true" slot="${hibernate-orm.module.slot}" />
         <module name="org.hibernate.commons-annotations" />
         <module name="org.hibernate.hql" slot="${hibernate.hql.module.slot}" />
         <module name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}" optional="true" />

--- a/modules/wildfly/src/main/modules/org/hibernate/infinispan/module.xml
+++ b/modules/wildfly/src/main/modules/org/hibernate/infinispan/module.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.infinispan" slot="${hibernate-orm.module.slot}">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+
+    <resources>
+        <artifact name="org.hibernate:hibernate-infinispan:${hibernateVersion}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.hibernate" slot="${hibernate-orm.module.slot}"/>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="org.infinispan" services="import"/>
+        <module name="org.infinispan.commons"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/modules/wildfly/src/main/modules/org/hibernate/module.xml
+++ b/modules/wildfly/src/main/modules/org/hibernate/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+
+<!-- Represents the Hibernate 5.1.x module-->
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="${hibernate-orm.module.slot}">
+    <resources>
+        <artifact name="org.hibernate:hibernate-core:${hibernateVersion}"/>
+        <artifact name="org.hibernate:hibernate-envers:${hibernateVersion}"/>
+        <artifact name="org.hibernate:hibernate-entitymanager:${hibernateVersion}"/>
+        <artifact name="org.hibernate:hibernate-java8:${hibernateVersion}"/>
+    </resources>
+
+    <dependencies>
+        <module name="asm.asm"/>
+        <module name="com.fasterxml.classmate"/>
+        <module name="javax.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.persistence.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.validation.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.antlr"/>
+        <module name="org.dom4j"/>
+        <module name="org.javassist"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.hibernate.commons-annotations"/>
+        <module name="org.hibernate.infinispan" services="import" optional="true" slot="${hibernate-orm.module.slot}" />
+        <module name="org.hibernate.jipijapa-hibernate5" services="import"/>
+    </dependencies>
+</module>

--- a/modules/wildfly/src/main/modules/org/hibernate/search/orm/module.xml
+++ b/modules/wildfly/src/main/modules/org/hibernate/search/orm/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}">
+    <resources>
+        <artifact name="org.hibernate:hibernate-search-orm:${hibernateSearchVersion}"/>
+    </resources>
+    <dependencies>
+        <module name="javax.transaction.api" />
+        <module name="org.hibernate" slot="5.1" />
+        <module name="org.hibernate.commons-annotations" />
+        <module name="org.hibernate.search.engine" export="true" services="import" slot="${hibernateSearchVersion}" />
+        <module name="org.jboss.logging" />
+        <module name="javax.persistence.api" />
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,11 @@
         <!-- Since we require users to import a specific Hibernate Search module explicitly,
          all integration tests need to know which version that shall be.
          So the property needs to be defined in the global parent pom -->
-        <hibernate-search.module.slot>main</hibernate-search.module.slot>
+        <hibernate-search.module.slot>5.5.3.Final-orm51</hibernate-search.module.slot>
         <!-- Following might not match the slot, for example when 'main' is being used. Needed in docs URL rendering. -->
         <hibernate-search-major-minor-version>5.5</hibernate-search-major-minor-version>
+
+        <hibernate-orm.module.slot>5.1</hibernate-orm.module.slot>
     </properties>
 
     <!-- Only for management of test-scoped dependencies; All other dependencies (which are exposed to users) are


### PR DESCRIPTION
The actual update wasn't too hard, that's done in the first commit. The more challenging issue was getting the integration tests to work. The reason being that WF 10 - naturally - still contains ORM 5.0. So that's what I did to make it work:

* Create a new module for ORM 5.1; Note that it doesn't contain the actual JARs but refers to them via Maven artifact coordinates; That requires a Maven repo on the system running WF, but I find that a good compromise for the sake of not futher increasing the size of the module ZIP
* Create a new module for HSEARCH 5.5.3-orm51; This is to make HSEARCH use ORM 5.1 instead of 5.0, as otherwise OGM and HSEARCH would work with conflicting ORM versions. This requires the 5.5.3 HSEARCH module ZIP to have been unzipped.

Let me know what you think. If we agree on the general approach, I'll update the docs.