### PR TITLE
OGM-1026 Support Neo4j 3.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ env:
     - REDIS_HOSTNAME=localhost
     - COUCHDB_HOSTNAME=localhost
     - CASSANDRA_HOSTNAME=localhost CASSANDRA_VERSION=2.2.5 
-    - NEO4J_HOSTNAME=localhost NEO4J_PORT=7474 NEO4J_VERSION=2.3.4 NEO4J_USERNAME=neo4j NEO4J_PASSWORD=hibernate 
+    - NEO4J_HOSTNAME=localhost NEO4J_PORT=7474 NEO4J_VERSION=3.0.3 NEO4J_USERNAME=neo4j NEO4J_PASSWORD=hibernate NEO4J_HOME=neo4j-community-$NEO4J_VERSION
 before_install:
   - curl http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
 install:
-  - neo4j-community-$NEO4J_VERSION/bin/neo4j start
+  - $NEO4J_HOME/bin/neo4j start
   - sudo apt-get install -qq couchdb
   - bash travis/setup-cassandra.sh 2>&1 > cassandra.log
   # The Maven install provided by Travis is outdated, use Maven wrapper to get the latest version

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
         <infinispanVersion>8.2.1.Final</infinispanVersion>
         <mongodbVersion>3.2.2</mongodbVersion>
         <fongodbVersion>2.0.6</fongodbVersion>
-        <neo4jVersion>2.3.4</neo4jVersion>
+        <neo4jVersion>3.0.3</neo4jVersion>
         <!-- Update dependency versions accordingly when updating C*  -->
         <cassandraVersion>2.2.0-rc3</cassandraVersion>
         <!-- Update dependency versions accordingly when updating lettuce  -->
@@ -36,10 +36,10 @@
         <hdrHistogramVersion>2.1.8</hdrHistogramVersion>
         <latencyUtilsVersion>2.0.3</latencyUtilsVersion>
         <!-- Neo4j supports different versions of Cypher -->
-        <neo4jCypherCompiler19Version>2.0.5</neo4jCypherCompiler19Version>
-        <neo4jCypherCompiler22Version>2.2.9</neo4jCypherCompiler22Version>
+        <neo4jCypherCompiler23Version>2.3.4</neo4jCypherCompiler23Version>
+        <neo4jCypherCompiler30Version>${neo4jVersion}</neo4jCypherCompiler30Version>
         <!-- Neo4j does not support Lucene 4 currently-->
-        <neo4jLuceneVersion>3.6.2</neo4jLuceneVersion>
+        <neo4jLuceneVersion>5.5.0</neo4jLuceneVersion>
         <hibernateVersion>5.0.9.Final</hibernateVersion>
         <hibernateSearchVersion>5.5.3.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.2.0.Final</hibernateParserVersion>
@@ -52,8 +52,7 @@
         <resteasyVersion>3.0.14.Final</resteasyVersion>
         <jacksonVersion>2.5.4</jacksonVersion>
         <parboiledVersion>1.1.7</parboiledVersion>
-        <scalaLibraryVersion>2.11.7</scalaLibraryVersion>
-        <scalaParserCombinatorVersion>1.0.4</scalaParserCombinatorVersion>
+        <scalaLibraryVersion>2.11.8</scalaLibraryVersion>
         <concurrentlinkedhashmapVersion>1.4.2</concurrentlinkedhashmapVersion>
         <commonsLang3Version>3.3.2</commonsLang3Version>
         <asmVersion>5.0.3</asmVersion>

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -51,6 +51,14 @@
             <groupId>org.hibernate.ogm</groupId>
             <artifactId>hibernate-ogm-infinispan</artifactId>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                <!-- Hibernate Search might use a different version than Neo4j.
+                     It is safe to exclude it as we are going to use a module already present on WildFly -->
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-search-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate.ogm</groupId>

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -240,7 +240,7 @@
                   <include>org.neo4j:neo4j-graph-matching</include>
                   <include>org.neo4j:neo4j-jmx</include>
                   <include>org.neo4j:neo4j-cypher</include>
-              </includes>
+             </includes>
        </dependencySet>
        <dependencySet>
               <useProjectArtifact>false</useProjectArtifact>
@@ -248,25 +248,34 @@
               <useTransitiveFiltering>false</useTransitiveFiltering>
               <unpack>false</unpack>
               <includes>
-                  <!-- Include the Lucene version used by Neo4J, not the one from Hibernate Search! -->
-                  <include>org.apache.lucene:lucene-core</include>
                   <include>org.neo4j:neo4j-io</include>
+                  <include>org.neo4j:neo4j-security</include>
                   <include>org.neo4j:neo4j-lucene-index</include>
-                  <include>org.parboiled:parboiled-scala_2.11</include>
+                  <include>org.neo4j:neo4j-lucene-upgrade</include>
+                  <include>org.neo4j:neo4j-common</include>
+                  <include>org.neo4j:neo4j-resource</include>
                   <include>org.scala-lang:scala-reflect</include>
                   <include>org.scala-lang:scala-library</include>
-                  <include>org.scala-lang.modules:scala-parser-combinators_2.11</include>
+                  <include>org.neo4j:neo4j-collections</include>
                   <include>org.neo4j:neo4j-primitive-collections</include>
                   <include>org.neo4j:neo4j-codegen</include>
                   <include>org.neo4j:neo4j-unsafe</include>
-                  <include>org.neo4j:neo4j-function</include>
                   <include>org.neo4j:neo4j-logging</include>
-                  <include>org.neo4j:neo4j-cypher-compiler-1.9_2.11</include>
-                  <include>org.neo4j:neo4j-cypher-compiler-2.2_2.11</include>
+                  <include>org.neo4j:neo4j-graphdb-api</include>
                   <include>org.neo4j:neo4j-cypher-compiler-2.3</include>
                   <include>org.neo4j:neo4j-cypher-frontend-2.3</include>
+                  <include>org.neo4j:neo4j-cypher-compiler-3.0</include>
+                  <include>org.neo4j:neo4j-cypher-frontend-3.0</include>
+                  <include>org.parboiled:parboiled-scala_2.11</include>
                   <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
                   <include>org.apache.commons:commons-lang3</include>
+
+                 <!-- Include the Lucene version used by Neo4J, not the one from Hibernate Search! -->
+                  <include>org.apache.lucene:lucene-core</include>
+                  <include>org.apache.lucene:lucene-codecs</include>
+                  <include>org.apache.lucene:lucene-backward-codecs</include>
+                  <include>org.apache.lucene:lucene-queryparser</include>
+                  <include>org.apache.lucene:lucene-analyzers-common</include>
               </includes>
        </dependencySet>
        <!-- HQL -->

--- a/modules/wildfly/src/main/modules/ogm/neo4j-internal/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/neo4j-internal/module.xml
@@ -11,22 +11,31 @@
     </properties>
 
     <resources>
-        <resource-root path="lucene-core-${neo4jLuceneVersion}.jar"/>
+        <resource-root path="lucene-core-${neo4jLuceneVersion}.jar" />
+        <resource-root path="lucene-codecs-${neo4jLuceneVersion}.jar" />
+        <resource-root path="lucene-backward-codecs-${neo4jLuceneVersion}.jar" />
+        <resource-root path="lucene-queryparser-${neo4jLuceneVersion}.jar" />
+        <resource-root path="lucene-analyzers-common-${neo4jLuceneVersion}.jar" />
+
+        <resource-root path="neo4j-lucene-upgrade-${neo4jVersion}.jar" />
         <resource-root path="neo4j-lucene-index-${neo4jVersion}.jar" />
         <resource-root path="parboiled-scala_2.11-${parboiledVersion}.jar" />
-        <resource-root path="scala-parser-combinators_2.11-${scalaParserCombinatorVersion}.jar" />
         <resource-root path="scala-library-${scalaLibraryVersion}.jar" />
         <resource-root path="scala-reflect-${scalaLibraryVersion}.jar" />
-        <resource-root path="neo4j-function-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-security-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-graphdb-api-${neo4jVersion}.jar" />
         <resource-root path="neo4j-io-${neo4jVersion}.jar" />
         <resource-root path="neo4j-codegen-${neo4jVersion}.jar" />
         <resource-root path="neo4j-logging-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-resource-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-collections-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-common-${neo4jVersion}.jar" />
         <resource-root path="neo4j-primitive-collections-${neo4jVersion}.jar" />
         <resource-root path="neo4j-unsafe-${neo4jVersion}.jar" />
-        <resource-root path="neo4j-cypher-compiler-1.9_2.11-${neo4jCypherCompiler19Version}.jar" />
-        <resource-root path="neo4j-cypher-compiler-2.2_2.11-${neo4jCypherCompiler22Version}.jar" />
-        <resource-root path="neo4j-cypher-compiler-2.3-${neo4jVersion}.jar" />
-        <resource-root path="neo4j-cypher-frontend-2.3-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-cypher-compiler-2.3-${neo4jCypherCompiler23Version}.jar" />
+        <resource-root path="neo4j-cypher-frontend-2.3-${neo4jCypherCompiler23Version}.jar" />
+        <resource-root path="neo4j-cypher-compiler-3.0-${neo4jCypherCompiler30Version}.jar" />
+        <resource-root path="neo4j-cypher-frontend-3.0-${neo4jCypherCompiler30Version}.jar" />
         <resource-root path="concurrentlinkedhashmap-lru-${concurrentlinkedhashmapVersion}.jar" />
         <resource-root path="commons-lang3-${commonsLang3Version}.jar" />
     </resources>

--- a/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/neo4j/module.xml
@@ -9,12 +9,13 @@
     <resources>
         <resource-root path="hibernate-ogm-neo4j-${project.version}.jar" />
         <resource-root path="neo4j-${neo4jVersion}.jar" />
-        <resource-root path="neo4j-cypher-${neo4jVersion}.jar" />
         <resource-root path="neo4j-kernel-${neo4jVersion}.jar" />
         <resource-root path="neo4j-udc-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-cypher-${neo4jVersion}.jar" />
         <resource-root path="neo4j-graph-algo-${neo4jVersion}.jar" />
         <resource-root path="neo4j-graph-matching-${neo4jVersion}.jar" />
         <resource-root path="neo4j-jmx-${neo4jVersion}.jar" />
+        <resource-root path="neo4j-cypher-${neo4jVersion}.jar" />
     </resources>
     <dependencies>
         <module name="org.hibernate.ogm" slot="${hibernate.ogm.module.slot}" />

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
@@ -48,7 +48,7 @@ import org.hibernate.type.Type;
  */
 public abstract class BaseNeo4jDialect extends BaseGridDialect implements QueryableGridDialect<String>, ServiceRegistryAwareService, SessionFactoryLifecycleAwareDialect, MultigetGridDialect {
 
-	public static final String CONSTRAINT_VIOLATION_CODE = "Neo.ClientError.Schema.ConstraintViolation";
+	public static final String CONSTRAINT_VIOLATION_CODE = "Neo.ClientError.Schema.ConstraintValidationFailed";
 
 	private ServiceRegistryImplementor serviceRegistry;
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/impl/EmbeddedNeo4jGraphDatabaseFactory.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/impl/EmbeddedNeo4jGraphDatabaseFactory.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.neo4j.embedded.impl;
 
+import java.io.File;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,13 +19,13 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 
 /**
- * Contains methods to create an {@link org.neo4j.kernel.EmbeddedGraphDatabase}.
+ * Contains methods to create a {@link GraphDatabaseService} for the embedded Neo4j.
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
 public class EmbeddedNeo4jGraphDatabaseFactory implements GraphDatabaseServiceFactory {
 
-	private String dbLocation;
+	private File dbLocation;
 
 	private URL configurationLocation;
 
@@ -34,9 +35,11 @@ public class EmbeddedNeo4jGraphDatabaseFactory implements GraphDatabaseServiceFa
 	public void initialize(Map<?, ?> properties) {
 		ConfigurationPropertyReader configurationPropertyReader = new ConfigurationPropertyReader( properties );
 
-		this.dbLocation = configurationPropertyReader.property( Neo4jProperties.DATABASE_PATH, String.class )
+		String path = configurationPropertyReader.property( Neo4jProperties.DATABASE_PATH, String.class )
 				.required()
 				.getValue();
+
+		this.dbLocation = new File( path );
 
 		this.configurationLocation = configurationPropertyReader
 				.property( Neo4jProperties.CONFIGURATION_RESOURCE_NAME, URL.class )

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jInPredicate.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jInPredicate.java
@@ -46,7 +46,7 @@ public class Neo4jInPredicate extends InPredicate<StringBuilder> implements Nega
 
 	@Override
 	public StringBuilder getNegatedQuery() {
-		builder.append( "NOT HAS(" );
+		builder.append( "NOT EXISTS(" );
 		identifier( builder, alias, propertyName );
 		builder.append( ") OR " );
 		builder.append( " NONE( " );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jIsNullPredicate.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jIsNullPredicate.java
@@ -27,7 +27,7 @@ public class Neo4jIsNullPredicate extends IsNullPredicate<StringBuilder> impleme
 
 	@Override
 	public StringBuilder getQuery() {
-		builder.append( "NOT HAS(" );
+		builder.append( "NOT EXISTS(" );
 		identifier( builder, alias, propertyName );
 		builder.append( ")" );
 		return builder;
@@ -35,7 +35,7 @@ public class Neo4jIsNullPredicate extends IsNullPredicate<StringBuilder> impleme
 
 	@Override
 	public StringBuilder getNegatedQuery() {
-		builder.append( "HAS(" );
+		builder.append( "EXISTS(" );
 		identifier( builder, alias, propertyName );
 		builder.append( ")" );
 		return builder;

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jLikePredicate.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/query/parsing/impl/predicate/impl/Neo4jLikePredicate.java
@@ -46,7 +46,7 @@ public class Neo4jLikePredicate extends LikePredicate<StringBuilder> implements 
 	 */
 	@Override
 	public StringBuilder getNegatedQuery() {
-		builder.append( "NOT HAS(" );
+		builder.append( "NOT EXISTS(" );
 		identifier( builder, alias, propertyName );
 		builder.append( ") OR NOT(" );
 		getQuery();

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/json/impl/Row.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/json/impl/Row.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.neo4j.remote.json.impl;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The result of a {@link Statement} expressed as rows or {@link Graph}.
@@ -22,12 +23,22 @@ public class Row {
 
 	private Graph graph;
 
+	private List<Map<String, Object>> meta;
+
 	public Graph getGraph() {
 		return graph;
 	}
 
 	public List<Object> getRow() {
 		return row;
+	}
+
+	public List<Map<String, Object>> getMeta() {
+		return meta;
+	}
+
+	public void setMeta(List<Map<String, Object>> meta) {
+		this.meta = meta;
 	}
 
 	public void setRow(List<Object> row) {

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/Neo4jGraphDatabaseServiceLoaderTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/Neo4jGraphDatabaseServiceLoaderTest.java
@@ -119,16 +119,6 @@ public class Neo4jGraphDatabaseServiceLoaderTest {
 		}
 
 		@Override
-		public Iterable<Node> getAllNodes() {
-			return null;
-		}
-
-		@Override
-		public Iterable<RelationshipType> getRelationshipTypes() {
-			return null;
-		}
-
-		@Override
 		public void shutdown() {
 		}
 
@@ -164,11 +154,6 @@ public class Neo4jGraphDatabaseServiceLoaderTest {
 
 		@Override
 		public Node createNode(Label... labels) {
-			return null;
-		}
-
-		@Override
-		public ResourceIterable<Node> findNodesByLabelAndProperty(Label label, String key, Object value) {
 			return null;
 		}
 
@@ -214,6 +199,41 @@ public class Neo4jGraphDatabaseServiceLoaderTest {
 
 		@Override
 		public Result execute(String query, Map<String, Object> parameters) throws QueryExecutionException {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<Node> getAllNodes() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<Relationship> getAllRelationships() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<Label> getAllLabelsInUse() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<RelationshipType> getAllRelationshipTypesInUse() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<Label> getAllLabels() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<RelationshipType> getAllRelationshipTypes() {
+			return null;
+		}
+
+		@Override
+		public ResourceIterable<String> getAllPropertyKeys() {
 			return null;
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1026

This version still requires Apache Lucene 5.5, I was wrong about it when we talked in chat.
 
Changes in the new version:

  * the Rest API response has an additional field `meta` that needs to be mapped in
    `org.hibernate.ogm.datastore.neo4j.remote.json.imp.Row`;
  * libraries need to be updated in the WildFly module;
  * the operator `HAS` in cypher has been replaced by `EXISTS`;
  * some changes in the signature of methods used when dealing with the embedded datastore.
