### PR TITLE
OGM-1119 / OGM-1120 Improve test infrastructure to speed up Cassandra tests

### DIFF
--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/impl/CassandraDatastoreProvider.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/impl/CassandraDatastoreProvider.java
@@ -107,7 +107,7 @@ public class CassandraDatastoreProvider extends BaseDatastoreProvider
 	public void start() {
 		if ( cluster == null ) {
 			if ( ! config.getHosts().isSingleHost() ) {
-				throw new HibernateException( "Hibernate OGM Cassandra backend does not yet support multiple hosts, Coming soom" );
+				throw new HibernateException( "Hibernate OGM Cassandra backend does not yet support multiple hosts. Coming soon." );
 			}
 			try {
 				Hosts.HostAndPort hostAndPort = config.getHosts().getFirst();
@@ -119,14 +119,13 @@ public class CassandraDatastoreProvider extends BaseDatastoreProvider
 						.withCredentials( config.getUsername(), config.getPassword() )
 						.build();
 
-				Session bootstrapSession = cluster.connect();
-				bootstrapSession.execute(
+				session = cluster.connect();
+				session.execute(
 						"CREATE KEYSPACE IF NOT EXISTS " + config.getDatabaseName() +
 								" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 }"
 				);
-				bootstrapSession.close();
 
-				session = cluster.connect( config.getDatabaseName() );
+				session.execute( "USE " + config.getDatabaseName() );
 
 				sequenceHandler = new CassandraSequenceHandler(this);
 			}
@@ -147,9 +146,7 @@ public class CassandraDatastoreProvider extends BaseDatastoreProvider
 	}
 
 	public void removeKeyspace() {
-		Session bootstrapSession = cluster.connect();
-		bootstrapSession.execute( "DROP KEYSPACE " + config.getDatabaseName() );
-		bootstrapSession.close();
+		session.execute( "DROP KEYSPACE " + config.getDatabaseName() );
 	}
 
 	public void createSecondaryIndexIfNeeded(String entityName, String columnName) {

--- a/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/query/nativequery/CassandraEntityManagerNativeQueryTest.java
+++ b/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/query/nativequery/CassandraEntityManagerNativeQueryTest.java
@@ -18,7 +18,7 @@ import javax.persistence.Query;
 import org.hibernate.ogm.backendtck.jpa.Poem;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.TestForIssue;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -31,7 +31,7 @@ import org.junit.Test;
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  * @author Jonathan Halliday
  */
-public class CassandraEntityManagerNativeQueryTest extends JpaTestCase {
+public class CassandraEntityManagerNativeQueryTest extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Poem.class );
@@ -132,7 +132,7 @@ public class CassandraEntityManagerNativeQueryTest extends JpaTestCase {
 
 	@Test
 	@Ignore
-	// TODO OGM-564 Re-enable once HHH-8237 is resolved and we're on ORM 4.3.6
+	// TODO OGM-564 Re-enable once HHH-9279 is resolved and we upgraded ORM
 	public void testProjectionQueryWithTypeConversion() throws Exception {
 		begin();
 
@@ -203,7 +203,7 @@ public class CassandraEntityManagerNativeQueryTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {OscarWildePoem.class, Critic.class};
 	}
 
@@ -228,7 +228,8 @@ public class CassandraEntityManagerNativeQueryTest extends JpaTestCase {
 
 	private EntityManager delete(Object... entities) {
 		for ( Object object : entities ) {
-			em.detach( object );
+			Object entity = em.merge( object );
+			em.remove( entity );
 		}
 		return em;
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/BatchFetchingTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/BatchFetchingTest.java
@@ -217,7 +217,7 @@ public class BatchFetchingTest extends OgmTestCase {
 	}
 
 	private boolean isMultigetDialect() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		return GridDialects.hasFacet( gridDialect, MultigetGridDialect.class );
 	}
 
@@ -227,7 +227,7 @@ public class BatchFetchingTest extends OgmTestCase {
 	}
 
 	private InvokedOperationsLoggingDialect getOperationsLogger() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		InvokedOperationsLoggingDialect invocationLogger = GridDialects.getDelegateOrNull(
 				gridDialect,
 				InvokedOperationsLoggingDialect.class

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -174,7 +174,7 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 	}
 
 	private MultigetGridDialect multiGetGridDialect() {
-		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
+		MultigetGridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
@@ -173,7 +173,7 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 	}
 
 	private MultigetGridDialect multiGetGridDialect() {
-		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
+		MultigetGridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
@@ -170,7 +170,7 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 	}
 
 	private MultigetGridDialect multiGetGridDialect() {
-		MultigetGridDialect gridDialect = sfi().getServiceRegistry().getService( MultigetGridDialect.class );
+		MultigetGridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( MultigetGridDialect.class );
 		return gridDialect;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/callbacks/PostLoadTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/callbacks/PostLoadTest.java
@@ -16,7 +16,8 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.SkipByGridDialect;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -26,7 +27,7 @@ import org.junit.Test;
 		value = { GridDialectType.CASSANDRA },
 		comment = "Zoo.animals set - bag semantics unsupported (no primary key)"
 )
-public class PostLoadTest extends JpaTestCase {
+public class PostLoadTest extends OgmJpaTestCase {
 
 	/**
 	 * Load an entity with an embedded collection which uses a @PostLoad annotated method
@@ -95,8 +96,17 @@ public class PostLoadTest extends JpaTestCase {
 		return animal;
 	}
 
+	@After
+	public void removeEntities() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+		em.remove( em.find( Zoo.class, 1 ) );
+		em.getTransaction().commit();
+		em.close();
+	}
+
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Zoo.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
@@ -19,7 +19,6 @@ import javax.persistence.Persistence;
 import javax.transaction.TransactionManager;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.jpa.HibernateEntityManagerFactory;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.compensation.ErrorHandler.RollbackContext;
@@ -37,7 +36,7 @@ import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.TestHelper;
 import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +51,7 @@ import org.junit.Test;
 		value = { GridDialectType.CASSANDRA },
 		comment = "Cassandra always upserts, doesn't read-lock before write, doesn't support unique constraints even on primary key except by explicit/slow CAS use"
 )
-public class CompensationSpiJpaTest  extends JpaTestCase {
+public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/transaction-type-jta.xml", Shipment.class );
@@ -210,12 +209,12 @@ public class CompensationSpiJpaTest  extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Shipment.class };
 	}
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.getProperties().put( OgmProperties.ERROR_HANDLER, InvocationTrackingHandler.INSTANCE );
 	}
 
@@ -233,9 +232,4 @@ public class CompensationSpiJpaTest  extends JpaTestCase {
 		return gridDialect.getDuplicateInsertPreventionStrategy( ekm ) == DuplicateInsertPreventionStrategy.LOOK_UP;
 	}
 
-	private TransactionManager getTransactionManager(EntityManagerFactory factory) {
-		SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) ( (HibernateEntityManagerFactory) factory )
-				.getSessionFactory();
-		return sessionFactory.getServiceRegistry().getService( JtaPlatform.class ).retrieveTransactionManager();
-	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiTest.java
@@ -486,12 +486,12 @@ public class CompensationSpiTest extends OgmTestCase {
 	}
 
 	private boolean currentDialectHasFacet(Class<? extends GridDialect> facet) {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		return GridDialects.hasFacet( gridDialect, facet );
 	}
 
 	private boolean currentDialectUsesLookupDuplicatePreventionStrategy() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		DefaultEntityKeyMetadata ekm = new DefaultEntityKeyMetadata( "Shipment", new String[]{"id"} );
 
 		return gridDialect.getDuplicateInsertPreventionStrategy( ekm ) == DuplicateInsertPreventionStrategy.LOOK_UP;

--- a/core/src/test/java/org/hibernate/ogm/backendtck/hsearch/HibernateSearchAtopOgmTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/hsearch/HibernateSearchAtopOgmTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.backendtck.hsearch;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -14,7 +16,7 @@ import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.SkipByGridDialect;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.FullTextQuery;
@@ -22,13 +24,11 @@ import org.hibernate.search.jpa.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 @SkipByGridDialect(value = { GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE }, comment = "Neo4j is not compatible with HSEARCH 5")
-public class HibernateSearchAtopOgmTest extends JpaTestCase {
+public class HibernateSearchAtopOgmTest extends OgmJpaTestCase {
 
 	@Test
 	public void testHibernateSearchJPAAPIUsage() throws Exception {
@@ -88,7 +88,7 @@ public class HibernateSearchAtopOgmTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Insurance.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/AutoIdGeneratorTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/AutoIdGeneratorTest.java
@@ -11,7 +11,7 @@ import javax.persistence.EntityManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -20,7 +20,7 @@ import static org.fest.assertions.Assertions.assertThat;
  *
  * @author Nabeel Ali Memon &lt;nabeel@nabeelalimemon.com&gt;
  */
-public class AutoIdGeneratorTest extends JpaTestCase {
+public class AutoIdGeneratorTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -61,7 +61,7 @@ public class AutoIdGeneratorTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 				DistributedRevisionControl.class
 		};

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/CompositeIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/CompositeIdTest.java
@@ -14,14 +14,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  */
-public class CompositeIdTest extends JpaTestCase {
+public class CompositeIdTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -111,7 +111,7 @@ public class CompositeIdTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 				News.class,
 				NewsID.class,

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/DuplicateIdDetectionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/DuplicateIdDetectionTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.SkipByGridDialect;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -29,7 +29,7 @@ import static org.junit.Assert.fail;
 		value = { GridDialectType.CASSANDRA },
 		comment = "Cassandra always upserts, doesn't read-lock before write, doesn't support unique constraints even on primary key except by explicit/slow CAS use"
 )
-public class DuplicateIdDetectionTest extends JpaTestCase {
+public class DuplicateIdDetectionTest extends OgmJpaTestCase {
 	EntityManager em;
 
 	@Before
@@ -125,7 +125,7 @@ public class DuplicateIdDetectionTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { MakeupArtist.class, MakeupArtistWithCompositeKey.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/IdentityIdGeneratorTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/IdentityIdGeneratorTest.java
@@ -15,7 +15,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.Throwables;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.SingleJpaTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,7 +24,7 @@ import org.junit.rules.ExpectedException;
 /**
  * @author Nabeel Ali Memon &lt;nabeel@nabeelalimemon.com&gt;
  */
-public class IdentityIdGeneratorTest extends JpaTestCase {
+public class IdentityIdGeneratorTest extends SingleJpaTestCase {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/SequenceIdGeneratorTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/SequenceIdGeneratorTest.java
@@ -11,14 +11,14 @@ import javax.persistence.EntityManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Nabeel Ali Memon &lt;nabeel@nabeelalimemon.com&gt;
  */
-public class SequenceIdGeneratorTest extends JpaTestCase {
+public class SequenceIdGeneratorTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -86,7 +86,7 @@ public class SequenceIdGeneratorTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 				Song.class,
 				Actor.class

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/TableIdGeneratorTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/TableIdGeneratorTest.java
@@ -12,14 +12,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
-public class TableIdGeneratorTest extends JpaTestCase {
+public class TableIdGeneratorTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -79,7 +79,7 @@ public class TableIdGeneratorTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 				Music.class,
 				Video.class,

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/sharedpk/SharedPrimaryKeyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/sharedpk/SharedPrimaryKeyTest.java
@@ -11,7 +11,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import javax.persistence.EntityManager;
 import javax.persistence.PrimaryKeyJoinColumn;
 
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import org.junit.After;
 import org.junit.Before;
@@ -22,7 +22,7 @@ import org.junit.Test;
  *
  * @author Gunnar Morling
  */
-public class SharedPrimaryKeyTest extends JpaTestCase {
+public class SharedPrimaryKeyTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -61,7 +61,7 @@ public class SharedPrimaryKeyTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { CoffeeMug.class, Lid.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/InnerClassFindTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/innertypes/InnerClassFindTest.java
@@ -10,7 +10,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import javax.persistence.EntityManager;
 import org.hibernate.ogm.backendtck.innertypes.CommunityMember.Employee;
 import org.hibernate.ogm.utils.TestForIssue;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.Test;
 
 /**
@@ -25,7 +25,7 @@ import org.junit.Test;
  * @author Sanne Grinovero
  */
 @TestForIssue(jiraKey = "OGM-265")
-public class InnerClassFindTest extends JpaTestCase {
+public class InnerClassFindTest extends OgmJpaTestCase {
 
 	@Test
 	public void testInnerClassFind() throws Exception {
@@ -57,7 +57,7 @@ public class InnerClassFindTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[]{ CommunityMember.class, Employee.class };
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAAPIWrappingTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAAPIWrappingTest.java
@@ -17,7 +17,7 @@ import org.hibernate.ogm.jpa.impl.OgmEntityManager;
 import org.hibernate.ogm.jpa.impl.OgmEntityManagerFactory;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.TestHelper;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -25,7 +25,7 @@ import org.junit.rules.ExpectedException;
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
-public class JPAAPIWrappingTest extends JpaTestCase {
+public class JPAAPIWrappingTest extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Poem.class );
@@ -74,7 +74,7 @@ public class JPAAPIWrappingTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Poem.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAJTATest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAJTATest.java
@@ -6,29 +6,26 @@
  */
 package org.hibernate.ogm.backendtck.jpa;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.utils.TestHelper.dropSchemaAndDatabase;
+
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.transaction.TransactionManager;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
-import org.hibernate.jpa.HibernateEntityManagerFactory;
 import org.hibernate.ogm.utils.GridDialectType;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.TestHelper;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.hibernate.ogm.utils.TestHelper.dropSchemaAndDatabase;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
-public class JPAJTATest extends JpaTestCase {
+public class JPAJTATest extends OgmJpaTestCase {
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/transaction-type-jta.xml", Poem.class );
 
@@ -68,14 +65,8 @@ public class JPAJTATest extends JpaTestCase {
 		emf.close();
 	}
 
-	private TransactionManager getTransactionManager(EntityManagerFactory factory) {
-		SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) ( (HibernateEntityManagerFactory) factory )
-				.getSessionFactory();
-		return sessionFactory.getServiceRegistry().getService( JtaPlatform.class ).retrieveTransactionManager();
-	}
-
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Poem.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/massindex/AssociationMassIndexerTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/massindex/AssociationMassIndexerTest.java
@@ -22,7 +22,7 @@ import org.hibernate.ogm.backendtck.massindex.model.IndexedLabel;
 import org.hibernate.ogm.backendtck.massindex.model.IndexedNews;
 import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
@@ -31,7 +31,7 @@ import org.junit.Test;
 /**
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class AssociationMassIndexerTest extends JpaTestCase {
+public class AssociationMassIndexerTest extends OgmJpaTestCase {
 
 	@Test
 	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Uses embedded key which is currently not supported by the db query parsers")
@@ -131,13 +131,13 @@ public class AssociationMassIndexerTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { IndexedNews.class, IndexedLabel.class };
 	}
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
-		super.refineInfo( info );
+	protected void configure(GetterPersistenceUnitInfo info) {
+		super.configure( info );
 		info.getProperties().setProperty( "hibernate.search.default.directory_provider", "ram" );
 		// Infinispan requires to be set to distribution mode for this test to pass
 		info.getProperties().setProperty( "hibernate.ogm.infinispan.configuration_resourcename", "infinispan-dist.xml" );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/perf/PerfTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/perf/PerfTest.java
@@ -13,7 +13,7 @@ import java.util.Random;
 
 import javax.persistence.EntityManager;
 
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.SingleJpaTestCase;
 import org.junit.Ignore;
 
 /**
@@ -23,7 +23,7 @@ import org.junit.Ignore;
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 @Ignore
-public class PerfTest extends JpaTestCase {
+public class PerfTest extends SingleJpaTestCase {
 
 	private static Random rand = new Random();
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/JpaQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/JpaQueriesTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,7 +22,7 @@ import org.junit.rules.ExpectedException;
 /**
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class JpaQueriesTest extends JpaTestCase {
+public class JpaQueriesTest extends OgmJpaTestCase {
 
 	private static final String POLICE_HELICOPTER = "Bell 206";
 
@@ -155,13 +155,13 @@ public class JpaQueriesTest extends JpaTestCase {
 		//Do not hide the real cause with an NPE if there are initialization issues:
 		if ( em != null ) {
 			em.getTransaction().commit();
-			removeEntities();
 			em.close();
+			removeEntities();
 		}
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Helicopter.class };
 	}
 
@@ -169,17 +169,6 @@ public class JpaQueriesTest extends JpaTestCase {
 		Helicopter helicopter = new Helicopter();
 		helicopter.setName( name );
 		return helicopter;
-	}
-
-	private void removeEntities() throws Exception {
-		em.getTransaction().begin();
-		for ( Class<?> each : getEntities() ) {
-			List<?> entities = em.createQuery( "FROM " + each.getSimpleName() ).getResultList();
-			for ( Object object : entities ) {
-				em.remove( object );
-			}
-		}
-		em.getTransaction().commit();
 	}
 
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithAssociationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithAssociationsTest.java
@@ -24,7 +24,7 @@ import java.util.TimeZone;
 import javax.persistence.EntityManager;
 
 import org.hibernate.ogm.utils.SkipByGridDialect;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +35,7 @@ import org.junit.Test;
 @SkipByGridDialect(
 		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH },
 		comment = "We need a QueryParserService to be able to perform these queries.")
-public class QueriesWithAssociationsTest extends JpaTestCase {
+public class QueriesWithAssociationsTest extends OgmJpaTestCase {
 
 	private EntityManager em;
 
@@ -148,6 +148,12 @@ public class QueriesWithAssociationsTest extends JpaTestCase {
 		garibaldiStreet.setStreet( "rue Garibaldi" );
 		em.persist( garibaldiStreet );
 
+		Address monumentStreet = new Address();
+		monumentStreet.setId( 3L );
+		monumentStreet.setCity( "London" );
+		monumentStreet.setStreet( "Monument Street" );
+		em.persist( monumentStreet );
+
 		Author alfred = new Author();
 		alfred.setId( 1L );
 		alfred.setName( "alfred" );
@@ -163,7 +169,7 @@ public class QueriesWithAssociationsTest extends JpaTestCase {
 		Author alphonse = new Author();
 		alphonse.setId( 3L );
 		alphonse.setName( "alphonse" );
-		alphonse.setAddress( mainStreet );
+		alphonse.setAddress( monumentStreet );
 		em.persist( alphonse );
 
 		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( "GMT" ) );
@@ -214,25 +220,14 @@ public class QueriesWithAssociationsTest extends JpaTestCase {
 		//Do not hide the real cause with an NPE if there are initialization issues:
 		if ( em != null ) {
 			em.getTransaction().commit();
-			removeEntities();
 			em.close();
+			removeEntities();
 		}
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
-		return new Class<?>[] { Address.class, Author.class, Hypothesis.class };
-	}
-
-	private void removeEntities() throws Exception {
-		em.getTransaction().begin();
-		for ( Class<?> each : getEntities() ) {
-			List<?> entities = em.createQuery( "FROM " + each.getSimpleName() ).getResultList();
-			for ( Object object : entities ) {
-				em.remove( object );
-			}
-		}
-		em.getTransaction().commit();
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Hypothesis.class, Author.class, Address.class };
 	}
 
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithToOnePropertyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithToOnePropertyTest.java
@@ -15,13 +15,11 @@ import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_JSON;
 
-import java.util.List;
-
 import javax.persistence.EntityManager;
 
 import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.TestForIssue;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +30,7 @@ import org.junit.Test;
 @SkipByGridDialect(
 		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH },
 		comment = "We need a QueryParserService to be able to perform these queries.")
-public class QueriesWithToOnePropertyTest extends JpaTestCase {
+public class QueriesWithToOnePropertyTest extends OgmJpaTestCase {
 
 	private EntityManager em;
 
@@ -74,25 +72,14 @@ public class QueriesWithToOnePropertyTest extends JpaTestCase {
 		//Do not hide the real cause with an NPE if there are initialization issues:
 		if ( em != null ) {
 			em.getTransaction().commit();
-			removeEntities();
 			em.close();
+			removeEntities();
 		}
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
-		return new Class<?>[] { Address.class, Author.class, Hypothesis.class };
-	}
-
-	private void removeEntities() throws Exception {
-		em.getTransaction().begin();
-		for ( Class<?> each : getEntities() ) {
-			List<?> entities = em.createQuery( "FROM " + each.getSimpleName() ).getResultList();
-			for ( Object object : entities ) {
-				em.remove( object );
-			}
-		}
-		em.getTransaction().commit();
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Author.class, Address.class, Hypothesis.class };
 	}
 
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/parameters/QueryWithParametersTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/parameters/QueryWithParametersTest.java
@@ -12,14 +12,11 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Map;
 
 import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 
 import org.hibernate.ogm.utils.PackagingRule;
-import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -30,32 +27,14 @@ import org.junit.Test;
  * @author Gunnar Morling
  *
  */
-public class QueryWithParametersTest {
+public class QueryWithParametersTest extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Movie.class );
 
-	private EntityManagerFactory emf;
-
-	@Before
-	public void setupEntityManagerFactory() throws Exception {
-		Map<String, String> properties = TestHelper.getDefaultTestSettings();
-		properties.put( "hibernate.search.default.directory_provider", "ram" );
-
-		emf = Persistence.createEntityManagerFactory( "ogm", properties );
-
-		insertTestEntities();
-	}
-
-	@After
-	public void closeEntityManagerFactory() {
-		TestHelper.dropSchemaAndDatabase( emf );
-		emf.close();
-	}
-
 	@Test
 	public void canUseByteForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.viewerRating = 8", Movie.class )
@@ -69,7 +48,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseByteAsParameterForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.viewerRating = :viewerRating", Movie.class )
@@ -84,7 +63,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseByteAsParameterForInComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.viewerRating IN (:viewerRating)", Movie.class )
@@ -100,7 +79,7 @@ public class QueryWithParametersTest {
 	@Test
 	@Ignore("TODO HQLPARSER-59")
 	public void canUseEnumLiteralForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.genre = org.hibernate.ogm.backendtck.queries.enums.Genre.THRILLER", Movie.class )
@@ -114,7 +93,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseEnumAsParameterForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.genre = :genre", Movie.class )
@@ -129,7 +108,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseQueriesWithEnumAsParameterForInQuery() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.genre IN (:genre)", Movie.class )
@@ -145,7 +124,7 @@ public class QueryWithParametersTest {
 	@Test
 	@Ignore("TODO HQLPARSER-59")
 	public void canUseBooleanLiteralForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.suitableForKids = FALSE", Movie.class )
@@ -159,7 +138,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseBooleanAsParameterForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.suitableForKids = :suitable", Movie.class )
@@ -175,7 +154,7 @@ public class QueryWithParametersTest {
 	@Test
 	@Ignore("TODO HQLPARSER-59")
 	public void canUseDateLiteralForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.releaseDate = '02 April 1958'", Movie.class )
@@ -189,7 +168,7 @@ public class QueryWithParametersTest {
 
 	@Test
 	public void canUseDateParameterForSimpleComparison() {
-		EntityManager entityManager = emf.createEntityManager();
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		List<Movie> thrillers = entityManager.createQuery( "SELECT m FROM Movie m WHERE m.releaseDate = :releaseDate", Movie.class )
@@ -202,8 +181,9 @@ public class QueryWithParametersTest {
 		entityManager.close();
 	}
 
-	private void insertTestEntities() throws Exception {
-		EntityManager entityManager = emf.createEntityManager();
+	@Before
+	public void insertTestEntities() throws Exception {
+		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
 
 		entityManager.persist( new Movie( "movie-1", Genre.COMEDY, "To thatch a roof", true, new GregorianCalendar( 1955, 5, 10 ).getTime(), (byte) 8 ) );
@@ -213,5 +193,24 @@ public class QueryWithParametersTest {
 
 		entityManager.getTransaction().commit();
 		entityManager.close();
+	}
+
+	@After
+	public void removeTestEntities() {
+		EntityManager entityManager = getFactory().createEntityManager();
+		entityManager.getTransaction().begin();
+
+		entityManager.remove( entityManager.find( Movie.class, "movie-1" ) );
+		entityManager.remove( entityManager.find( Movie.class, "movie-2" ) );
+		entityManager.remove( entityManager.find( Movie.class, "movie-3" ) );
+		entityManager.remove( entityManager.find( Movie.class, "movie-4" ) );
+
+		entityManager.getTransaction().commit();
+		entityManager.close();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Movie.class };
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/test/associations/AssociationKeyMetadataEqualityTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/associations/AssociationKeyMetadataEqualityTest.java
@@ -28,10 +28,10 @@ public class AssociationKeyMetadataEqualityTest extends OgmTestCase {
 	// Each association must have a different table. For this reason we decided to update the tests and rename the
 	// tables. I'll leave this here just in case someone decides to change the test.
 	public void testDefaultAssociationKeyMetadataEquals() throws Exception {
-		OgmCollectionPersister collection1 = (OgmCollectionPersister) sfi().getCollectionPersister( User.class.getName() + ".phoneNumbersByPriority" );
+		OgmCollectionPersister collection1 = (OgmCollectionPersister) getSessionFactory().getCollectionPersister( User.class.getName() + ".phoneNumbersByPriority" );
 		AssociationKeyMetadata byPriority = collection1.getAssociationKeyMetadata();
 
-		OgmCollectionPersister collection2 = (OgmCollectionPersister) sfi().getCollectionPersister( User.class.getName() + ".alternativePhoneNumbers" );
+		OgmCollectionPersister collection2 = (OgmCollectionPersister) getSessionFactory().getCollectionPersister( User.class.getName() + ".alternativePhoneNumbers" );
 		AssociationKeyMetadata alternatvePhoneNumbers = collection2.getAssociationKeyMetadata();
 
 		assertThat( byPriority ).as( "Missing required association for testing" ).isNotNull();

--- a/core/src/test/java/org/hibernate/ogm/test/dialectinvocations/GridDialectOperationInvocationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/dialectinvocations/GridDialectOperationInvocationsTest.java
@@ -170,7 +170,7 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 	}
 
 	private InvokedOperationsLoggingDialect getOperationsLogger() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		InvokedOperationsLoggingDialect invocationLogger = GridDialects.getDelegateOrNull(
 				gridDialect,
 				InvokedOperationsLoggingDialect.class

--- a/core/src/test/java/org/hibernate/ogm/test/persister/AssociationKeyMetadataTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/persister/AssociationKeyMetadataTest.java
@@ -68,11 +68,11 @@ public class AssociationKeyMetadataTest extends OgmTestCase {
 	}
 
 	private OgmEntityPersister getEntityPersister(String entityName) {
-		return (OgmEntityPersister) ( sfi() ).getEntityPersister( entityName );
+		return (OgmEntityPersister) ( getSessionFactory() ).getEntityPersister( entityName );
 	}
 
 	private OgmCollectionPersister getCollectionPersister(String role) {
-		return (OgmCollectionPersister) ( sfi() ).getCollectionPersister( role );
+		return (OgmCollectionPersister) ( getSessionFactory() ).getCollectionPersister( role );
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/test/persister/BiDirectionalAssociationHelperTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/persister/BiDirectionalAssociationHelperTest.java
@@ -134,11 +134,11 @@ public class BiDirectionalAssociationHelperTest extends OgmTestCase {
 	}
 
 	private OgmEntityPersister getEntityPersister(String entityName) {
-		return (OgmEntityPersister) ( sfi() ).getEntityPersister( entityName );
+		return (OgmEntityPersister) ( getSessionFactory() ).getEntityPersister( entityName );
 	}
 
 	private OgmCollectionPersister getCollectionPersister(String role) {
-		return (OgmCollectionPersister) ( sfi() ).getCollectionPersister( role );
+		return (OgmCollectionPersister) ( getSessionFactory() ).getCollectionPersister( role );
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/test/testsupport/OgmTestCaseConfigureTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/testsupport/OgmTestCaseConfigureTest.java
@@ -33,7 +33,7 @@ public class OgmTestCaseConfigureTest extends OgmTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1113")
 	public void testConfigureWorksProperly() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 
 		assertThat( ( (GridDialectLogger) gridDialect ).getGridDialect() ).isInstanceOf( InvocationCollectingGridDialect.class );
 	}

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
@@ -96,7 +96,7 @@ public abstract class OgmTestCase {
 		}
 	}
 
-	protected OgmSessionFactoryImplementor sfi() {
+	protected OgmSessionFactoryImplementor getSessionFactory() {
 		return (OgmSessionFactoryImplementor) sessionFactory;
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestCase.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.OgmSessionFactory;
 import org.hibernate.ogm.engine.spi.OgmSessionFactoryImplementor;
@@ -27,7 +26,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Base class for OGM tests. While tests also can directly make use of {@link OgmTestRunner}, this base class provides
- * template methods for entity type configuration and modifications to {@link Configuration} as well as a member for the
+ * template methods for entity type configuration and modifications to the configuration as well as a member for the
  * session factory.
  *
  * @author Gunnar Morling
@@ -55,13 +54,13 @@ public abstract class OgmTestCase {
 	 */
 	protected abstract Class<?>[] getAnnotatedClasses();
 
-	@SessionFactoryConfiguration
+	@TestSessionFactoryConfiguration
 	private void modifyConfiguration(Map<String, Object> cfg) {
 		configure( cfg );
 	}
 
 	/**
-	 * Can be overridden in subclasses to inspect or modify the {@link Configuration} of this test.
+	 * Can be overridden in subclasses to inspect or modify the configuration of this test.
 	 *
 	 * @param cfg the configuration
 	 */

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import javax.transaction.TransactionManager;
 
 import org.hibernate.SessionFactory;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.ogm.OgmSessionFactory;
@@ -43,8 +42,8 @@ import org.junit.runners.model.TestClass;
  * {@link TestSessionFactory#scope() } setting, either the same session factory instance will be used for all test
  * methods of a given test class or a new session factory will be created and injected for each individual test method.
  * <p>
- * Finally the {@link Configuration} used for bootstrapping the factory can optionally be modified by annotating a
- * configuration method with the {@link SessionFactoryConfiguration} a shown in the example below.
+ * Finally the configuration used for bootstrapping the factory can optionally be modified by annotating a
+ * configuration method with the {@link TestSessionFactoryConfiguration} a shown in the example below.
  * <p>
  * Usage example:
  *
@@ -63,12 +62,9 @@ import org.junit.runners.model.TestClass;
  *         session.close();
  *     }
  *
- *    @SessionFactoryConfiguration
- *    public static void configure(Configuration cfg) {
- *        cfg.setProperty(
- *            Environment.MONGODB_ASSOCIATIONS_STORE,
- *            AssociationStorage.COLLECTION.name()
- *        );
+ *    @TestSessionFactoryConfiguration
+ *    public static void configure(Map<String, Object> cfg) {
+ *        cfg.put( Environment.MONGODB_ASSOCIATIONS_STORE, AssociationStorage.COLLECTION.name() );
  *    }
  *
  *    @TestEntities
@@ -218,7 +214,7 @@ public class OgmTestRunner extends SkippableTestRunner {
 		Map<String, Object> testSpecificSettings = new HashMap<>();
 
 		try {
-			for ( FrameworkMethod frameworkMethod : getTestClass().getAnnotatedMethods( SessionFactoryConfiguration.class ) ) {
+			for ( FrameworkMethod frameworkMethod : getTestClass().getAnnotatedMethods( TestSessionFactoryConfiguration.class ) ) {
 				Method method = frameworkMethod.getMethod();
 				method.setAccessible( true );
 				method.invoke( super.createTest(), testSpecificSettings );

--- a/core/src/test/java/org/hibernate/ogm/utils/TestEntityManagerFactory.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestEntityManagerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.ogm.utils.jpa.OgmJpaTestRunner;
+
+/**
+ * Causes the entity manager factory used by a test executed with {@link OgmJpaTestRunner} to be injected into the annotated
+ * field.
+ *
+ * @author Guillaume Smet
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TestEntityManagerFactory {
+
+	/**
+	 * The scope of the entity manager factory.
+	 *
+	 * @return the scope of the entity manager factory
+	 */
+	Scope scope() default Scope.TEST_CLASS;
+
+	public enum Scope {
+
+		/**
+		 * The same entity manager factory instance is used for all test methods of the given test
+		 */
+		TEST_CLASS,
+
+		/**
+		 * A fresh entity manager factory instance is used for each individual test methods of the given test
+		 */
+		TEST_METHOD;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/TestEntityManagerFactoryConfiguration.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestEntityManagerFactoryConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.ogm.utils.jpa.OgmJpaTestRunner;
+
+/**
+ * Marks a method of a test executed with {@link OgmJpaTestRunner} which should inspect or modify the test's
+ * {@link GetterPersistenceUnitInfo}.
+ * <p>
+ * The method must have a single parameter of type {@code GetterPersistenceUnitInfo}.
+ *
+ * @author Guillaume Smet
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TestEntityManagerFactoryConfiguration {
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -310,10 +310,14 @@ public class TestHelper {
 			// DatastoreProvider service initialized.
 			// This dialect instance is initialized with the default configuration and is not aware of the additional settings
 			// set in the test itself. This is not an issue per se as this dialect is not used for anything else.
-			Object gridDialect = getDefaultTestStandardServiceRegistry( Collections.<String, Object>emptyMap() )
-					.getService( GridDialect.class );
+			StandardServiceRegistry isolatedServiceRegistry = getDefaultTestStandardServiceRegistry( Collections.<String, Object>emptyMap() );
 
-			return GridDialects.getWrappedDialect( (GridDialect) gridDialect );
+			Object gridDialect = isolatedServiceRegistry.getService( GridDialect.class );
+			Class<? extends GridDialect> gridDialectClass = GridDialects.getWrappedDialect( (GridDialect) gridDialect );
+
+			StandardServiceRegistryBuilder.destroy( isolatedServiceRegistry );
+
+			return gridDialectClass;
 		}
 	}
 
@@ -322,10 +326,14 @@ public class TestHelper {
 		private static final DatastoreProviderType INSTANCE = getDatastoreProvider();
 
 		private static DatastoreProviderType getDatastoreProvider() {
-			Object datastoreProviderProperty = getDefaultTestStandardServiceRegistry( Collections.<String, Object>emptyMap() )
+			StandardServiceRegistry isolatedServiceRegistry = getDefaultTestStandardServiceRegistry( Collections.<String, Object>emptyMap() );
+
+			Object datastoreProviderProperty = isolatedServiceRegistry
 					.getService( ConfigurationService.class )
 					.getSettings()
 					.get( OgmProperties.DATASTORE_PROVIDER );
+
+			StandardServiceRegistryBuilder.destroy( isolatedServiceRegistry );
 
 			if ( datastoreProviderProperty == null ) {
 				return null;
@@ -387,4 +395,5 @@ public class TestHelper {
 			return null;
 		}
 	}
+
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/TestSessionFactoryConfiguration.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestSessionFactoryConfiguration.java
@@ -13,13 +13,13 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method of a test executed with {@link OgmTestRunner} which should inspect or modify the test's
- * {@link Configuration}.
+ * configuration.
  * <p>
- * The method must have a single parameter of type {@code Configuration}.
+ * The method must have a single parameter of type {@code Map<String, Object>}.
  *
  * @author Gunnar Morling
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface SessionFactoryConfiguration {
+public @interface TestSessionFactoryConfiguration {
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestCase.java
@@ -1,0 +1,95 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils.jpa;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.transaction.TransactionManager;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.ogm.jpa.impl.OgmEntityManagerFactory;
+import org.hibernate.ogm.utils.TestEntities;
+import org.hibernate.ogm.utils.TestEntityManagerFactory;
+import org.hibernate.ogm.utils.TestEntityManagerFactoryConfiguration;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt;
+ * @author Guillaume Smet
+ */
+@RunWith(OgmJpaTestRunner.class)
+public abstract class OgmJpaTestCase {
+
+	@TestEntityManagerFactory
+	private EntityManagerFactory factory;
+
+	public EntityManagerFactory getFactory() {
+		return factory;
+	}
+
+	@TestEntities
+	private Class<?>[] getTestEntities() {
+		return getAnnotatedClasses();
+	}
+
+	/**
+	 * Must be implemented by subclasses to return the entity types used by this test.
+	 *
+	 * @return an array with this tests entity types
+	 */
+	protected abstract Class<?>[] getAnnotatedClasses();
+
+	@TestEntityManagerFactoryConfiguration
+	private void modifyConfiguration(GetterPersistenceUnitInfo info) {
+		configure( info );
+	}
+
+	/**
+	 * Can be overridden in subclasses to inspect or modify the {@link GetterPersistenceUnitInfo} of this test.
+	 *
+	 * @param info the configuration
+	 */
+	protected void configure(GetterPersistenceUnitInfo info) {
+	}
+
+	/**
+	 * @return Return the transaction manager in the case where one is available. Can be {@code null}.
+	 * A transaction manager will be available if JBoss Transaction is on the classpath. Where it is in use depends on
+	 * the current persistence unit under test and its persistence type setting.
+	 *
+	 * @throws Exception
+	 */
+	protected TransactionManager getTransactionManager(EntityManagerFactory factory) {
+		return getServiceRegistry().getService( JtaPlatform.class ).retrieveTransactionManager();
+	}
+
+	protected ServiceRegistryImplementor getServiceRegistry() {
+		OgmEntityManagerFactory emFactory = ( (OgmEntityManagerFactory) getFactory() );
+		SessionFactoryImplementor sessionFactory = emFactory.getSessionFactory();
+		ServiceRegistryImplementor serviceRegistry = sessionFactory.getServiceRegistry();
+		return serviceRegistry;
+	}
+
+	protected void removeEntities() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+		for ( Class<?> each : getAnnotatedClasses() ) {
+			List<?> entities = em.createQuery( "FROM " + each.getSimpleName() ).getResultList();
+			for ( Object object : entities ) {
+				em.remove( object );
+			}
+		}
+		em.getTransaction().commit();
+		em.close();
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestRunner.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestRunner.java
@@ -1,0 +1,296 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils.jpa;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.SharedCacheMode;
+import javax.persistence.ValidationMode;
+import javax.persistence.spi.PersistenceUnitTransactionType;
+import javax.transaction.Status;
+import javax.transaction.TransactionManager;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.jpa.HibernateEntityManagerFactory;
+import org.hibernate.ogm.exception.impl.Exceptions;
+import org.hibernate.ogm.jpa.HibernateOgmPersistence;
+import org.hibernate.ogm.utils.SkippableTestRunner;
+import org.hibernate.ogm.utils.TestEntities;
+import org.hibernate.ogm.utils.TestEntityManagerFactory;
+import org.hibernate.ogm.utils.TestEntityManagerFactoryConfiguration;
+import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.ogm.utils.TestEntityManagerFactory.Scope;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+
+/**
+ * A JUnit 4 runner for OGM tests using JPA. Based on a given set of entities, it manages a entity manager factory, which is used
+ * throughout all test methods of the given test class.
+ * <p>
+ * The entities of the test are to be returned by a parameterless method annotated with {@link TestEntities} in form of
+ * a {@code Class<?>[]}.
+ * <p>
+ * The used entity manager factory can be obtained by annotating a field of type {@link EntityManagerFactory} with the
+ * {@link TestEntityManagerFactory} annotation. The runner will inject the factory in this field then. Depending on the
+ * {@link TestEntityManagerFactory#scope() } setting, either the same entity manager factory instance will be used for all test
+ * methods of a given test class or a new entity manager factory will be created and injected for each individual test method.
+ * <p>
+ * Finally the {@link Configuration} used for bootstrapping the factory can optionally be modified by annotating a
+ * configuration method with the {@link TestEntityManagerFactoryConfiguration} a shown in the example below.
+ * <p>
+ * Usage example:
+ *
+ * <pre>
+ * {@code
+ * @RunWith(OgmJpaTestRunner.class)
+ * public class AnimalFarmTest {
+ *
+ *     @TestEntityManagerFactory
+ *     public EntityManagerFactory entityManagerFactory;
+ *
+ *     @Test
+ *     public void shouldCountAnimals() throws Exception {
+ *         EntityManager em = entityManagerFactory.createEntityManager();
+ *         ...
+ *         em.close();
+ *     }
+ *
+ *    @TestEntityManagerFactoryConfiguration
+ *    public static void configure(GetterPersistenceUnitInfo info) {
+ *        info.getProperties().setProperty( Environment.MONGODB_ASSOCIATIONS_STORE, AssociationStorage.COLLECTION.name() );
+ *    }
+ *
+ *    @TestEntities
+ *    public Class<?>[] getTestEntities() {
+ *        return new Class<?>[]{ PolarBear.class, Giraffe.class };
+ *    }
+ * }
+ * }
+ * </pre>
+ *
+ * @see OgmJpaTestCase Base class for tests which is configured with this runner for ease of use
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ */
+public class OgmJpaTestRunner extends SkippableTestRunner {
+
+	private final Set<Field> testScopedFactoryFields;
+	private final Set<Field> testMethodScopedFactoryFields;
+
+	private EntityManagerFactory testScopedEntityManagerFactory;
+	private EntityManagerFactory testMethodScopedEntityManagerFactory;
+
+	public OgmJpaTestRunner(Class<?> klass) throws InitializationError {
+		super( klass );
+
+		testScopedFactoryFields = getTestFactoryFields( getTestClass(), Scope.TEST_CLASS );
+		testMethodScopedFactoryFields = getTestFactoryFields( getTestClass(), Scope.TEST_METHOD );
+	}
+
+	private static Set<Field> getTestFactoryFields(TestClass testClass, TestEntityManagerFactory.Scope scope) {
+		Set<Field> testFactoryFields = new HashSet<Field>();
+
+		for ( FrameworkField frameworkField : testClass.getAnnotatedFields( TestEntityManagerFactory.class ) ) {
+			Field field = frameworkField.getField();
+			if ( scope == field.getAnnotation( TestEntityManagerFactory.class ).scope() ) {
+				field.setAccessible( true );
+				testFactoryFields.add( field );
+			}
+		}
+
+		return testFactoryFields;
+	}
+
+	@Override
+	public void run(RunNotifier notifier) {
+		if ( isTestScopedEntityManagerFactoryRequired() ) {
+			testScopedEntityManagerFactory = buildEntityManagerFactory();
+			injectEntityManagerFactory( null, testScopedFactoryFields, testScopedEntityManagerFactory );
+		}
+
+		try {
+			super.run( notifier );
+		}
+		finally {
+			if ( testScopedEntityManagerFactory != null ) {
+				cleanUpPendingTransactionIfRequired( testScopedEntityManagerFactory );
+				TestHelper.dropSchemaAndDatabase( testScopedEntityManagerFactory );
+				testScopedEntityManagerFactory.close();
+			}
+		}
+	}
+
+	@Override
+	protected void runChild(FrameworkMethod method, RunNotifier notifier) {
+		// create test method scoped SF if required; it will be injected in createTest()
+		if ( isTestMethodScopedEntityManagerFactoryRequired( method ) ) {
+			testMethodScopedEntityManagerFactory = buildEntityManagerFactory();
+		}
+
+		try {
+			super.runChild( method, notifier );
+		}
+		finally {
+			if ( testMethodScopedEntityManagerFactory != null ) {
+				cleanUpPendingTransactionIfRequired( testMethodScopedEntityManagerFactory );
+				testMethodScopedEntityManagerFactory.close();
+			}
+		}
+	}
+
+	private boolean isTestScopedEntityManagerFactoryRequired() {
+		return !isTestClassSkipped() && !areAllTestMethodsSkipped();
+	}
+
+	private boolean isTestMethodScopedEntityManagerFactoryRequired(FrameworkMethod method) {
+		return !testMethodScopedFactoryFields.isEmpty() && !super.isTestMethodSkipped( method );
+	}
+
+	private void cleanUpPendingTransactionIfRequired(EntityManagerFactory entityManagerFactory) {
+		SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) ( (HibernateEntityManagerFactory) entityManagerFactory ).getSessionFactory();
+		TransactionManager transactionManager = sessionFactory.getServiceRegistry().getService( JtaPlatform.class ).retrieveTransactionManager();
+
+		try {
+			if ( transactionManager != null && transactionManager.getStatus() == Status.STATUS_ACTIVE ) {
+				transactionManager.rollback();
+			}
+		}
+		catch (Exception e) {
+			throw new IllegalStateException( "Error while cleaning up the pending transactions", e );
+		}
+	}
+
+	protected EntityManagerFactory buildEntityManagerFactory() {
+		try {
+			GetterPersistenceUnitInfo info = new GetterPersistenceUnitInfo();
+			info.setClassLoader( Thread.currentThread().getContextClassLoader() );
+			// we explicitly list them to avoid scanning
+			info.setExcludeUnlistedClasses( true );
+			info.setJtaDataSource( new NoopDatasource() );
+			List<String> classNames = new ArrayList<String>();
+			for ( Class<?> clazz : getConfiguredEntityTypes() ) {
+				classNames.add( clazz.getName() );
+			}
+			info.setManagedClassNames( classNames );
+			info.setNonJtaDataSource( null );
+			info.setPersistenceProviderClassName( HibernateOgmPersistence.class.getName() );
+			info.setPersistenceUnitName( "default" );
+			final URL persistenceUnitRootUrl = new File( "" ).toURI().toURL();
+			info.setPersistenceUnitRootUrl( persistenceUnitRootUrl );
+			info.setPersistenceXMLSchemaVersion( "2.0" );
+			info.setProperties( new Properties() );
+			info.setSharedCacheMode( SharedCacheMode.ENABLE_SELECTIVE );
+			info.setTransactionType( PersistenceUnitTransactionType.RESOURCE_LOCAL );
+			info.setValidationMode( ValidationMode.AUTO );
+
+			for ( Map.Entry<String, String> entry : TestHelper.getDefaultTestSettings().entrySet() ) {
+				info.getProperties().setProperty( entry.getKey(), entry.getValue() );
+			}
+			applyTestSpecificSettings( info );
+
+			return new HibernateOgmPersistence().createContainerEntityManagerFactory( info, Collections.EMPTY_MAP );
+		}
+		catch (Exception e) {
+			throw new IllegalStateException( "Unable to build the entity manager factory", e );
+		}
+	}
+
+	private Class<?>[] getConfiguredEntityTypes() {
+		for ( FrameworkMethod frameworkMethod : getTestClass().getAnnotatedMethods( TestEntities.class ) ) {
+			Class<?>[] entityTypes = invokeTestEntitiesMethod( frameworkMethod );
+
+			if ( entityTypes == null || entityTypes.length == 0 ) {
+				throw new IllegalArgumentException( "Define at least a single annotated entity" );
+			}
+
+			return entityTypes;
+		}
+
+		throw new IllegalStateException( "The entities of the test must be retrievable via a parameterless method which is annotated with "
+				+ TestEntities.class.getSimpleName() + " and returns Class<?>[]." );
+	}
+
+	private Class<?>[] invokeTestEntitiesMethod(FrameworkMethod frameworkMethod) {
+		Method method = frameworkMethod.getMethod();
+		method.setAccessible( true );
+
+		if ( method.getReturnType() != Class[].class || method.getParameterTypes().length > 0 ) {
+			throw new IllegalStateException( "Method annotated with " + TestEntities.class.getSimpleName()
+					+ " must have no parameters and must return Class<?>[]." );
+		}
+
+		Class<?>[] entityTypes = null;
+
+		try {
+			entityTypes = (Class<?>[]) method.invoke( super.createTest() );
+		}
+		catch (Exception e) {
+			Exceptions.<RuntimeException>sneakyThrow( e );
+		}
+
+		return entityTypes;
+	}
+
+	private void applyTestSpecificSettings(GetterPersistenceUnitInfo info) {
+		try {
+			for ( FrameworkMethod frameworkMethod : getTestClass().getAnnotatedMethods( TestEntityManagerFactoryConfiguration.class ) ) {
+				Method method = frameworkMethod.getMethod();
+				method.setAccessible( true );
+				method.invoke( super.createTest(), info );
+			}
+		}
+		catch (Exception e) {
+			Exceptions.<RuntimeException>sneakyThrow( e );
+		}
+	}
+
+	@Override
+	protected Object createTest() throws Exception {
+		Object test = super.createTest();
+
+		// inject SFs as per given scopes
+		if ( !testScopedFactoryFields.isEmpty() ) {
+			injectEntityManagerFactory( test, testScopedFactoryFields, testScopedEntityManagerFactory );
+		}
+		if ( !testMethodScopedFactoryFields.isEmpty() ) {
+			injectEntityManagerFactory( test, testMethodScopedFactoryFields, testMethodScopedEntityManagerFactory );
+		}
+
+		return test;
+	}
+
+	private void injectEntityManagerFactory(Object test, Iterable<Field> fields, EntityManagerFactory sessionFactory) {
+		for ( Field field : fields ) {
+			try {
+				if ( ( test == null && Modifier.isStatic( field.getModifiers() ) ) ||
+						( test != null && !Modifier.isStatic( field.getModifiers() ) ) ) {
+					field.set( test, sessionFactory );
+				}
+			}
+			catch (Exception e) {
+				throw new RuntimeException( "Can't inject entity manager factory into field " + field );
+			}
+		}
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/jpa/SingleJpaTestCase.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/jpa/SingleJpaTestCase.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
  * @author Sanne Grinovero &lt;sanne@hibernate.org&gt;
  */
 @RunWith(SkippableTestRunner.class)
-public abstract class JpaTestCase {
+public abstract class SingleJpaTestCase {
 
 	private EntityManagerFactory factory;
 	private TransactionManager transactionManager;
@@ -66,7 +66,7 @@ public abstract class JpaTestCase {
 		info.setNonJtaDataSource( null );
 		info.setPersistenceProviderClassName( HibernateOgmPersistence.class.getName() );
 		info.setPersistenceUnitName( "default" );
-		final URL persistenceUnitRootUrl = new File( "" ).toURL();
+		final URL persistenceUnitRootUrl = new File( "" ).toURI().toURL();
 		info.setPersistenceUnitRootUrl( persistenceUnitRootUrl );
 		info.setPersistenceXMLSchemaVersion( "2.0" );
 		info.setProperties( new Properties() );

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
@@ -18,16 +18,16 @@ import static org.junit.Assert.fail;
 
 import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
 import org.hibernate.ogm.utils.SkipByDatastoreProvider;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import org.junit.Test;
 
 /**
- * Test {@link SkipByDatastoreProvider} is working with {@link JpaTestCase}
+ * Test {@link SkipByDatastoreProvider} is working with {@link OgmJpaTestCase}
  *
  * @author Mark Paluch
  */
-public class SkipByDatastoreProviderSelfJpaTest extends JpaTestCase {
+public class SkipByDatastoreProviderSelfJpaTest extends OgmJpaTestCase {
 
 	@Test
 	@SkipByDatastoreProvider({
@@ -43,7 +43,7 @@ public class SkipByDatastoreProviderSelfJpaTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Hypothesis.class };
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByGridDialectSelfJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByGridDialectSelfJpaTest.java
@@ -18,15 +18,15 @@ import static org.junit.Assert.fail;
 
 import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
 import org.hibernate.ogm.utils.SkipByGridDialect;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.Test;
 
 /**
- * Test {@link SkipByGridDialect} is working with {@link JpaTestCase}
+ * Test {@link SkipByGridDialect} is working with {@link OgmJpaTestCase}
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class SkipByGridDialectSelfJpaTest extends JpaTestCase {
+public class SkipByGridDialectSelfJpaTest extends OgmJpaTestCase {
 
 	@Test
 	@SkipByGridDialect({ HASHMAP, INFINISPAN, MONGODB, EHCACHE, NEO4J_EMBEDDED, NEO4J_REMOTE, COUCHDB, REDIS_JSON })
@@ -40,7 +40,7 @@ public class SkipByGridDialectSelfJpaTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Hypothesis.class };
 	}
 

--- a/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/test/serialization/ReadingFromDiskStoreTest.java
+++ b/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/test/serialization/ReadingFromDiskStoreTest.java
@@ -16,7 +16,7 @@ import javax.persistence.EntityManager;
 import org.hibernate.ogm.datastore.ehcache.EhcacheProperties;
 import org.hibernate.ogm.utils.TestForIssue;
 import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +29,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @TestForIssue(jiraKey = "OGM-443")
-public class ReadingFromDiskStoreTest extends JpaTestCase {
+public class ReadingFromDiskStoreTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -104,12 +104,12 @@ public class ReadingFromDiskStoreTest extends JpaTestCase {
 	}
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.getProperties().put( EhcacheProperties.CONFIGURATION_RESOURCE_NAME, "enforced-disk-read-ehcache.xml" );
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Bridge.class, Engineer.class };
 	}
 }

--- a/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/test/serialization/ReadingFromDiskStoreUsingCachePerKindStrategyTest.java
+++ b/ehcache/src/test/java/org/hibernate/ogm/datastore/ehcache/test/serialization/ReadingFromDiskStoreUsingCachePerKindStrategyTest.java
@@ -19,8 +19,8 @@ import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
 public class ReadingFromDiskStoreUsingCachePerKindStrategyTest extends ReadingFromDiskStoreTest {
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
-		super.refineInfo( info );
+	protected void configure(GetterPersistenceUnitInfo info) {
+		super.configure( info );
 		info.getProperties().put( EhcacheProperties.CACHE_MAPPING, CacheMappingType.CACHE_PER_KIND );
 	}
 }

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CacheMappingTestBase.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CacheMappingTestBase.java
@@ -74,7 +74,7 @@ public abstract class CacheMappingTestBase extends OgmTestCase {
 	}
 
 	private InfinispanDatastoreProvider getProvider() {
-		return (InfinispanDatastoreProvider) sfi()
+		return (InfinispanDatastoreProvider) getSessionFactory()
 				.getServiceRegistry()
 				.getService( DatastoreProvider.class );
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/CompositeIdInEmbeddedTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/associations/CompositeIdInEmbeddedTest.java
@@ -16,8 +16,8 @@ import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
  */
 public class CompositeIdInEmbeddedTest extends CompositeIdTest {
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
-		super.refineInfo( info );
+	protected void configure(GetterPersistenceUnitInfo info) {
+		super.configure( info );
 		info.getProperties()
 			.put( DocumentStoreProperties.ASSOCIATIONS_STORE, AssociationStorageType.IN_ENTITY );
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
@@ -215,7 +215,7 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 	}
 
 	private InvokedOperationsLoggingDialect getOperationsLogger() {
-		GridDialect gridDialect = sfi().getServiceRegistry().getService( GridDialect.class );
+		GridDialect gridDialect = getSessionFactory().getServiceRegistry().getService( GridDialect.class );
 		InvokedOperationsLoggingDialect invocationLogger = GridDialects.getDelegateOrNull(
 				gridDialect,
 				InvokedOperationsLoggingDialect.class

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/id/objectid/ObjectIdJpaTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/id/objectid/ObjectIdJpaTest.java
@@ -12,7 +12,7 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 
 import org.junit.After;
 import org.junit.Before;
@@ -24,7 +24,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  *
  */
-public class ObjectIdJpaTest extends JpaTestCase {
+public class ObjectIdJpaTest extends OgmJpaTestCase {
 	private EntityManager em;
 
 	@Before
@@ -59,12 +59,12 @@ public class ObjectIdJpaTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Bar.class, DoorMan.class, MusicGenre.class };
 	}
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.getProperties().put( AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "false" );
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -149,7 +149,7 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 		AssociationContext associationContext = new AssociationContextImpl(
 				new AssociationTypeContextImpl(
 						OptionsContextImpl.forProperty(
-								OptionValueSources.getDefaultSources( new ConfigurationPropertyReader( sfi().getProperties(), new ClassLoaderServiceImpl() ) ),
+								OptionValueSources.getDefaultSources( new ConfigurationPropertyReader( getSessionFactory().getProperties(), new ClassLoaderServiceImpl() ) ),
 								Project.class,
 								"modules"
 						),
@@ -185,7 +185,7 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 	}
 
 	protected <S extends Service> S getService(Class<S> serviceRole) {
-		SessionFactoryImplementor factory = super.sfi();
+		SessionFactoryImplementor factory = super.getSessionFactory();
 		ServiceRegistryImplementor serviceRegistry = factory.getServiceRegistry();
 		return serviceRegistry.getService( serviceRole );
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBEntityManagerNativeQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBEntityManagerNativeQueryTest.java
@@ -17,7 +17,7 @@ import javax.persistence.Query;
 import org.hibernate.ogm.backendtck.jpa.Poem;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.TestForIssue;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -29,7 +29,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
+public class MongoDBEntityManagerNativeQueryTest extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Poem.class );
@@ -283,7 +283,7 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { OscarWildePoem.class, LiteratureSociety.class, Poet.class, Critic.class };
 	}
 
@@ -308,7 +308,8 @@ public class MongoDBEntityManagerNativeQueryTest extends JpaTestCase {
 
 	private EntityManager delete(Object... entities) {
 		for ( Object object : entities ) {
-			em.detach( object );
+			Object entity = em.merge( object );
+			em.remove( entity );
 		}
 		return em;
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/MongoDBQueryParsingTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/MongoDBQueryParsingTest.java
@@ -256,7 +256,7 @@ public class MongoDBQueryParsingTest extends OgmTestCase {
 		entityNames.put( "IndexedEntity", IndexedEntity.class );
 		EntityNamesResolver nameResolver = new MapBasedEntityNamesResolver( entityNames );
 
-		return new MongoDBProcessingChain( sfi(), nameResolver, namedParameters );
+		return new MongoDBProcessingChain( getSessionFactory(), nameResolver, namedParameters );
 	}
 
 	@Override

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/SequenceNextValueGenerationTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/SequenceNextValueGenerationTest.java
@@ -19,7 +19,7 @@ import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.model.impl.DefaultIdSourceKeyMetadata;
 import org.hibernate.ogm.model.key.spi.IdSourceKey;
 import org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +29,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto
  */
-public class SequenceNextValueGenerationTest extends JpaTestCase {
+public class SequenceNextValueGenerationTest extends OgmJpaTestCase {
 
 	private static final String THREAD_SAFETY_SEQUENCE = "ThreadSafetySequence";
 	private static final String THREAD_SAFETY_SEQUENCE_GEN = THREAD_SAFETY_SEQUENCE + "Gen";
@@ -88,7 +88,7 @@ public class SequenceNextValueGenerationTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { EntityWithSequence.class, AnotherEntityWithSequence.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/TableNextValueGenerationTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/TableNextValueGenerationTest.java
@@ -19,7 +19,7 @@ import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.model.impl.DefaultIdSourceKeyMetadata;
 import org.hibernate.ogm.model.key.spi.IdSourceKey;
 import org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +29,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto
  */
-public class TableNextValueGenerationTest extends JpaTestCase {
+public class TableNextValueGenerationTest extends OgmJpaTestCase {
 
 	private static final String HIBERNATE_SEQUENCES = "hibernate_sequences";
 	private static final String THREAD_SAFETY_SEQUENCE = "ThreadSafetySequence";
@@ -84,7 +84,7 @@ public class TableNextValueGenerationTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { EntityWithTableGenerator.class, AnotherEntityWithTableGenerator.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalManyToManyTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalManyToManyTest.java
@@ -72,7 +72,7 @@ public class BidirectionalManyToManyTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { AccountOwner.class, BankAccount.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalManyToOneTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalManyToOneTest.java
@@ -74,7 +74,7 @@ public class BidirectionalManyToOneTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { SalesForce.class, SalesGuy.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalOneToOneTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/BidirectionalOneToOneTest.java
@@ -62,7 +62,7 @@ public class BidirectionalOneToOneTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Husband.class, Wife.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/CollectionOfEmbeddableTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/CollectionOfEmbeddableTest.java
@@ -100,7 +100,7 @@ public class CollectionOfEmbeddableTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { MultiAddressAccount.class, Address.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/CompositeEmbeddedIdTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/CompositeEmbeddedIdTest.java
@@ -75,7 +75,7 @@ public class CompositeEmbeddedIdTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { News.class, Label.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ElementCollectionListWithIndexTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ElementCollectionListWithIndexTest.java
@@ -69,7 +69,7 @@ public class ElementCollectionListWithIndexTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { GrandMother.class, Child.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ElementCollectionMappingTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ElementCollectionMappingTest.java
@@ -165,7 +165,7 @@ public class ElementCollectionMappingTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { StoryGame.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/EmbeddableTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/EmbeddableTest.java
@@ -160,7 +160,7 @@ public class EmbeddableTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Account.class, Address.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/EmbeddableWithCollectionMappingTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/EmbeddableWithCollectionMappingTest.java
@@ -78,7 +78,7 @@ public class EmbeddableWithCollectionMappingTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Order.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/MapTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/MapTest.java
@@ -95,7 +95,7 @@ public class MapTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { User.class, Address.class, PhoneNumber.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/Neo4jJpaTestCase.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/Neo4jJpaTestCase.java
@@ -29,7 +29,7 @@ import org.hibernate.ogm.datastore.neo4j.utils.Neo4jTestHelper;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.jpa.impl.OgmEntityManagerFactory;
 import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -42,12 +42,12 @@ import org.neo4j.graphdb.Transaction;
  *
  * @author Davide D'Alto
  */
-public abstract class Neo4jJpaTestCase extends JpaTestCase {
+public abstract class Neo4jJpaTestCase extends OgmJpaTestCase {
 
 	private static final Log log = LoggerFactory.getLogger();
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.getProperties().setProperty( Neo4jProperties.DATABASE_PATH, Neo4jTestHelper.dbLocation() );
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ReferencedCompositeIdTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/ReferencedCompositeIdTest.java
@@ -70,7 +70,7 @@ public class ReferencedCompositeIdTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Director.class, Tournament.class, TournamentId.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleEntityTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleEntityTest.java
@@ -45,7 +45,7 @@ public class SingleEntityTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { JUG.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleEntityWithSequenceTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleEntityWithSequenceTest.java
@@ -55,7 +55,7 @@ public class SingleEntityWithSequenceTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Song.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToManyTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToManyTest.java
@@ -71,7 +71,7 @@ public class UnidirectionalManyToManyTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { AccountOwner.class, BankAccount.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToOneTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToOneTest.java
@@ -72,7 +72,7 @@ public class UnidirectionalManyToOneTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { JUG.class, Member.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToOneWithIndexTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToOneWithIndexTest.java
@@ -101,7 +101,7 @@ public class UnidirectionalManyToOneWithIndexTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Father.class, Child.class };
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UniqueConstraintCanBeSkippedTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UniqueConstraintCanBeSkippedTest.java
@@ -93,12 +93,12 @@ public class UniqueConstraintCanBeSkippedTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.getProperties().put( Environment.UNIQUE_CONSTRAINT_SCHEMA_UPDATE_STRATEGY, UniqueConstraintSchemaUpdateStrategy.SKIP );
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { EntityWithConstraints.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UniqueConstraintTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UniqueConstraintTest.java
@@ -216,7 +216,7 @@ public class UniqueConstraintTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { EntityWithConstraints.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/nativequery/Neo4jEntityManagerNativeQueryTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/nativequery/Neo4jEntityManagerNativeQueryTest.java
@@ -18,7 +18,7 @@ import javax.persistence.Query;
 import org.hibernate.ogm.backendtck.jpa.Poem;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.TestForIssue;
-import org.hibernate.ogm.utils.jpa.JpaTestCase;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,7 +29,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class Neo4jEntityManagerNativeQueryTest extends JpaTestCase {
+public class Neo4jEntityManagerNativeQueryTest extends OgmJpaTestCase {
 
 	@Rule
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Poem.class );
@@ -165,14 +165,15 @@ public class Neo4jEntityManagerNativeQueryTest extends JpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { OscarWildePoem.class, Critic.class };
 	}
 
 	private void delete(Object... entities) {
 		em.getTransaction().begin();
 		for ( Object object : entities ) {
-			em.detach( object );
+			Object entity = em.merge( object );
+			em.remove( entity );
 		}
 		em.getTransaction().commit();
 		em.clear();

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/transaction/JtaRollbackTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/transaction/JtaRollbackTest.java
@@ -30,14 +30,14 @@ import org.junit.Test;
 public class JtaRollbackTest extends Neo4jJpaTestCase {
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.setTransactionType( PersistenceUnitTransactionType.JTA );
 	}
 
 	@Test
 	public void testRollbackCausedByException() throws Exception {
 		final Game game1 = new Game( "game-1", "Title 1" );
-		TransactionManager transactionManager = getTransactionManager();
+		TransactionManager transactionManager = getTransactionManager( getFactory() );
 		transactionManager.begin();
 		EntityManager em = getFactory().createEntityManager();
 		em.persist( game1 );
@@ -70,7 +70,7 @@ public class JtaRollbackTest extends Neo4jJpaTestCase {
 	@Test
 	public void testManualRollback() throws Exception {
 		final Game game1 = new Game( "game-1", "Title 1" );
-		TransactionManager transactionManager = getTransactionManager();
+		TransactionManager transactionManager = getTransactionManager( getFactory() );
 		transactionManager.begin();
 		EntityManager em = getFactory().createEntityManager();
 		em.persist( game1 );
@@ -104,7 +104,7 @@ public class JtaRollbackTest extends Neo4jJpaTestCase {
 	public void testFailedRollback() throws Exception {
 		final Game game1 = new Game( "game-1", "Title 1" );
 		final Game game2 = new Game( "game-2", "Title 2" );
-		TransactionManager transactionManager = getTransactionManager();
+		TransactionManager transactionManager = getTransactionManager( getFactory() );
 		transactionManager.begin();
 		EntityManager em = getFactory().createEntityManager();
 		em.persist( game1 );
@@ -151,7 +151,7 @@ public class JtaRollbackTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Game.class };
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/transaction/ResourceLocalRollbackTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/transaction/ResourceLocalRollbackTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class ResourceLocalRollbackTest extends Neo4jJpaTestCase {
 
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
+	protected void configure(GetterPersistenceUnitInfo info) {
 		info.setTransactionType( PersistenceUnitTransactionType.RESOURCE_LOCAL );
 	}
 
@@ -86,7 +86,7 @@ public class ResourceLocalRollbackTest extends Neo4jJpaTestCase {
 	}
 
 	@Override
-	public Class<?>[] getEntities() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Game.class };
 	}
 }

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/RedisOgmTestCase.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/RedisOgmTestCase.java
@@ -24,7 +24,7 @@ public abstract class RedisOgmTestCase extends OgmTestCase {
 	}
 
 	protected RedisDatastoreProvider getProvider() {
-		return (RedisDatastoreProvider) sfi()
+		return (RedisDatastoreProvider) getSessionFactory()
 				.getServiceRegistry()
 				.getService( DatastoreProvider.class );
 	}

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/CompositeIdInEmbeddedTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/CompositeIdInEmbeddedTest.java
@@ -16,8 +16,8 @@ import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
  */
 public class CompositeIdInEmbeddedTest extends CompositeIdTest {
 	@Override
-	protected void refineInfo(GetterPersistenceUnitInfo info) {
-		super.refineInfo( info );
+	protected void configure(GetterPersistenceUnitInfo info) {
+		super.configure( info );
 		info.getProperties()
 				.put( DocumentStoreProperties.ASSOCIATIONS_STORE, AssociationStorageType.IN_ENTITY );
 	}

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/ManyToOneInEntityJsonRepresentationTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/associations/ManyToOneInEntityJsonRepresentationTest.java
@@ -108,7 +108,7 @@ public class ManyToOneInEntityJsonRepresentationTest extends OgmTestCase {
 
 
 	private RedisDatastoreProvider getProvider() {
-		return (RedisDatastoreProvider) sfi()
+		return (RedisDatastoreProvider) getSessionFactory()
 				.getServiceRegistry()
 				.getService( DatastoreProvider.class );
 	}

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/id/TableGeneratorTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/id/TableGeneratorTest.java
@@ -63,7 +63,7 @@ public class TableGeneratorTest extends OgmTestCase {
 	}
 
 	private RedisDatastoreProvider getProvider() {
-		return (RedisDatastoreProvider) sfi()
+		return (RedisDatastoreProvider) getSessionFactory()
 				.getServiceRegistry()
 				.getService( DatastoreProvider.class );
 	}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/OGM-1119
 * https://hibernate.atlassian.net/browse/OGM-1120

Various cleanups to the test infrastructure.

Introduce `OgmJpaTestCase` and `OgmJpaTestRunner` to improve performances of the Cassandra tests. They are as symmetrical as possible to `OgmTestCase` and `OgmTestRunner`.

Avoid as many calls to `cluster.connect()` as possible as they are really slow.