### PR TITLE
OGM-1132 Document that we do not support named parameters for Cassandra

### DIFF
--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/query/impl/CassandraParameterMetadataBuilder.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/query/impl/CassandraParameterMetadataBuilder.java
@@ -46,7 +46,7 @@ public class CassandraParameterMetadataBuilder implements ParameterMetadataBuild
 
 			// the cassandra metadata will give us the CQL type, but the type conversion system only goes
 			// in hibernate->cassandra direction, so we can't turn it back into the required hibernate type.
-			// instead we rely on the cached hibernate metdata from schema creation time
+			// instead we rely on the cached hibernate metadata from schema creation time
 
 			String tableName = columnDefinitions.getTable( 0 );
 			Table table = metaDataCache.get( tableName );

--- a/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/query/nativequery/CassandraEntityManagerNativeQueryTest.java
+++ b/cassandra/src/test/java/org/hibernate/ogm/datastore/cassandra/test/query/nativequery/CassandraEntityManagerNativeQueryTest.java
@@ -202,6 +202,34 @@ public class CassandraEntityManagerNativeQueryTest extends OgmJpaTestCase {
 		commit();
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "OGM-1008")
+	@SuppressWarnings("unchecked")
+	public void testQueryWithParameters() throws Exception {
+		Query query;
+
+		begin();
+
+		query = em.createNativeQuery( "SELECT * FROM \"WILDE_POEM\" WHERE name = ?" );
+		query.setParameter( 1, "Portia" ); // CQL parameters positions start at 1
+
+		List<OscarWildePoem> results = query.getResultList();
+		assertThat( results ).as( "Unexpected number of results" ).hasSize( 1 );
+
+		commit();
+
+//		Named parameters do not work at all due to CassandraParameterMetadataBuilder's limitations.
+//		See https://hibernate.atlassian.net/projects/OGM/issues/OGM-1008 for dicussions about this issue.
+//		begin();
+//
+//		Query query = em.createNativeQuery( "SELECT * \"WILDE_POEM\" WHERE name = :nameParam" );
+//		query.setParameter( "nameParam", "Portia" );
+//		List<OscarWildePoem> results = query.getResultList();
+//		assertThat( results ).as( "Unexpected number of results" ).hasSize( 1 );
+//
+//		commit();
+	}
+
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {OscarWildePoem.class, Critic.class};

--- a/documentation/manual/src/main/asciidoc/en-US/modules/cassandra.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/cassandra.asciidoc
@@ -124,3 +124,24 @@ Cassandra does not natively support sequences (auto increment identifiers) at pr
 Cassandra does not support transactions. Changes to a single Entity are atomic. Changes to more than one entity are neither atomic nor isolated.
 
 Cassandra does not distinguish between update and insert operations and will not prevent creation of an Entity with duplicate Id, instead treating it as modification of the existing Entity.
+
+=== Native queries
+
+Native queries are supported: you can execute native CQL queries using the [classname]`EntityManager` infrastructure.
+
+Currently, only ordinal parameters are supported, named parameters do not work.
+
+.Using native CQL queries
+====
+[source, JAVA]
+----
+Query query = em.createNativeQuery( "SELECT * FROM \"WILDE_POEM\" WHERE name = ?" );
+query.setParameter( 1, "Portia" ); // CQL parameters positions start at 1
+List<OscarWildePoem> results = query.getResultList();
+----
+====
+
+[WARNING]
+====
+Unlike in JPQL, in CQL, parameters positions start at 1, not 0.
+====


### PR DESCRIPTION
On Cassandra, we currently only support ordinal parameters for CQL
natives queries.