### PR TITLE
OGM-1146 Properly ignore hibernate-noorm-release-scripts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Our build scripts - necessary for our release jobs
+hibernate-noorm-release-scripts
+
 #OS
 .DS_Store
 

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -208,8 +208,12 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <exclude>../README.md</exclude>
+                <exclude>../how-to-release.md</exclude>
                 <exclude>../license.txt</exclude>
                 <exclude>../changelog.txt</exclude>
+                <exclude>../.travis.yml</exclude>
+                <exclude>../travis/**</exclude>
+                <exclude>../hibernate-noorm-release-scripts/**</exclude>
                 <exclude>../*.sh</exclude>
                 <exclude>**/.git/**</exclude>
                 <exclude>**/.gitignore</exclude>


### PR DESCRIPTION
And additional cleanup to the distribution.

 * https://hibernate.atlassian.net/browse/OGM-1146