### PR TITLE
OGM-1082 Include the exception message in the log when we batch several

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/BatchOperationsDelegator.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/BatchOperationsDelegator.java
@@ -77,7 +77,7 @@ public class BatchOperationsDelegator extends ForwardingGridDialect<Serializable
 			// information via the original exception; It'd require a fair bit of changes to obtain the entity name here
 			// (we'd have to obtain the persister matching the given entity key metadata which in turn would require
 			// access to the session factory which is not easily available here)
-			throw log.mustNotInsertSameEntityTwice( null, taee );
+			throw log.mustNotInsertSameEntityTwice( taee.getMessage(), taee );
 		}
 	}
 


### PR DESCRIPTION
entity insertions and we end up with a TupleAlreadyExistsException.

It's not perfect but it's far better than having the following message:
    Trying to insert an already existing entity: null
which is quite misleading.