### PR TITLE
OGM-1090 Use Central first to get the artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ install:
   # The Maven install provided by Travis is outdated, use Maven wrapper to get the latest version
   - mvn -N io.takari:maven:wrapper
   - ./mvnw -v
-  # Use the Google mirror for central - we also declare explicitly central as the JBoss repository takes precedences over it
-  - sed -i settings-example.xml -e "s@</mirrors>@<mirror><id>google-maven-central</id><name>Google Maven Central</name><url>https://maven-central.storage.googleapis.com</url><mirrorOf>central</mirrorOf></mirror></mirrors>@"
-  - sed -i settings-example.xml -e "s@<repositories>@<repositories><repository><id>central</id><name>Central</name><url>https://maven-central.storage.googleapis.com/</url></repository>@"
-  - sed -i settings-example.xml -e "s@<pluginRepositories>@<pluginRepositories><pluginRepository><id>central</id><name>Central</name><url>https://maven-central.storage.googleapis.com/</url></pluginRepository>@"
   # first run to download all the Maven dependencies without logging
   - travis_wait ./mvnw -B -q -s settings-example.xml -Ptest -DskipTests=true -Dmaven.javadoc.skip=true -DskipDistro=true install
   # we run checkstyle first to fail fast if there is a styling error

--- a/settings-example.xml
+++ b/settings-example.xml
@@ -255,6 +255,16 @@ under the License.
         <profile>
             <id>jboss-public-repository</id>
             <repositories>
+                <!-- Use Central first -->
+                <repository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
                 <repository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
@@ -271,6 +281,16 @@ under the License.
                 </repository>
             </repositories>
             <pluginRepositories>
+                <!-- Use Central first -->
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
                 <pluginRepository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1090

In passing, remove the sed calls adding this for the Travis build.

Note, I'm using the default Central repository instead of the Google
mirror as apparently a few artifacts are missing on Google mirror.

The default Central repository is now hosted by Fastly and is very fast.