### PR TITLE
Set global UTC timezone for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,7 @@
                         <systemPropertyVariables>
                            <!-- See test org.hibernate.ogm.test.utils.EnvironmentTest -->
                            <hibernate.service.allow_crawling>false</hibernate.service.allow_crawling>
+                           <user.timezone>UTC</user.timezone>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Set default timezone for testing globally. It needs for run  tests in other timezones. 

I am located in Moscow (UTC+3) .I got incorrect work of test org.hibernate.ogm.backendtck.type.BuiltInTypeTest