### PR TITLE
OGM-1038 Pass transaction id to dialects

### DIFF
--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -490,7 +490,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 
 	@Override
 	public ClosableIterator<Tuple> executeBackendQuery(
-			BackendQuery<String> query, QueryParameters queryParameters) {
+			BackendQuery<String> query, QueryParameters queryParameters, TupleContext tupleContext) {
 
 		Object[] parameters = new Object[queryParameters.getPositionalParameters().size()];
 		int i = 0;
@@ -521,7 +521,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters) {
+	public int executeBackendUpdateQuery(BackendQuery<String> query, QueryParameters queryParameters, TupleContext tupleContext) {
 		// TODO implement. org.hibernate.ogm.datastore.mongodb.MongoDBDialect.executeBackendUpdateQuery(BackendQuery<MongoDBQueryDescriptor>, QueryParameters) might be helpful as a reference.
 		throw new UnsupportedOperationException("Not yet implemented.");
 	}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
@@ -10,6 +10,7 @@ import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.util.impl.Contracts;
@@ -25,21 +26,26 @@ public class AssociationContextImpl implements AssociationContext {
 	private final AssociationTypeContext associationTypeContext;
 	private final OperationsQueue operationsQueue;
 	private final Tuple entityTuple;
+	private final TransactionContext transactionContext;
 
-	public AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple) {
-		this( associationTypeContext, entityTuple, null );
+	public AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple, TransactionContext transactionContext) {
+		this( associationTypeContext, entityTuple, null, transactionContext );
 	}
 
 	public AssociationContextImpl(AssociationContextImpl original, OperationsQueue operationsQueue) {
-		this( original.associationTypeContext, original.entityTuple, operationsQueue );
+		this( original.associationTypeContext, original.entityTuple, operationsQueue, original.transactionContext );
 	}
 
-	private AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple, OperationsQueue operationsQueue) {
+	private AssociationContextImpl(AssociationTypeContext associationTypeContext,
+			Tuple entityTuple,
+			OperationsQueue operationsQueue,
+			TransactionContext transactionContext) {
 		Contracts.assertParameterNotNull( associationTypeContext, "associationTypeContext" );
 
 		this.associationTypeContext = associationTypeContext;
 		this.entityTuple = entityTuple;
 		this.operationsQueue = operationsQueue;
+		this.transactionContext = transactionContext;
 	}
 
 	@Override
@@ -50,6 +56,11 @@ public class AssociationContextImpl implements AssociationContext {
 	@Override
 	public OperationsQueue getOperationsQueue() {
 		return operationsQueue;
+	}
+
+	@Override
+	public TransactionContext getTransactionContext() {
+		return transactionContext;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/EmptyTransactionContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/EmptyTransactionContext.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
+/**
+ * A {@link TransactionContext} that can be used when the dialect does not need to know the transaction id.
+ *
+ * @author Davide D'Alto
+ */
+public class EmptyTransactionContext implements TransactionContext {
+
+	public static TransactionContext INSTANCE = new EmptyTransactionContext();
+
+	private static final Log LOG = LoggerFactory.make();
+
+	private EmptyTransactionContext() {
+	}
+
+	@Override
+	public Object getTransactionId() {
+		throw LOG.transactionIdIsNotAvailable();
+	}
+
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -181,13 +181,13 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	 */
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters) {
-		return queryableGridDialect.executeBackendQuery( query, queryParameters );
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters, TupleContext tupleContext) {
+		return queryableGridDialect.executeBackendQuery( query, queryParameters, tupleContext );
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters) {
-		return queryableGridDialect.executeBackendUpdateQuery( query, queryParameters );
+	public int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters, TupleContext tupleContext) {
+		return queryableGridDialect.executeBackendUpdateQuery( query, queryParameters, tupleContext );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
@@ -139,8 +139,8 @@ public class GridDialectLogger extends ForwardingGridDialect<Serializable> {
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters) {
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters, TupleContext tupleContext) {
 		log.tracef( "Executing backend query: %1$s", query.getQuery() );
-		return super.executeBackendQuery( query, queryParameters );
+		return super.executeBackendQuery( query, queryParameters, tupleContext );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/IdentifiableDriver.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/IdentifiableDriver.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
+
+/**
+ * A {@link TransactionDriver} that can return an identifier for the underlying transaction.
+ *
+ * @author Davide D'Alto
+ */
+public interface IdentifiableDriver extends TransactionDriver {
+
+	Object getTransactionId();
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TransactionContextImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+
+/**
+ * Default implementation of the {@link TransactionContext}.
+ *
+ * @author Davide D'Alto
+ */
+public class TransactionContextImpl implements TransactionContext {
+
+	private final Object transactionId;
+
+	public TransactionContextImpl(IdentifiableDriver driver) {
+		this.transactionId = driver.getTransactionId();
+	}
+
+	@Override
+	public Object getTransactionId() {
+		return transactionId;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.options.spi.OptionsContext;
@@ -27,6 +28,7 @@ public class TupleContextImpl implements TupleContext {
 	private final List<String> selectableColumns;
 	private final OptionsContext optionsContext;
 	private final OperationsQueue operationsQueue;
+	private final TransactionContext transactionContext;
 
 	/**
 	 * Information of the associated entity stored per foreign key column names
@@ -36,19 +38,30 @@ public class TupleContextImpl implements TupleContext {
 	private final Map<String, String> roles;
 
 	public TupleContextImpl(TupleContextImpl original, OperationsQueue operationsQueue) {
-		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, operationsQueue );
+		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, operationsQueue, original.transactionContext );
 	}
 
-	public TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext) {
-		this( selectableColumns, associatedEntityMetadata, roles, optionsContext, null );
+	public TupleContextImpl(TupleContextImpl original, TransactionContext transactionContext) {
+		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, original.operationsQueue, transactionContext );
 	}
 
-	private TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext, OperationsQueue operationsQueue) {
+	public TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext, TransactionContext transactionContext) {
+		this( selectableColumns, associatedEntityMetadata, roles, optionsContext, null, transactionContext );
+	}
+
+	private TupleContextImpl(List<String> selectableColumns,
+			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
+			Map<String, String> roles,
+			OptionsContext optionsContext,
+			OperationsQueue operationsQueue,
+			TransactionContext transactionContext) {
+
 		this.selectableColumns = selectableColumns;
 		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
 		this.roles = Collections.unmodifiableMap( roles );
 		this.optionsContext = optionsContext;
 		this.operationsQueue = operationsQueue;
+		this.transactionContext = transactionContext;
 	}
 
 	@Override
@@ -59,6 +72,11 @@ public class TupleContextImpl implements TupleContext {
 	@Override
 	public OptionsContext getOptionsContext() {
 		return optionsContext;
+	}
+
+	@Override
+	public TransactionContext getTransactionContext() {
+		return transactionContext;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/BackendQuery.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/BackendQuery.java
@@ -11,7 +11,7 @@ import org.hibernate.ogm.util.Experimental;
 
 /**
  * Represents a NoSQL query as to be executed via
- * {@link QueryableGridDialect#executeBackendQuery(BackendQuery, QueryParameters)}.
+ * {@link QueryableGridDialect#executeBackendQuery(BackendQuery, QueryParameters, TupleContext)}
  * <p>
  * The wrapped query object generally represents the query in the native form supported by a given datastore, e.g. a
  * String in a native query syntax or an object-based query representation such as the {@code DBObject}-based query

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryParameters.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryParameters.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.TypedValue;
 import org.hibernate.ogm.type.spi.TypeTranslator;
 
@@ -33,14 +34,14 @@ public class QueryParameters {
 		this.positionalParameters = positionalParameters;
 	}
 
-	public static QueryParameters fromOrmQueryParameters(org.hibernate.engine.spi.QueryParameters parameters, TypeTranslator typeTranslator) {
+	public static QueryParameters fromOrmQueryParameters(org.hibernate.engine.spi.QueryParameters parameters, TypeTranslator typeTranslator, SessionFactoryImplementor sessionFactoryImplementor) {
 		RowSelection selection = RowSelection.fromOrmRowSelection( parameters.getRowSelection() );
-		Map<String, TypedGridValue> namedParameters = new HashMap<>();
+		Map<String, TypedGridValue> namedParameters = createNamedParameters( sessionFactoryImplementor, parameters, typeTranslator );
+		List<TypedGridValue> positionalParameters = createPositionalParameters( parameters, typeTranslator );
+		return new QueryParameters( selection, namedParameters, positionalParameters);
+	}
 
-		for ( Entry<String, TypedValue> parameter : parameters.getNamedParameters().entrySet() ) {
-			namedParameters.put( parameter.getKey(), TypedGridValue.fromOrmTypedValue( parameter.getValue(), typeTranslator ) );
-		}
-
+	private static List<TypedGridValue> createPositionalParameters(org.hibernate.engine.spi.QueryParameters parameters, TypeTranslator typeTranslator) {
 		List<TypedGridValue> positionalParameters = new ArrayList<>( parameters.getPositionalParameterTypes().length );
 		for ( int i = 0; i < parameters.getPositionalParameterTypes().length; i++) {
 			positionalParameters.add(
@@ -50,7 +51,16 @@ public class QueryParameters {
 					)
 			);
 		}
-		return new QueryParameters( selection, namedParameters, positionalParameters );
+		return positionalParameters;
+	}
+
+	private static Map<String, TypedGridValue> createNamedParameters(SessionFactoryImplementor factory, org.hibernate.engine.spi.QueryParameters parameters, TypeTranslator typeTranslator) {
+		Map<String, TypedGridValue> namedParameters = new HashMap<>();
+		for ( Entry<String, TypedValue> parameter : parameters.getNamedParameters().entrySet() ) {
+			TypedGridValue typedGridValue = TypedGridValue.fromOrmTypedValue( parameter.getValue(), typeTranslator, factory );
+			namedParameters.put( parameter.getKey(), typedGridValue );
+		}
+		return namedParameters;
 	}
 
 	public RowSelection getRowSelection() {

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryableGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/QueryableGridDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.dialect.query.spi;
 import java.io.Serializable;
 
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.spi.Tuple;
 
 /**
@@ -27,9 +28,10 @@ public interface QueryableGridDialect<T extends Serializable> extends GridDialec
 	 * @param query the query to execute in a representation understood by the underlying datastore. May have been
 	 * created by converting a JP-QL query or from a (named) native query.
 	 * @param queryParameters parameters passed for this query
+	 * @param tupleContext
 	 * @return an {@link ClosableIterator} with the result of the query
 	 */
-	ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters);
+	ClosableIterator<Tuple> executeBackendQuery(BackendQuery<T> query, QueryParameters queryParameters, TupleContext tupleContext);
 
 	/**
 	 * Returns the result of a native update query executed on the backend.
@@ -45,7 +47,7 @@ public interface QueryableGridDialect<T extends Serializable> extends GridDialec
 	 * @param queryParameters parameters passed for this query
 	 * @return the number of elements that have been updated.
 	 */
-	int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters);
+	int executeBackendUpdateQuery(BackendQuery<T> query, QueryParameters queryParameters, TupleContext queryContext);
 
 	/**
 	 * Returns a builder for retrieving parameter meta-data from native queries in this datastore's format.

--- a/core/src/main/java/org/hibernate/ogm/dialect/query/spi/TypedGridValue.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/query/spi/TypedGridValue.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.dialect.query.spi;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.TypedValue;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.ogm.type.spi.TypeTranslator;
@@ -26,9 +27,10 @@ public class TypedGridValue {
 		this.value = value;
 	}
 
-	public static TypedGridValue fromOrmTypedValue(TypedValue typedValue, TypeTranslator typeTranslator) {
+	public static TypedGridValue fromOrmTypedValue(TypedValue typedValue, TypeTranslator typeTranslator, SessionFactoryImplementor factory) {
 		GridType gridType = typeTranslator.getType( typedValue.getType() );
-		return new TypedGridValue( gridType, typedValue.getValue() );
+		Object backendValue = gridType.convertToBackendType( typedValue.getValue(), factory );
+		return new TypedGridValue( gridType, backendValue );
 	}
 
 	public GridType getType() {

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
@@ -40,4 +40,11 @@ public interface AssociationContext {
 	 * @return A tuple representing the entity on the current side of the association
 	 */
 	Tuple getEntityTuple();
+
+	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TransactionContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TransactionContext.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.spi;
+
+/**
+ * Contains information about the running transaction.
+ *
+ * @author Davide D'Alto
+ */
+public interface TransactionContext {
+
+	/**
+	 * A value that can be used to identify the running transaction.
+	 *
+	 * @return the transaction identifier
+	 */
+	Object getTransactionId();
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
@@ -29,6 +29,13 @@ public interface TupleContext {
 	OptionsContext getOptionsContext();
 
 	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
+
+	/**
 	 * Returns the mapped columns of the given entity. May be used by a dialect to only load those columns instead of
 	 * the complete document/record. If the dialect supports the embedded storage of element collections and
 	 * associations, the respective columns will be part of the returned list as well.

--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -568,7 +568,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 					keys[index] = EntityKeyBuilder.fromPersister( persister, (Serializable) qp.getPositionalParameterValues()[index], session );
 				}
 				if ( multigetGridDialect != null ) {
-					for ( Tuple tuple : multigetGridDialect.getTuples( keys, persister.getTupleContext() ) ) {
+					for ( Tuple tuple : multigetGridDialect.getTuples( keys, persister.getTupleContext( session ) ) ) {
 						if ( tuple != null ) {
 							resultset.addTuple( tuple );
 						}
@@ -576,7 +576,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				}
 				else {
 					for ( EntityKey entityKey : keys ) {
-						Tuple entry = gridDialect.getTuple( entityKey, persister.getTupleContext() );
+						Tuple entry = gridDialect.getTuple( entityKey, persister.getTupleContext( session ) );
 						if ( entry != null ) {
 							resultset.addTuple( entry );
 						}
@@ -585,7 +585,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 			}
 			else {
 				final EntityKey key = EntityKeyBuilder.fromPersister( persister, id, session );
-				Tuple entry = gridDialect.getTuple( key, persister.getTupleContext() );
+				Tuple entry = gridDialect.getTuple( key, persister.getTupleContext( session ) );
 				if ( entry != null ) {
 					resultset.addTuple( entry );
 				}

--- a/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchIndexingWorkspace.java
+++ b/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchIndexingWorkspace.java
@@ -74,7 +74,7 @@ public class BatchIndexingWorkspace implements Runnable {
 			final EntityKeyMetadata keyMetadata = new DefaultEntityKeyMetadata( persister.getTableName(), persister.getRootTableIdentifierColumnNames() );
 
 			final SessionAwareRunnable consumer = new TupleIndexer( indexedType, monitor, sessionFactory, searchIntegrator, cacheMode, batchBackend, errorHandler, tenantId );
-			gridDialect.forEachTuple( new OptionallyWrapInJTATransaction( sessionFactory, errorHandler, consumer ), persister.getTupleContext(), keyMetadata );
+			gridDialect.forEachTuple( new OptionallyWrapInJTATransaction( sessionFactory, errorHandler, consumer ), persister.getTupleContext( null ), keyMetadata );
 		}
 		catch ( RuntimeException re ) {
 			// being this an async thread we want to make sure everything is somehow reported

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -621,7 +621,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			OgmEntityPersister persister = (OgmEntityPersister) getElementPersister();
 			final EntityKey entityKey = EntityKeyBuilder.fromPersister( persister, entityId, session );
 
-			final Tuple entityTuple = gridDialect.getTuple( entityKey, persister.getTupleContext() );
+			final Tuple entityTuple = gridDialect.getTuple( entityKey, persister.getTupleContext( session ) );
 			// the entity tuple could already be gone (not 100% sure this can happen but that feels right)
 			if ( entityTuple == null ) {
 				return;
@@ -640,7 +640,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			else {
 				throw new AssertionFailure( "Unknown action type: " + action );
 			}
-			gridDialect.insertOrUpdateTuple( entityKey, entityTuple, persister.getTupleContext() );
+			gridDialect.insertOrUpdateTuple( entityKey, entityTuple, persister.getTupleContext( session ) );
 		}
 		else if ( associationType == AssociationType.ASSOCIATION_TABLE_TO_ENTITY ) {
 			String[] elementColumnNames = getElementColumnNames();

--- a/core/src/main/java/org/hibernate/ogm/query/impl/NativeNoSqlQueryPlan.java
+++ b/core/src/main/java/org/hibernate/ogm/query/impl/NativeNoSqlQueryPlan.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.query.impl;
 
+import static org.hibernate.ogm.util.impl.TupleContextHelper.tupleContext;
+
 import java.io.Serializable;
 
 import org.hibernate.HibernateException;
@@ -15,6 +17,7 @@ import org.hibernate.loader.custom.CustomQuery;
 import org.hibernate.ogm.dialect.query.spi.BackendQuery;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
 import org.hibernate.ogm.dialect.query.spi.QueryableGridDialect;
+import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.loader.nativeloader.impl.BackendCustomQuery;
 import org.hibernate.ogm.type.spi.TypeTranslator;
 
@@ -35,14 +38,18 @@ class NativeNoSqlQueryPlan extends NativeSQLQueryPlan {
 	public int performExecuteUpdate(org.hibernate.engine.spi.QueryParameters queryParameters, SessionImplementor session) throws HibernateException {
 		QueryableGridDialect<?> gridDialect = session.getFactory().getServiceRegistry().getService( QueryableGridDialect.class );
 		TypeTranslator typeTranslator = session.getFactory().getServiceRegistry().getService( TypeTranslator.class );
-		return performExecuteUpdateQuery( gridDialect, QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
+		return performExecuteUpdateQuery( gridDialect, QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator, session.getFactory() ), session );
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T extends Serializable> int performExecuteUpdateQuery( QueryableGridDialect<T> gridDialect, QueryParameters queryParameters ) {
-		// Safe cast, see org.hibernate.ogm.query.impl.NativeNoSqlQueryInterpreter.createQueryPlan(NativeSQLQuerySpecification, SessionFactoryImplementor)
+	private <T extends Serializable> int performExecuteUpdateQuery(QueryableGridDialect<T> gridDialect, QueryParameters queryParameters,
+			SessionImplementor session) {
+		// Safe cast, see
+		// org.hibernate.ogm.query.impl.NativeNoSqlQueryInterpreter.createQueryPlan(NativeSQLQuerySpecification,
+		// SessionFactoryImplementor)
 		BackendCustomQuery<T> customQuery = (BackendCustomQuery<T>) getCustomQuery();
 		BackendQuery<T> backendQuery = new BackendQuery<T>( customQuery.getQueryObject(), customQuery.getSingleEntityMetadataInformationOrNull() );
-		return gridDialect.executeBackendUpdateQuery( backendQuery, queryParameters );
+		TupleContext tupleContext = tupleContext( session, customQuery.getSingleEntityMetadataInformationOrNull() );
+		return gridDialect.executeBackendUpdateQuery( backendQuery, queryParameters, tupleContext );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/query/impl/OgmQueryLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/query/impl/OgmQueryLoader.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.query.impl;
 
+import static org.hibernate.ogm.util.impl.TupleContextHelper.tupleContext;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -67,7 +69,7 @@ public class OgmQueryLoader extends QueryLoader {
 	protected List<?> list(SessionImplementor session, org.hibernate.engine.spi.QueryParameters queryParameters, Set<Serializable> querySpaces, Type[] resultTypes)
 			throws HibernateException {
 
-		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator ) );
+		ClosableIterator<Tuple> tuples = loaderContext.executeQuery( session, QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator, session.getFactory() ) );
 		try {
 			if ( hasScalars ) {
 				return listOfArrays( session, tuples );
@@ -143,8 +145,8 @@ public class OgmQueryLoader extends QueryLoader {
 			this.query = query;
 		}
 
-		public ClosableIterator<Tuple> executeQuery(QueryParameters queryParameters) {
-			return gridDialect.executeBackendQuery( query, queryParameters );
+		public ClosableIterator<Tuple> executeQuery(SessionImplementor session, QueryParameters queryParameters) {
+			return gridDialect.executeBackendQuery( query, queryParameters, tupleContext( session, query.getSingleEntityMetadataInformationOrNull() ) );
 		}
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.util.impl;
 
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
+
 import java.io.Serializable;
 
 import org.hibernate.SessionFactory;
@@ -226,7 +228,8 @@ public class AssociationPersister {
 		if ( associationContext == null ) {
 			associationContext = new AssociationContextImpl(
 					associationTypeContext,
-					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuple() : null
+					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuple() : null,
+					transactionContext( session )
 			);
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -289,4 +289,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 85, value = "Unable to find an entity entry for the entity '%1$s'")
 	PersistenceException cannotFindEntityEntryForEntity(Object entity);
+
+	@Message(id = 86, value = "Transaction identifier not available")
+	HibernateException transactionIdIsNotAvailable();
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TransactionContextHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.util.impl;
+
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.dialect.impl.EmptyTransactionContext;
+import org.hibernate.ogm.dialect.impl.IdentifiableDriver;
+import org.hibernate.ogm.dialect.impl.TransactionContextImpl;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
+import org.hibernate.resource.transaction.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinator.TransactionDriver;
+
+/**
+ * @author Davide D'Alto
+ */
+public final class TransactionContextHelper {
+
+	private TransactionContextHelper() {
+	}
+
+	/**
+	 * Return a transaction context given the session; it never returns {@code null}.
+	 *
+	 * @param session current {@link Session}
+	 * @return the {@link TransactionContext}
+	 */
+	public static TransactionContext transactionContext(Session session) {
+		return transactionContext( (SessionImplementor) session );
+	}
+
+	/**
+	 * Return a transaction context given the session implementor; it never returns {@code null}.
+	 *
+	 * @param session current {@link SessionImplementor}
+	 * @return the {@link TransactionContext}
+	 */
+	public static TransactionContext transactionContext(SessionImplementor session) {
+		TransactionCoordinator transactionCoordinator = session.getTransactionCoordinator();
+		if ( transactionCoordinator != null && transactionCoordinator.getTransactionDriverControl() != null ) {
+			TransactionDriver driver = transactionCoordinator.getTransactionDriverControl();
+			if ( driver instanceof IdentifiableDriver ) {
+				return new TransactionContextImpl( (IdentifiableDriver) driver );
+			}
+		}
+		return EmptyTransactionContext.INSTANCE;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.util.impl;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.spi.EntityMetadataInformation;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+
+/**
+ * @author Davide D'Alto
+ */
+public class TupleContextHelper {
+
+	/**
+	 * Given a {@link SessionImplementor} returns the {@link TupleContext} associated to an entity.
+	 *
+	 * @param session the current session
+	 * @param metadata the {@link EntityMetadataInformation} of the entity associated to the TupleContext
+	 * @return the TupleContext associated to the current session for the entity specified, or {@code null} if the
+	 * EntityMetadataInformation is {@code null}
+	 */
+	public static TupleContext tupleContext(SessionImplementor session, EntityMetadataInformation metadata) {
+		if ( metadata != null ) {
+			OgmEntityPersister persister = (OgmEntityPersister) session.getFactory().getEntityPersister( metadata.getTypeName() );
+			return persister.getTupleContext( session );
+		}
+		return null;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
@@ -9,10 +9,7 @@ package org.hibernate.ogm.backendtck.batchfetching;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -20,17 +17,16 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 
+import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
-import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.utils.EmptyOptionsContext;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.ogm.utils.SkipByGridDialect;
@@ -47,12 +43,6 @@ import org.junit.Test;
 @SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.INFINISPAN, GridDialectType.EHCACHE, GridDialectType.REDIS_HASH })
 public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
-	private static final Map<String, AssociatedEntityKeyMetadata> EMPTY_ASSOCIATION_METADATA = Collections.emptyMap();
-	private static final Map<String, String> EMPTY_ROLES = Collections.emptyMap();
-
-	private static final TupleContext TUPLECONTEXT = new TupleContextImpl( Arrays.asList( "name", "publisher" ), EMPTY_ASSOCIATION_METADATA, EMPTY_ROLES,
-			EmptyOptionsContext.INSTANCE );
-
 	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[]{ "name", "publisher" } );
 
 	private static final EntityKey NOT_IN_THE_DB = new EntityKey( METADATA, new Object[]{ "none", "none" } );
@@ -67,8 +57,8 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
 
-				EntityKey[] keys = new EntityKey[]{ key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
-				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
+				EntityKey[] keys = new EntityKey[] { key( SPLENDOR ), key( DOMINION ), key( KING_OF_TOKYO ) };
+				List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 				assertThat( tuples.get( 0 ).get( "publisher" ) ).isEqualTo( SPLENDOR.getPublisher() );
 				assertThat( tuples.get( 0 ).get( "name" ) ).isEqualTo( SPLENDOR.getName() );
@@ -95,10 +85,8 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
 
-				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
-				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
-
-				assertThat( tuples.get( 0 ) ).isNull();
+				EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, key( KING_OF_TOKYO ), NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 				assertThat( tuples.get( 1 ).get( "publisher" ) ).isEqualTo( KING_OF_TOKYO.getPublisher() );
 				assertThat( tuples.get( 1 ).get( "name" ) ).isEqualTo( KING_OF_TOKYO.getName() );
@@ -122,10 +110,8 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 			try {
 				MultigetGridDialect dialect = multiGetGridDialect();
 
-				EntityKey[] keys = new EntityKey[]{ NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
-				List<Tuple> tuples = dialect.getTuples( keys, TUPLECONTEXT );
-
-				assertThat( tuples ).containsExactly( null, null, null, null );
+				EntityKey[] keys = new EntityKey[] { NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB, NOT_IN_THE_DB };
+				List<Tuple> tuples = dialect.getTuples( keys, tupleContext( session ) );
 
 				tx.commit();
 			}
@@ -134,6 +120,13 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 				throw e;
 			}
 		}
+	}
+
+	private TupleContext tupleContext(Session session) {
+		return new GridDialectOperationContexts.TupleContextBuilder()
+				.selectableColumns( METADATA.getColumnNames() )
+				.transactionContext( session )
+				.buildTupleContext();
 	}
 
 	private EntityKey key(BoardGame boardGame) {

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.datastore.document.impl.EmbeddableStateFinder;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
@@ -92,6 +93,11 @@ public class EmbeddableStateFinderTest {
 
 			@Override
 			public OperationsQueue getOperationsQueue() {
+				return null;
+			}
+
+			@Override
+			public TransactionContext getTransactionContext() {
 				return null;
 			}
 		};

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -6,16 +6,22 @@
  */
 package org.hibernate.ogm.utils;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
+import org.hibernate.Session;
 import org.hibernate.ogm.dialect.impl.AssociationContextImpl;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
 import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
+import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
-import org.hibernate.ogm.options.navigation.impl.OptionsContextImpl;
-import org.hibernate.ogm.options.navigation.source.impl.OptionValueSource;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.impl.TransactionContextHelper;
 
 /**
  * Useful functionality around {@link GridDialectOperationContext}s.
@@ -24,26 +30,72 @@ import org.hibernate.ogm.options.navigation.source.impl.OptionValueSource;
  */
 public class GridDialectOperationContexts {
 
+	public static class TupleContextBuilder {
+
+		private List<String> selectableColumns = Collections.<String>emptyList();
+		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = Collections.<String, AssociatedEntityKeyMetadata>emptyMap();
+		private Map<String, String> roles = Collections.<String, String>emptyMap();
+		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
+		private TransactionContext transactionContext = null;
+
+		public TupleContextBuilder selectableColumns(String... columns) {
+			this.selectableColumns = Arrays.asList( columns );
+			return this;
+		}
+
+		public TupleContextBuilder selectableColumns(List<String> columns) {
+			this.selectableColumns = columns;
+			return this;
+		}
+
+		public TupleContextBuilder transactionContext(Session session) {
+			this.transactionContext = TransactionContextHelper.transactionContext( session );
+			return this;
+		}
+
+		public TupleContextBuilder optionContext(OptionsContext optionsContext) {
+			this.optionsContext = optionsContext;
+			return this;
+		}
+
+		public TupleContext buildTupleContext() {
+			return new TupleContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
+					Collections.unmodifiableMap( roles ), optionsContext, transactionContext );
+		}
+	}
+
+	public static class AssociationContextBuilder {
+
+		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
+		private AssociatedEntityKeyMetadata associatedEntityKeyMetadata = null;
+		private String roleOnMainSide = null;
+		private TransactionContext transactionContext = null;
+		private Tuple tuple = null;
+
+		public AssociationContextBuilder optionContext(OptionsContext optionsContext) {
+			this.optionsContext = optionsContext;
+			return this;
+		}
+
+		public AssociationContextBuilder transactionContext(Session session) {
+			this.transactionContext = TransactionContextHelper.transactionContext( session );
+			return this;
+		}
+
+		public AssociationContext buildAssociationContext() {
+			return new AssociationContextImpl( new AssociationTypeContextImpl( optionsContext, associatedEntityKeyMetadata, roleOnMainSide ), tuple,
+					transactionContext );
+		}
+	}
+
 	private GridDialectOperationContexts() {
 	}
 
 	public static TupleContext emptyTupleContext() {
-		return new TupleContextImpl(
-				Collections.<String>emptyList(),
-				Collections.<String, AssociatedEntityKeyMetadata>emptyMap(),
-				Collections.<String, String>emptyMap(),
-				EmptyOptionsContext.INSTANCE
-		);
+		return new TupleContextBuilder().buildTupleContext();
 	}
 
 	public static AssociationContext emptyAssociationContext() {
-		return new AssociationContextImpl(
-				new AssociationTypeContextImpl(
-						OptionsContextImpl.forProperty( Collections.<OptionValueSource>emptyList(), Object.class, "" ),
-						null,
-						null
-				),
-				null
-		);
+		return new AssociationContextBuilder().buildAssociationContext();
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
@@ -166,8 +166,8 @@ public class InvokedOperationsLoggingDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters) {
-		ClosableIterator<Tuple> result = super.executeBackendQuery( query, queryParameters );
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<Serializable> query, QueryParameters queryParameters, TupleContext tupleContext) {
+		ClosableIterator<Tuple> result = super.executeBackendQuery( query, queryParameters, tupleContext );
 		log( "executeBackendQuery", query.toString() + ", " + queryParameters.toString(), "tbd." );
 		return result;
 	}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -791,7 +791,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	@Override
-	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<MongoDBQueryDescriptor> backendQuery, QueryParameters queryParameters) {
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<MongoDBQueryDescriptor> backendQuery, QueryParameters queryParameters, TupleContext tupleContext) {
 		MongoDBQueryDescriptor queryDescriptor = backendQuery.getQuery();
 
 		EntityKeyMetadata entityKeyMetadata =
@@ -826,7 +826,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	@Override
-	public int executeBackendUpdateQuery(final BackendQuery<MongoDBQueryDescriptor> backendQuery, final QueryParameters queryParameters) {
+	public int executeBackendUpdateQuery(final BackendQuery<MongoDBQueryDescriptor> backendQuery, final QueryParameters queryParameters, final TupleContext tupleContext) {
 		MongoDBQueryDescriptor queryDescriptor = backendQuery.getQuery();
 
 		EntityKeyMetadata entityKeyMetadata =

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.mongodb.test.loading;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.util.impl.TransactionContextHelper.transactionContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -32,14 +33,12 @@ import org.hibernate.ogm.datastore.mongodb.options.AssociationDocumentStorageTyp
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.impl.AssociationContextImpl;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
-import org.hibernate.ogm.dialect.impl.TupleContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.impl.DefaultAssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -53,6 +52,7 @@ import org.hibernate.ogm.options.spi.Option;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.options.spi.UniqueOption;
 import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.service.Service;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -156,7 +156,8 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 						new DefaultAssociatedEntityKeyMetadata( null, null ),
 						null
 				),
-				new Tuple( new MongoDBTupleSnapshot( null, null, null ) )
+				new Tuple( new MongoDBTupleSnapshot( null, null, null ) ),
+				transactionContext( session )
 		);
 
 		final Association association = getService( GridDialect.class ).getAssociation( associationKey, associationContext );
@@ -175,12 +176,10 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 				new DefaultEntityKeyMetadata( collectionName, new String[] { MongoDBDialect.ID_FIELDNAME } ),
 				new Object[] { id }
 		);
-		TupleContext tupleContext = new TupleContextImpl(
-				selectedColumns,
-				Collections.<String, AssociatedEntityKeyMetadata>emptyMap(),
-				Collections.<String, String>emptyMap(),
-				TestOptionContext.INSTANCE
-		);
+		TupleContext tupleContext = new GridDialectOperationContexts.TupleContextBuilder()
+				.selectableColumns( selectedColumns )
+				.optionContext( TestOptionContext.INSTANCE )
+				.buildTupleContext();
 
 		return getService( GridDialect.class ).getTuple( key, tupleContext );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1038

This will make it possible for a dialect to access information about the current transaction. At the moment is only the transaction id.

I haven't added any tests for this specific part since none of the current dialects need this information.
It will be used by the Neo4j remote dialect in following PR.

Note that I added a `QueryContext` to the method executing native queries. It will also store the `TupleContext` removing the need to save the sessionFactory in the Neo4j dialect.

We already discussed about this PR in the pasts but we changed the codebase a bit so, maybe, you won't to have a quick look.