### PR TITLE
OGM-1115 Relax regexp used to detect primary key constraint violation

### DIFF
--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -156,9 +156,9 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	/**
 	 * Pattern used to recognize a constraint violation on the primary key.
 	 *
-	 * MongoDB returns an exception with {@code .$_id_ } while Fongo returns an exception with {@code ._id }
+	 * MongoDB returns an exception with {@code .$_id_ } or {@code  _id_ } while Fongo returns an exception with {@code ._id }
 	 */
-	private static final Pattern PRIMARY_KEY_CONSTRAINT_VIOLATION_MESSAGE = Pattern.compile( ".*\\.(\\$_id_|_id) .*" );
+	private static final Pattern PRIMARY_KEY_CONSTRAINT_VIOLATION_MESSAGE = Pattern.compile( ".*[. ]\\$?_id_? .*" );
 
 	private final MongoDBDatastoreProvider provider;
 	private final DB currentDB;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1115

More modern versions of MongoDB have a different syntax.

The regexp we use now should be sufficiently future proof.

I'm not very fond of this and we should probably try to get the MongoDB people to differentiate the 2 exceptions but IIRC the server doesn't do any difference between the 2.