### PR TITLE
OGM-1112 Avoid creation of test jar in integration tests

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -89,29 +89,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>build-test-jar</id>
-                            <goals>
-                                <goal>test-jar</goal>
-                            </goals>
-                            <configuration>
-                                <archive>
-                                    <manifest>
-                                        <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                                        <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                    </manifest>
-                                </archive>
-                                <excludes>
-                                    <exclude>**/hibernate.properties</exclude>
-                                    <exclude>**/log4j.properties</exclude>
-                                </excludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                         <execution>


### PR DESCRIPTION
  https://hibernate.atlassian.net/browse/OGM-1112

  We used to create a jar with the integration tests when we had separate
  maven modules for several datastore. Now that all datastores are tested
  in the same project there is no need to create a jar that it is not
  deployed or used.