### PR TITLE
OGM-1145 Upgrade maven-jdocbook-plugin and pressgang

### DIFF
--- a/documentation/manual/pom.xml
+++ b/documentation/manual/pom.xml
@@ -209,7 +209,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.jboss.maven.plugins</groupId>
                                         <artifactId>maven-jdocbook-plugin</artifactId>
-                                        <versionRange>[2.3.4,)</versionRange>
+                                        <versionRange>[2.3.10,)</versionRange>
                                         <goals>
                                             <goal>generate</goal>
                                             <goal>resources</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -507,19 +507,19 @@
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>
                     <artifactId>maven-jdocbook-plugin</artifactId>
-                    <version>2.3.9</version>
+                    <version>2.3.10</version>
                     <extensions>true</extensions>
                     <dependencies>
                         <dependency>
                             <groupId>org.jboss.pressgang</groupId>
                             <artifactId>pressgang-xslt-ns</artifactId>
-                            <version>3.1.3</version>
+                            <version>3.1.4</version>
                         </dependency>
                         <dependency>
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-jdocbook-style</artifactId>
                             <type>jdocbook-style</type>
-                            <version>3.0.0</version>
+                            <version>3.0.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/OGM-1145

It allows to generate valid HTML5 output and fixes a bug where the user
was not brought to the right place when clicking on an anchor.