### PR TITLE
OGM-1104 Properly throw an exception in GridDialectInitiator

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectInitiator.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectInitiator.java
@@ -88,7 +88,7 @@ public class GridDialectInitiator implements StandardServiceInitiator<GridDialec
 					}
 				}
 				if ( injector == null ) {
-					log.gridDialectHasNoProperConstructor( clazz );
+					throw log.gridDialectHasNoProperConstructor( clazz );
 				}
 				GridDialect gridDialect = (GridDialect) injector.newInstance( datastore );
 

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -66,7 +66,7 @@ public interface Log extends BasicLogger {
 	@Message(id = 11, value = "Cannot instantiate GridDialect class [%1$s]")
 	HibernateException cannotInstantiateGridDialect(@FormatWith(ClassObjectFormatter.class) Class<?> dialectClass, @Cause Exception e);
 
-	@Message(id = 14, value = "%1$s has no constructor accepting DatasourceProvider")
+	@Message(id = 14, value = "%1$s has no constructor accepting DatastoreProvider")
 	HibernateException gridDialectHasNoProperConstructor(@FormatWith(ClassObjectFormatter.class) Class<?> dialectClass);
 
 	@Message(id = 15, value = "Expected DatastoreProvider %2$s but found %1$s")

--- a/core/src/test/java/org/hibernate/ogm/test/boot/GridDialectInitiatorTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/boot/GridDialectInitiatorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.boot;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.ogm.boot.OgmSessionFactoryBuilder;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+public class GridDialectInitiatorTest {
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1104")
+	public void testInvalidGridDialect() {
+		try {
+			StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
+					.applySetting( OgmProperties.ENABLED, true )
+					.applySetting( OgmProperties.GRID_DIALECT, "org.hibernate.ogm.test.boot.InvalidGridDialect" )
+					.applySetting( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" )
+					.build();
+
+			new MetadataSources( registry )
+					.buildMetadata()
+					.getSessionFactoryBuilder()
+					.unwrap( OgmSessionFactoryBuilder.class )
+					.build();
+
+			fail( "Expected exception was not raised" );
+		}
+		catch (Exception e) {
+			assertThat( e.getCause().getCause().getMessage() ).startsWith( "OGM000014" );
+		}
+
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/test/boot/InvalidGridDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/test/boot/InvalidGridDialect.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.boot;
+
+import org.hibernate.ogm.datastore.map.impl.MapDialect;
+
+
+/**
+ * Invalid GridDialect: no constructor accepts a DatastoreProvider parameter.
+ *
+ * @author Guillaume Smet
+ */
+public class InvalidGridDialect extends MapDialect {
+
+	public InvalidGridDialect() {
+		super( null );
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1104

If the GridDialect does not have a valid constructor, we
ignored the error and we threw a NPE instead of an explicit error
message.

In passing, fix the error message.