### PR TITLE
OGM-1103 Alternative proposal

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventContextManagingPersistEventListener.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventContextManagingPersistEventListener.java
@@ -12,7 +12,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.event.service.spi.DuplicationStrategy;
 import org.hibernate.event.spi.PersistEvent;
 import org.hibernate.event.spi.PersistEventListener;
-import org.hibernate.jpa.event.internal.core.JpaPersistEventListener;
 import org.hibernate.ogm.util.impl.EffectivelyFinal;
 
 /**
@@ -67,8 +66,8 @@ public class EventContextManagingPersistEventListener implements PersistEventLis
 
 		@Override
 		public boolean areMatch(Object listener, Object original) {
-			if ( listener instanceof EventContextManagingPersistEventListener && original instanceof JpaPersistEventListener ) {
-				( (EventContextManagingPersistEventListener) listener ).setDelegate( (JpaPersistEventListener) original );
+			if ( listener instanceof EventContextManagingPersistEventListener && original instanceof PersistEventListener ) {
+				( (EventContextManagingPersistEventListener) listener ).setDelegate( (PersistEventListener) original );
 				return true;
 			}
 

--- a/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventStateLifecycle.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventStateLifecycle.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.dialect.eventstate.impl;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 /**
  * Callback for event cycle scoped state objects.
@@ -19,8 +20,13 @@ import org.hibernate.engine.spi.SessionImplementor;
 public interface EventStateLifecycle<T> {
 
 	/**
-	 * Creates a new instance of the represented event state type. Invoked by {@link EventContextManager} in case a
-	 * event state type is accessed for the first time during a given event cycle.
+	 * Whether this lifecycle is needed as per the given configuration or not.
+	 */
+	boolean mustBeEnabled(ServiceRegistryImplementor serviceRegistry);
+
+	/**
+	 * Creates a new instance of the represented event state type. Invoked by {@link EventContextManager} when
+	 * initializing the state context for a given event cycle.
 	 */
 	T create(SessionImplementor session);
 

--- a/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventStateLifecycles.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/eventstate/impl/EventStateLifecycles.java
@@ -6,16 +6,22 @@
  */
 package org.hibernate.ogm.dialect.eventstate.impl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.compensation.impl.ErrorHandlerEnabledTransactionCoordinatorDecorator;
 import org.hibernate.ogm.compensation.impl.OperationCollector;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.impl.BatchOperationsDelegator;
 import org.hibernate.ogm.dialect.impl.GridDialects;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.util.impl.Immutable;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 /**
  * Holds all known {@link EventStateLifecycle}s.
@@ -24,16 +30,30 @@ import org.hibernate.ogm.dialect.spi.GridDialect;
  */
 class EventStateLifecycles {
 
-	private EventStateLifecycles() {
-	}
+	public static final EventStateLifecycles INSTANCE = new EventStateLifecycles();
 
-	public static Map<Class<?>, EventStateLifecycle<?>> getLifecycles() {
+	@Immutable
+	private final Map<Class<?>, EventStateLifecycle<?>> lifecycles;
+
+	private EventStateLifecycles() {
 		Map<Class<?>, EventStateLifecycle<?>> lifecycles = new HashMap<>();
 
 		lifecycles.put( OperationCollector.class, OperationCollectorLifecycle.INSTANCE );
 		lifecycles.put( OperationsQueue.class, OperationsQueueLifecycle.INSTANCE );
 
-		return lifecycles;
+		this.lifecycles = Collections.unmodifiableMap( lifecycles );
+	}
+
+	public Map<Class<?>, EventStateLifecycle<?>> getEnabledLifecycles(ServiceRegistryImplementor serviceRegistry) {
+		Map<Class<?>, EventStateLifecycle<?>> enabledLifecycles = new HashMap<>();
+
+		for ( Entry<Class<?>, EventStateLifecycle<?>> lifecycle : lifecycles.entrySet() ) {
+			if ( lifecycle.getValue().mustBeEnabled( serviceRegistry ) ) {
+				enabledLifecycles.put( lifecycle.getKey(), lifecycle.getValue() );
+			}
+		}
+
+		return enabledLifecycles;
 	}
 
 	/**
@@ -42,6 +62,11 @@ class EventStateLifecycles {
 	private static class OperationCollectorLifecycle implements EventStateLifecycle<OperationCollector> {
 
 		private static EventStateLifecycle<?> INSTANCE = new OperationCollectorLifecycle();
+
+		@Override
+		public boolean mustBeEnabled(ServiceRegistryImplementor serviceRegistry) {
+			return serviceRegistry.getService( ConfigurationService.class ).getSettings().containsKey( OgmProperties.ERROR_HANDLER );
+		}
 
 		@Override
 		public OperationCollector create(SessionImplementor session) {
@@ -65,6 +90,13 @@ class EventStateLifecycles {
 		private static EventStateLifecycle<?> INSTANCE = new OperationsQueueLifecycle();
 
 		@Override
+		public boolean mustBeEnabled(ServiceRegistryImplementor serviceRegistry) {
+			GridDialect gridDialect = serviceRegistry.getService( GridDialect.class );
+			BatchOperationsDelegator batchDelegator = GridDialects.getDelegateOrNull( gridDialect, BatchOperationsDelegator.class );
+			return batchDelegator != null;
+		}
+
+		@Override
 		public OperationsQueue create(SessionImplementor session) {
 			return new OperationsQueue();
 		}
@@ -75,7 +107,10 @@ class EventStateLifecycles {
 					.getServiceRegistry()
 					.getService( GridDialect.class );
 
-			GridDialects.getDelegateOrNull( gridDialect, BatchOperationsDelegator.class ).executeBatch( operationsQueue );
+			if ( operationsQueue.size() > 0 ) {
+				GridDialects.getDelegateOrNull( gridDialect, BatchOperationsDelegator.class ).executeBatch( operationsQueue );
+			}
+
 			operationsQueue.close();
 		}
 	}

--- a/core/src/main/java/org/hibernate/ogm/service/impl/OgmIntegrator.java
+++ b/core/src/main/java/org/hibernate/ogm/service/impl/OgmIntegrator.java
@@ -6,16 +6,11 @@
  */
 package org.hibernate.ogm.service.impl;
 
-import java.util.Map;
-
 import org.hibernate.boot.Metadata;
-import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.integrator.spi.IntegratorService;
-import org.hibernate.jpa.event.spi.JpaIntegrator;
 import org.hibernate.ogm.cfg.impl.Version;
 import org.hibernate.ogm.dialect.eventstate.impl.EventContextManager;
 import org.hibernate.ogm.dialect.eventstate.impl.EventContextManagingAutoFlushEventListener;
@@ -58,9 +53,7 @@ public class OgmIntegrator implements Integrator {
 	}
 
 	private void attachEventContextManagingListenersIfRequired(SessionFactoryServiceRegistry serviceRegistry) {
-		@SuppressWarnings("unchecked")
-		Map<Object, Object> settings = serviceRegistry.getService( ConfigurationService.class ).getSettings();
-		if ( !EventContextManager.isEventContextRequired( settings, serviceRegistry ) ) {
+		if ( !EventContextManager.isEventContextRequired( serviceRegistry ) ) {
 			return;
 		}
 
@@ -73,22 +66,7 @@ public class OgmIntegrator implements Integrator {
 		eventListenerRegistry.addDuplicationStrategy( EventContextManagingFlushEventListenerDuplicationStrategy.INSTANCE );
 		eventListenerRegistry.getEventListenerGroup( EventType.FLUSH ).appendListener( new EventContextManagingFlushEventListener( stateManager ) );
 
-		if ( getIntegrator( JpaIntegrator.class, serviceRegistry ) != null ) {
-			eventListenerRegistry.addDuplicationStrategy( EventContextManagingPersistEventListenerDuplicationStrategy.INSTANCE );
-			eventListenerRegistry.getEventListenerGroup( EventType.PERSIST ).appendListener( new EventContextManagingPersistEventListener( stateManager ) );
-		}
-	}
-
-	@SuppressWarnings( "unchecked" )
-	private <T extends Integrator> T getIntegrator(Class<T> integratorType, SessionFactoryServiceRegistry serviceRegistry) {
-		Iterable<Integrator> integrators = serviceRegistry.getService( IntegratorService.class ).getIntegrators();
-
-		for ( Integrator integrator : integrators ) {
-			if ( integratorType.isInstance( integrator ) ) {
-				return (T) integrator;
-			}
-		}
-
-		return null;
+		eventListenerRegistry.addDuplicationStrategy( EventContextManagingPersistEventListenerDuplicationStrategy.INSTANCE );
+		eventListenerRegistry.getEventListenerGroup( EventType.PERSIST ).appendListener( new EventContextManagingPersistEventListener( stateManager ) );
 	}
 }

--- a/mongodb/src/test/resources/hibernate.properties
+++ b/mongodb/src/test/resources/hibernate.properties
@@ -10,3 +10,4 @@ hibernate.ogm.datastore.database = ogm_test_database
 hibernate.ogm.datastore.create_database=true
 
 hibernate.ogm.mongodb.connection_timeout = 1000
+hibernate.ogm.error_handler = org.hibernate.ogm.datastore.mongodb.test.id.objectid.ObjectIdTest$MyErrorHandler


### PR DESCRIPTION
Hey @gsmet, I took another look at the issue with fresh mind this morning and propose this alternative:

* It initializes the state eagerly at event begin for all those lifecycles enabled
* It pushes the decision whether to enable or not to lifecycles themselves

I think it's a nice evolution of the overall design. The eager init should be fine, as we'll need the states later on anyways (only for the exotic case of a no-op flush cycle it'd be superfluous). It avoids creation of that new dialect facet, too.

I believe it also revealed another issue on the side, where we wouldn't initialize the context properly in non-JPA.

The work would need a bit more polishing (esp. the test), but maybe you could take it from here if you like the approach?