### PR TITLE
[5.1] OGM-982 - Upgrade to ORM 5.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@
         <!-- Neo4j does not support Lucene 4 currently-->
         <neo4jLuceneVersion>5.5.0</neo4jLuceneVersion>
         <hibernateVersion>5.1.1-SNAPSHOT</hibernateVersion>
-        <hibernateSearchVersion>5.5.3.Final</hibernateSearchVersion>
+        <hibernateSearchVersion>5.5.4.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.2.0.Final</hibernateParserVersion>
         <hibernateCommonsAnnotationsVersion>5.0.1.Final</hibernateCommonsAnnotationsVersion>
         <narayanaVersion>5.2.14.Final</narayanaVersion>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
         <neo4jCypherCompiler30Version>${neo4jVersion}</neo4jCypherCompiler30Version>
         <!-- Neo4j does not support Lucene 4 currently-->
         <neo4jLuceneVersion>5.5.0</neo4jLuceneVersion>
-        <hibernateVersion>5.0.9.Final</hibernateVersion>
+        <hibernateVersion>5.1.1-SNAPSHOT</hibernateVersion>
         <hibernateSearchVersion>5.5.3.Final</hibernateSearchVersion>
         <hibernateParserVersion>1.2.0.Final</hibernateParserVersion>
         <hibernateCommonsAnnotationsVersion>5.0.1.Final</hibernateCommonsAnnotationsVersion>
@@ -226,6 +226,11 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-infinispan</artifactId>
+                <version>${hibernateVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-java8</artifactId>
                 <version>${hibernateVersion}</version>
             </dependency>
 

--- a/core/src/main/java/org/hibernate/ogm/boot/impl/OgmSessionFactoryBuilderImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/boot/impl/OgmSessionFactoryBuilderImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.ogm.OgmSessionFactory;
 import org.hibernate.ogm.boot.OgmSessionFactoryBuilder;
 import org.hibernate.ogm.hibernatecore.impl.OgmSessionFactoryImpl;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 
 /**
  * {@link SessionFactoryBuilder} building tge {@link OgmSessionFactory}.
@@ -52,5 +53,10 @@ public class OgmSessionFactoryBuilderImpl extends AbstractDelegatingSessionFacto
 		OgmSessionFactoryOptions options = new OgmSessionFactoryOptions( delegate.buildSessionFactoryOptions() );
 
 		return new OgmSessionFactoryImpl( new SessionFactoryImpl( metadata, options ) );
+	}
+
+	@Override
+	public SessionFactoryBuilder applyConnectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
+		return delegate.applyConnectionHandlingMode( connectionHandlingMode );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionFactoryImpl.java
@@ -440,4 +440,9 @@ public class OgmSessionFactoryImpl implements OgmSessionFactoryImplementor {
 	public DeserializationResolver getDeserializationResolver() {
 		return delegate.getDeserializationResolver();
 	}
+
+	@Override
+	public String getUuid() {
+		return delegate.getUuid();
+	}
 }

--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -1135,7 +1135,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 
 		//FIXME figure out what that means and what value should be set
 		//boolean eagerPropertyFetch = isEagerPropertyFetchEnabled(i);
-		boolean eagerPropertyFetch = true;
+		boolean fetchAllPropertiesRequested = true;
 
 		// add temp entry so that the next step is circular-reference
 		// safe - only needed because some types don't take proper
@@ -1145,7 +1145,6 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				object,
 				persister,
 				lockMode,
-				!eagerPropertyFetch,
 				session
 		);
 
@@ -1161,7 +1160,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				object,
 				rootPersister,
 				//cols,
-				eagerPropertyFetch,
+				fetchAllPropertiesRequested,
 				session
 			);
 
@@ -1201,7 +1200,6 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				rowId,
 				object,
 				lockMode,
-				!eagerPropertyFetch,
 				session
 			);
 

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -23,7 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
 import org.hibernate.StaleObjectStateException;
-import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -630,10 +630,10 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			Object ce = getCacheAccessStrategy().get( session, cacheKey, session.getTimestamp() );
 			if ( ce != null ) {
 				CacheEntry cacheEntry = (CacheEntry) getCacheEntryStructure().destructure( ce, getFactory() );
-				if ( !cacheEntry.areLazyPropertiesUnfetched() ) {
-					// note early exit here:
-					return initializeLazyPropertiesFromCache( fieldName, entity, session, entry, cacheEntry );
-				}
+				final Object initializedValue = initializeLazyPropertiesFromCache( fieldName, entity, session, entry, cacheEntry );
+
+				// NOTE EARLY EXIT!!!
+				return initializedValue;
 			}
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/transaction/emulated/impl/EmulatedLocalTransactionCoordinatorBuilder.java
+++ b/core/src/main/java/org/hibernate/ogm/transaction/emulated/impl/EmulatedLocalTransactionCoordinatorBuilder.java
@@ -48,7 +48,7 @@ public class EmulatedLocalTransactionCoordinatorBuilder implements TransactionCo
 
 	@Override
 	public ConnectionAcquisitionMode getDefaultConnectionAcquisitionMode() {
-		return ConnectionAcquisitionMode.DEFAULT;
+		return ConnectionAcquisitionMode.IMMEDIATELY;
 	}
 
 	/**

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -108,6 +108,15 @@
                                         <outputDirectory>${project.build.directory}</outputDirectory>
                                     </artifactItem>
                                     <artifactItem>
+                                        <groupId>org.hibernate</groupId>
+                                        <artifactId>hibernate-orm-modules</artifactId>
+                                        <version>${hibernateVersion}</version>
+                                        <classifier>wildfly-10-dist</classifier>
+                                        <type>zip</type>
+                                        <overWrite>false</overWrite>
+                                        <outputDirectory>${jboss.home}/modules</outputDirectory>
+                                    </artifactItem>
+                                    <artifactItem>
                                         <groupId>${project.groupId}</groupId>
                                         <artifactId>hibernate-ogm-modules-wildfly10</artifactId>
                                         <version>${project.version}</version>
@@ -119,6 +128,15 @@
                                         <groupId>org.infinispan</groupId>
                                         <artifactId>infinispan-as-embedded-modules</artifactId>
                                         <version>${infinispanVersion}</version>
+                                        <type>zip</type>
+                                        <overWrite>false</overWrite>
+                                        <outputDirectory>${jboss.home}/modules</outputDirectory>
+                                    </artifactItem>
+                                    <artifactItem>
+                                        <groupId>org.hibernate</groupId>
+                                        <artifactId>hibernate-search-modules</artifactId>
+                                        <version>${hibernateSearchVersion}</version>
+                                        <classifier>wildfly-10-dist</classifier>
                                         <type>zip</type>
                                         <overWrite>false</overWrite>
                                         <outputDirectory>${jboss.home}/modules</outputDirectory>

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/cassandra/ModulesMagicDeckIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/cassandra/ModulesMagicDeckIT.java
@@ -42,7 +42,7 @@ public class ModulesMagicDeckIT extends MagiccardsDatabaseScenario {
 		WebArchive webArchive = ShrinkWrap
 				.create( WebArchive.class, "modules-magic-cassandra.war" )
 				.addClasses( MagicCard.class, MagicCardsCollectionBean.class, ModulesMagicDeckIT.class, MagiccardsDatabaseScenario.class );
-		String persistenceXml = persistenceXml().exportAsString();
+		String persistenceXml = ModulesHelper.injectVariables( persistenceXml().exportAsString() );
 		webArchive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 		ModulesHelper.addModulesDependencyDeclaration( webArchive, "org.hibernate.ogm:${hibernate-ogm.module.slot} services, org.hibernate.ogm.cassandra:${hibernate-ogm.module.slot} services" );
 		return webArchive;
@@ -59,6 +59,7 @@ public class ModulesMagicDeckIT extends MagiccardsDatabaseScenario {
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.ogm.datastore.database" ).value( "ogm_test_database" ).up()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "cassandra_experimental" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 					;
 
 		setCassandraHostName( properties );

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/couchdb/CouchDBModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/couchdb/CouchDBModuleMemberRegistrationIT.java
@@ -76,6 +76,7 @@ public class CouchDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 							.createProperty().name( "hibernate.ogm.datastore.database" ).value( "ogm_test_database" ).up()
 							.createProperty().name( "hibernate.ogm.datastore.create_database" ).value( "true" ).up()
 							.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+							.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 					.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationIT.java
@@ -41,6 +41,7 @@ public class EhcacheModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 				.getOrCreateProperties()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/ehcache/EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT.java
@@ -43,6 +43,7 @@ public class EhcacheModuleMemberRegistrationUsingJBossDeploymentStructureIT exte
 				.getOrCreateProperties()
 					.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "ehcache" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
@@ -43,6 +43,7 @@ public class InfinispanModuleMemberRegistrationIT extends ModuleMemberRegistrati
 				.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
 				.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 			.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
@@ -33,7 +33,7 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 		WebArchive webArchive = ShrinkWrap
 				.create( WebArchive.class, "modules-magic-searchit.war" )
 				.addClasses( MagicCard.class, MagicCardsCollectionBean.class, SearchIntegrationIT.class, MagiccardsDatabaseScenario.class );
-		String persistenceXml = persistenceXml().exportAsString();
+		String persistenceXml = ModulesHelper.injectVariables( persistenceXml().exportAsString() );
 		webArchive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 		ModulesHelper.addModulesDependencyDeclaration( webArchive, "org.hibernate.ogm:${hibernate-ogm.module.slot} services, org.hibernate.ogm.infinispan:${hibernate-ogm.module.slot} services" );
 		return webArchive;
@@ -49,7 +49,7 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 						.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
 						.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
+						.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
-
 }

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
@@ -95,6 +95,7 @@ public class MongoDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 					.createProperty().name( OgmProperties.CREATE_DATABASE ).value( "true" ).up()
 					.createProperty().name( OgmProperties.ERROR_HANDLER ).value( TestErrorHandler.class.getName() ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jJtaModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jJtaModuleMemberRegistrationIT.java
@@ -62,6 +62,7 @@ public class EmbeddedNeo4jJtaModuleMemberRegistrationIT extends ModuleMemberRegi
 				.value( neo4jFolder() )
 				.up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 		return persistenceDescriptor;
 	}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT.java
@@ -59,6 +59,7 @@ public class EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT extends Module
 				.value( EmbeddedNeo4jJtaModuleMemberRegistrationIT.neo4jFolder() )
 				.up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 		return persistenceDescriptor;
 	}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationIT.java
@@ -65,6 +65,7 @@ public class RedisModuleMemberRegistrationIT extends ModuleMemberRegistrationSce
 				.createProperty().name( OgmProperties.DATASTORE_PROVIDER ).value( Redis.DATASTORE_PROVIDER_NAME ).up()
 				.createProperty().name( OgmProperties.DATABASE ).value( "0" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/redis/RedisModuleMemberRegistrationWithTTLConfiguredIT.java
@@ -78,6 +78,7 @@ public class RedisModuleMemberRegistrationWithTTLConfiguredIT extends ModuleMemb
 				.createProperty().name( OgmProperties.DATABASE ).value( "0" ).up()
 				.createProperty().name( RedisProperties.TTL ).value( "3600" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();
 	}
 

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModuleMemberRegistrationDeployment.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModuleMemberRegistrationDeployment.java
@@ -48,6 +48,7 @@ public class ModuleMemberRegistrationDeployment {
 		public Builder persistenceXml(PersistenceDescriptor descriptor) {
 			resourceLocal = descriptor.getOrCreatePersistenceUnit().getTransactionType() == PersistenceUnitTransactionType._RESOURCE_LOCAL;
 			String persistenceXml = descriptor.exportAsString();
+			persistenceXml = ModulesHelper.injectVariables( persistenceXml );
 			archive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
 			return this;
 		}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModulesHelper.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/testcase/util/ModulesHelper.java
@@ -58,7 +58,7 @@ public class ModulesHelper {
 		return new StringAsset( manifest );
 	}
 
-	private static String injectVariables(String dependencies) {
+	public static String injectVariables(String dependencies) {
 		String variablesFromProperties = injectVariablesFromProperties( dependencies );
 		//The OGM module slot is "hardcoded" as a special case:
 		return applyPropertyReplacement( variablesFromProperties, "hibernate-ogm.module.slot", getModuleSlotString() );

--- a/modules/wildfly/pom.xml
+++ b/modules/wildfly/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>hibernate-envers</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-java8</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- This is to satisfy Neo4J's custom Lucene,
           not to be confused with the one used by Hibernate Search -->
         <dependency>

--- a/modules/wildfly/src/main/aliases/org/hibernate/search/engine/module.xml
+++ b/modules/wildfly/src/main/aliases/org/hibernate/search/engine/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module-alias xmlns="urn:jboss:module:1.1"
+    name="org.hibernate.search.engine" slot="${hibernate-search.module.slot}"
+    target-name="org.hibernate.search.engine" target-slot="${hibernateSearchVersion}" />

--- a/modules/wildfly/src/main/assembly/dist.xml
+++ b/modules/wildfly/src/main/assembly/dist.xml
@@ -124,6 +124,18 @@
             <outputDirectory>/org/hibernate/ogm/internal/parboiled/${hibernate.ogm.module.slot}</outputDirectory>
             <filtered>true</filtered>
         </file>
+
+        <!-- HSEARCH 5.5 using ORM 5.1 -->
+        <file>
+            <source>${module.xml.basedir}/org/hibernate/search/orm/module.xml</source>
+            <outputDirectory>/org/hibernate/search/orm/${hibernate-search.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>${module.xml.aliases.basedir}/org/hibernate/search/engine/module.xml</source>
+            <outputDirectory>/org/hibernate/search/engine/${hibernate-search.module.slot}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
     </files>
 
     <dependencySets>

--- a/modules/wildfly/src/main/modules/ogm/core/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/core/module.xml
@@ -10,7 +10,7 @@
         <resource-root path="hibernate-ogm-core-${project.version}.jar" />
     </resources>
     <dependencies>
-        <module name="org.hibernate" export="true" />
+        <module name="org.hibernate" export="true" slot="${hibernate-orm.module.slot}" />
         <module name="org.hibernate.commons-annotations" />
         <module name="org.hibernate.hql" slot="${hibernate.hql.module.slot}" />
         <module name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}" optional="true" />

--- a/modules/wildfly/src/main/modules/ogm/jipijapa/module.xml
+++ b/modules/wildfly/src/main/modules/ogm/jipijapa/module.xml
@@ -10,8 +10,8 @@
         <resource-root path="hibernate-ogm-jipijapa-${project.version}.jar" />
     </resources>
     <dependencies>
-        <module name="org.hibernate.jipijapa-hibernate5" />
+        <module name="org.hibernate.jipijapa-hibernate5" slot="${hibernate-orm.module.slot}"/>
         <module name="org.jboss.as.jpa.spi" />
-        <module name="org.hibernate" />
+        <module name="org.hibernate" slot="${hibernate-orm.module.slot}" />
     </dependencies>
 </module>

--- a/modules/wildfly/src/main/modules/org/hibernate/search/orm/module.xml
+++ b/modules/wildfly/src/main/modules/org/hibernate/search/orm/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.orm" slot="${hibernate-search.module.slot}">
+    <resources>
+        <artifact name="org.hibernate:hibernate-search-orm:${hibernateSearchVersion}"/>
+    </resources>
+    <dependencies>
+        <module name="javax.transaction.api" />
+        <module name="org.hibernate" slot="${hibernate-orm.module.slot}" />
+        <module name="org.hibernate.commons-annotations" />
+        <module name="org.hibernate.search.engine" export="true" services="import" slot="${hibernateSearchVersion}" />
+        <module name="org.jboss.logging" />
+        <module name="javax.persistence.api" />
+    </dependencies>
+</module>

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/transaction/impl/EmbeddedNeo4jResourceLocalTransactionCoordinator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/transaction/impl/EmbeddedNeo4jResourceLocalTransactionCoordinator.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.datastore.neo4j.embedded.transaction.impl;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javax.transaction.Status;
 
@@ -50,7 +51,7 @@ public class EmbeddedNeo4jResourceLocalTransactionCoordinator implements Transac
 
 	private final transient List<TransactionObserver> observers;
 
-	private EmbeddedNeo4jDatastoreProvider provider;
+	private final EmbeddedNeo4jDatastoreProvider provider;
 
 	/**
 	 * Construct a ResourceLocalTransactionCoordinatorImpl instance. Package-protected to ensure access goes through
@@ -63,7 +64,7 @@ public class EmbeddedNeo4jResourceLocalTransactionCoordinator implements Transac
 			TransactionCoordinatorOwner owner,
 			EmbeddedNeo4jDatastoreProvider provider) {
 		this.provider = provider;
-		this.observers = new ArrayList<TransactionObserver>();
+		this.observers = new ArrayList<>();
 		this.transactionCoordinatorBuilder = transactionCoordinatorBuilder;
 		this.owner = owner;
 	}
@@ -154,6 +155,11 @@ public class EmbeddedNeo4jResourceLocalTransactionCoordinator implements Transac
 					tx = null;
 				}
 			}
+		}
+
+		@Override
+		public <T> T delegateCallable(Callable<T> callable, boolean transacted) throws HibernateException {
+			throw new UnsupportedOperationException( "Not implemented yet" );
 		}
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/transaction/impl/RemoteNeo4jResourceLocalTransactionCoordinator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/transaction/impl/RemoteNeo4jResourceLocalTransactionCoordinator.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.datastore.neo4j.remote.transaction.impl;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javax.transaction.Status;
 
@@ -51,7 +52,7 @@ public class RemoteNeo4jResourceLocalTransactionCoordinator implements Transacti
 
 	private final transient List<TransactionObserver> observers;
 
-	private RemoteNeo4jDatastoreProvider provider;
+	private final RemoteNeo4jDatastoreProvider provider;
 
 	/**
 	 * Construct a {@link RemoteNeo4jResourceLocalTransactionCoordinator} instance. package-protected to ensure access goes through
@@ -64,7 +65,7 @@ public class RemoteNeo4jResourceLocalTransactionCoordinator implements Transacti
 			TransactionCoordinatorOwner owner,
 			RemoteNeo4jDatastoreProvider provider) {
 		this.provider = provider;
-		this.observers = new ArrayList<TransactionObserver>();
+		this.observers = new ArrayList<>();
 		this.transactionCoordinatorBuilder = transactionCoordinatorBuilder;
 		this.owner = owner;
 	}
@@ -155,6 +156,11 @@ public class RemoteNeo4jResourceLocalTransactionCoordinator implements Transacti
 					tx = null;
 				}
 			}
+		}
+
+		@Override
+		public <T> T delegateCallable(Callable<T> callable, boolean transacted) throws HibernateException {
+			throw new UnsupportedOperationException( "Not implemented yet" );
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,13 @@
         <!-- Since we require users to import a specific Hibernate Search module explicitly,
          all integration tests need to know which version that shall be.
          So the property needs to be defined in the global parent pom -->
-        <hibernate-search.module.slot>main</hibernate-search.module.slot>
+        <hibernate-search.module.slot>${hibernateSearchVersion}-orm51</hibernate-search.module.slot>
         <!-- Following might not match the slot, for example when 'main' is being used. Needed in docs URL rendering. -->
         <hibernate-search-major-minor-version>5.5</hibernate-search-major-minor-version>
 
         <!-- Target version of WildFly (for testing and JipiJapa integration) -->
         <version.wildfly>10.0.0.Final</version.wildfly>
+        <hibernate-orm.module.slot>5.1</hibernate-orm.module.slot>
     </properties>
 
     <!-- Only for management of test-scoped dependencies; All other dependencies (which are exposed to users) are


### PR DESCRIPTION
Should be good to go now. I re-use the existing ORM 5.1.1-SNAPSHOT module ZIP now, so no need for the further "skinny module" approach. We only need to upgrade to 5.1.1.Final once out.