### PR TITLE
JDK9

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -15,6 +15,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,6 +112,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -131,31 +131,6 @@
                  <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.jboss.maven.plugins</groupId>
-                <artifactId>maven-injection-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>bytecode</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <bytecodeInjections>
-                        <bytecodeInjection>
-                            <expression>${project.version}</expression>
-                            <targetMembers>
-                                <methodBodyReturn>
-                                    <className>org.hibernate.ogm.cfg.impl.Version</className>
-                                    <methodName>getVersionString</methodName>
-                                </methodBodyReturn>
-                            </targetMembers>
-                        </bytecodeInjection>
-                    </bytecodeInjections>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>

--- a/core/src/main/java/org/hibernate/ogm/cfg/impl/Version.java
+++ b/core/src/main/java/org/hibernate/ogm/cfg/impl/Version.java
@@ -22,8 +22,7 @@ public class Version {
 	 * @return the current Hibernate OGM version
 	 */
 	public static String getVersionString() {
-		// The actual value will be injected into the class file during the build
-		return "[WORKING]";
+		return Version.class.getPackage().getImplementationVersion();
 	}
 
 	static {

--- a/couchdb/pom.xml
+++ b/couchdb/pom.xml
@@ -123,6 +123,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkMode>once</forkMode>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -125,6 +125,7 @@
                     <dependenciesToScan>
                         <dependency>org.hibernate.ogm:hibernate-ogm-core</dependency>
                     </dependenciesToScan>
+                    <argLine>${additionalRuntimeArgLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -110,6 +110,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -126,6 +126,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -161,6 +161,7 @@
                     <!-- Apache Lucene uses assertions which currently fail on JDK9: -->
                     <!-- not sure yet how that is going to be resolved, but it's not an OGM problem. -->
                     <enableAssertions>false</enableAssertions>
+                    <argLine>${additionalRuntimeArgLine}</argLine>
                     <dependenciesToScan>
                         <dependency>org.hibernate.ogm:hibernate-ogm-core</dependency>
                     </dependenciesToScan>

--- a/jipijapa/pom.xml
+++ b/jipijapa/pom.xml
@@ -55,6 +55,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
@@ -66,6 +70,8 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <encoding>UTF-8</encoding>
+                    <!-- Annotation processor is run as an independent step -->
+                    <proc>none</proc>
                 </configuration>
             </plugin>
             <!-- Allow using Java8 code as Java8 is the requirement for WildFly 10 -->

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -15,6 +15,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -28,6 +28,10 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <configuration>
                     <!-- Skipping it because neo4j uses a different Lucene version -->

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,8 @@
                     <source>1.7</source>
                     <target>1.7</target>
                     <encoding>UTF-8</encoding>
+                    <!-- Annotation processor is run as an independent step -->
+                    <proc>none</proc>
                 </configuration>
             </plugin>
             <plugin>
@@ -391,6 +393,41 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.bsc.maven</groupId>
+                    <artifactId>maven-processor-plugin</artifactId>
+                    <version>2.2.4</version>
+                    <executions>
+                        <!-- Run annotation processors on src/main/java sources -->
+                        <execution>
+                            <id>process</id>
+                            <goals>
+                                <goal>process</goal>
+                            </goals>
+                            <phase>generate-sources</phase>
+                            <configuration>
+                                <processors>
+                                    <processor>org.jboss.logging.processor.apt.LoggingToolsProcessor</processor>
+                                </processors>
+                                <compilerArguments>-AtranslationFilesPath=${project.basedir}/src/main/resources/ -source 1.7 -target 1.7</compilerArguments>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss.logging</groupId>
+                            <artifactId>jboss-logging-processor</artifactId>
+                            <version>${jbossLoggingProcessorVersion}</version>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.annotation</groupId>
+                            <artifactId>jsr250-api</artifactId>
+                            <version>1.0</version>
+                            <scope>compile</scope>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
     <modules>
         <module>bom</module>
         <module>core</module>
-        <module>ehcache</module>
-        <module>infinispan</module>
+        <!-- <module>ehcache</module> Is only enabled when not running in Java 9: see the profiles section-->
+        <!-- <module>infinispan</module> Is only enabled when not running in Java 9: see the profiles section-->
         <module>mongodb</module>
-        <module>neo4j</module>
+        <!-- <module>neo4j</module> Is only enabled when not running in Java 9: see the profiles section-->
         <module>couchdb</module>
         <module>cassandra</module>
         <module>redis</module>
@@ -425,6 +425,7 @@
                     <version>2.19.1</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <argLine>${additionalRuntimeArgLine}</argLine>
                         <systemPropertyVariables>
                            <!-- See test org.hibernate.ogm.test.utils.EnvironmentTest -->
                            <hibernate.service.allow_crawling>false</hibernate.service.allow_crawling>
@@ -673,12 +674,36 @@
 
     <profiles>
         <profile>
+            <id>non-jigsaw</id>
+            <activation>
+                <!-- The versions we're using of Ehcache, Infinispan and Neo4J won't work on JDK9. Needs upgrading.  -->
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>ehcache</module>
+                <module>infinispan</module>
+                <module>neo4j</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jigsaw</id>
+            <activation>
+                <!-- Java 9 doesn't identify itself as "1.9" but "9" -->
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <additionalRuntimeArgLine>-addmods java.xml.bind</additionalRuntimeArgLine>
+            </properties>
+        </profile>
+        <profile>
             <id>integrationtest</id>
             <activation>
                 <property>
                     <name>skipITs</name>
                     <value>!true</value>
                 </property>
+                <!-- Skip on Java 9, both because of some NoSQL stores aren't ready and because of WildFly -->
+                <jdk>1.8</jdk>
             </activation>
             <modules>
                 <module>integrationtest</module>
@@ -691,6 +716,8 @@
                     <name>skipDocs</name>
                     <value>!true</value>
                 </property>
+                <!-- And skip on Java 9 -->
+                <jdk>1.8</jdk>
             </activation>
             <modules>
                 <module>documentation</module>
@@ -703,6 +730,8 @@
                     <name>skipDistro</name>
                     <value>!true</value>
                 </property>
+                <!-- And skip on Java 9 -->
+                <jdk>1.8</jdk>
             </activation>
             <modules>
                 <module>distribution</module>

--- a/pom.xml
+++ b/pom.xml
@@ -367,34 +367,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-archetype-plugin</artifactId>
-                    <version>2.4</version>
-                    <executions>
-                        <execution>
-                            <id>generate-archetype-install</id>
-                            <phase>install</phase>
-                            <configuration>
-                                <archetypePostPhase>install</archetypePostPhase>
-                                <propertyFile>archetype.properties</propertyFile>
-                            </configuration>
-                            <goals>
-                                <goal>create-from-project</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>generate-archetype-deploy</id>
-                            <phase>deploy</phase>
-                            <configuration>
-                                <archetypePostPhase>deploy</archetypePostPhase>
-                                <propertyFile>archetype.properties</propertyFile>
-                            </configuration>
-                            <goals>
-                                <goal>create-from-project</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.bsc.maven</groupId>
                     <artifactId>maven-processor-plugin</artifactId>
                     <version>2.2.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,24 @@
                             </goals>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-archiver</artifactId>
+                            <!-- Required override to work on Java 9 -->
+                            <version>3.3</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-io</artifactId>
+                            <version>2.7.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.apache.resources</groupId>
+                            <artifactId>apache-source-release-assembly-descriptor</artifactId>
+                            <version>1.0.6</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -493,11 +493,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.jboss.maven.plugins</groupId>
-                    <artifactId>maven-injection-plugin</artifactId>
-                    <version>1.0.2</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.0</version>
                     <executions>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -151,6 +151,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
This allows us to run the core testsuite on Java 9 and prevent regressions with our own code, but still needs some investigation to get the actual NoSQL technologies to work.. although that might not be our responsibility.

There are still issues with:
 - running on WildFly (WildFly isn't ready for it)
 - Ehcache - we're using version 2, I doubt the Ehcache team will want to fix this unless we upgrade to 3
 - Infinispan - needs further investigation from the Infinispan team
 - Neo4J - some banned NIO usage, might be simple?

Not least this disables distribution and documentation build.

https://hibernate.atlassian.net/browse/OGM-1095