### PR TITLE
Hot rod dialect v4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,6 +51,7 @@
 
         <!-- Infinispan -->
         <infinispanVersion>8.2.4.Final</infinispanVersion>
+        <protostreamVersion>3.0.5.Final</protostreamVersion>
 
         <!-- Ehcache -->
         <ehcacheVersion>2.6.11</ehcacheVersion>
@@ -397,6 +398,18 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>hibernate-ogm-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -507,6 +520,52 @@
                 <version>${infinispanVersion}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-client-hotrod</artifactId>
+                <version>${infinispanVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan.protostream</groupId>
+                <artifactId>protostream</artifactId>
+                <version>${protostreamVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-client-hotrod</artifactId>
+                <version>${infinispanVersion}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-server-hotrod</artifactId>
+                <version>${infinispanVersion}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-server-hotrod</artifactId>
+                <type>test-jar</type>
+                <version>${infinispanVersion}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-remote-query-client</artifactId>
+                <version>${infinispanVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-query-dsl</artifactId>
+                <version>${infinispanVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-remote-query-server</artifactId>
+                <scope>test</scope>
+                <version>${infinispanVersion}</version>
             </dependency>
 
             <!-- MongoDB -->

--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
@@ -16,6 +16,7 @@ package org.hibernate.ogm.datastore.impl;
 public enum DatastoreProviderType {
 	MAP( "org.hibernate.ogm.datastore.map.impl.MapDatastoreProvider" ),
 	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider" ),
+	INFINISPAN_REMOTE( "org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider" ),
 	EHCACHE( "org.hibernate.ogm.datastore.ehcache.impl.EhcacheDatastoreProvider" ),
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider" ),
 	FONGO( "org.hibernate.ogm.datastore.mongodb.impl.FongoDBDatastoreProvider" ),

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
@@ -18,6 +18,9 @@ public final class MapTupleSnapshot implements TupleSnapshot {
 	private final Map<String, Object> map;
 
 	public MapTupleSnapshot(Map<String, Object> map) {
+		if ( map == null ) {
+			throw new NullPointerException( "the map parameter is required" );
+		}
 		this.map = map;
 	}
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/type/descriptor/impl/AttributeConverterGridTypeDescriptorAdaptor.java
+++ b/core/src/main/java/org/hibernate/ogm/type/descriptor/impl/AttributeConverterGridTypeDescriptorAdaptor.java
@@ -25,7 +25,7 @@ public class AttributeConverterGridTypeDescriptorAdaptor implements GridTypeDesc
 	private static final Log log = LoggerFactory.make();
 
 	private final AttributeConverter converter;
-	private final GridTypeDescriptor delegate;
+	private final GridTypeToGridTypeDescriptorAdapter delegate;
 	private final JavaTypeDescriptor intermediateJavaTypeDescriptor;
 
 	public AttributeConverterGridTypeDescriptorAdaptor(
@@ -36,6 +36,10 @@ public class AttributeConverterGridTypeDescriptorAdaptor implements GridTypeDesc
 		// take the intermediary type gridType and transform it into a GridTypeDescriptor
 		this.delegate =  new GridTypeToGridTypeDescriptorAdapter( delegate );
 		this.intermediateJavaTypeDescriptor = intermediateJavaTypeDescriptor;
+	}
+
+	public GridType unwrapTargetGridType() {
+		return delegate.gridType;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -46,6 +46,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * <li>1401-1500: neo4j</li>
  * <li>1501-1600: ehcache</li>
  * <li>1601-1700: redis</li>
+ * <li>1701-1800: infinispan_remote</li>
  * </ul>
  *
  * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
@@ -295,4 +296,5 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 87, value = "The tuple context is not available, probably because we are dealing with more than a single entity type")
 	HibernateException tupleContextNotAvailable();
+
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/manytomany/ManyToManyExtraTest.java
@@ -27,7 +27,7 @@ import static org.hibernate.ogm.utils.TestHelper.getNumberOfEntities;
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "Classroom.students list - bag semantics unsupported (no primary key)"
 )
 public class ManyToManyExtraTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapContentsStoredInSeparateDocumentTest.java
@@ -28,7 +28,8 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA, GridDialectType.REDIS_HASH },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE,
+				GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA, GridDialectType.REDIS_HASH },
 		comment = "Only the document stores CouchDB and MongoDB and Redis JSON support the configuration of specific association storage strategies"
 )
 public class MapContentsStoredInSeparateDocumentTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/collection/types/MapTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "hibernate core doesn't supply required primary key metadata for collections"
 )
 public class MapTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/compositeid/ReferencedCompositeIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/compositeid/ReferencedCompositeIdTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "Director.Tournament list - bag semantics unsupported (no primary key)"
 )
 public class ReferencedCompositeIdTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneExtraTest.java
@@ -22,7 +22,7 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Emmanuel Bernard
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "Basket.products list - bag semantics unsupported (no primary key)"
 )
 public class ManyToOneExtraTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaAnnotationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaAnnotationsTest.java
@@ -33,7 +33,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA, GridDialectType.REDIS_HASH },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE,
+				GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA, GridDialectType.REDIS_HASH },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class AssociationStorageConfiguredViaAnnotationsTest extends AssociationStorageTestBase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaPropertyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredViaPropertyTest.java
@@ -35,7 +35,8 @@ import org.junit.Test;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA },
+		value = { GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE,
+				GridDialectType.NEO4J_EMBEDDED, GridDialectType.NEO4J_REMOTE, GridDialectType.CASSANDRA },
 		comment = "Only the document stores CouchDB and MongoDB support the configuration of specific association storage strategies"
 )
 public class AssociationStorageConfiguredViaPropertyTest extends AssociationStorageTestBase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
  *
  * @author Davide D'Alto
  */
-@SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.INFINISPAN, GridDialectType.EHCACHE, GridDialectType.REDIS_HASH })
+@SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.EHCACHE, GridDialectType.REDIS_HASH })
 public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	private static final EntityKeyMetadata METADATA = new DefaultEntityKeyMetadata( "BoardGame", new String[]{ "id.name", "id.publisher" } );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/callbacks/PostLoadTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/callbacks/PostLoadTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  * @author David Williams
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "Zoo.animals set - bag semantics unsupported (no primary key)"
 )
 public class PostLoadTest extends OgmJpaTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
@@ -57,7 +57,8 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 	public PackagingRule packaging = new PackagingRule( "persistencexml/transaction-type-jta.xml", Shipment.class );
 
 	@Test
-	@SkipByGridDialect(value = GridDialectType.MONGODB, comment = "MongoDB tests runs w/o transaction manager")
+	@SkipByGridDialect(value = { GridDialectType.MONGODB, GridDialectType.INFINISPAN_REMOTE },
+		comment = "MongoDB and Infinispan Remote tests runs w/o transaction manager")
 	public void onRollbackTriggeredThroughJtaPresentsAppliedInsertOperations() throws Exception {
 		Map<String, Object> settings = new HashMap<>();
 		settings.putAll( TestHelper.getDefaultTestSettings() );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationForElementCollectionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationForElementCollectionTest.java
@@ -41,9 +41,9 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Emmanuel Bernard emmanuel@hibernate.org
  * @author Guillaume Smet
  */
-@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.REDIS_HASH },
+@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.REDIS_HASH, GridDialectType.INFINISPAN_REMOTE },
 		comment = "For Neo4j, the getAssociation always return an association, thus we don't have the createAssociation call. " +
-				"Redis Hash is just weird.")
+				"Redis Hash is just weird. Infinispan Remote needs to be investigated.")
 @TestForIssue(jiraKey = "OGM-1152")
 public class GridDialectOperationInvocationForElementCollectionTest extends OgmTestCase {
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationForOneToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationForOneToOneTest.java
@@ -34,9 +34,9 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Emmanuel Bernard emmanuel@hibernate.org
  * @author Guillaume Smet
  */
-@SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.REDIS_HASH },
+@SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.REDIS_HASH, GridDialectType.INFINISPAN_REMOTE  },
 		comment = "For Cassandra and Neo4j, the getAssociation always return an association, thus we don't have the createAssociation call. " +
-					"Redis Hash is just weird.")
+					"Redis Hash is just weird. Infinispan Remote needs to be investigated.")
 @TestForIssue(jiraKey = "OGM-1152")
 public class GridDialectOperationInvocationForOneToOneTest extends OgmTestCase {
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/embeddable/EmbeddableExtraTest.java
@@ -26,7 +26,7 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "POJOs contain lists - bag semantics unsupported (no primary key)"
 )
 public class EmbeddableExtraTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAJTATest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAJTATest.java
@@ -31,8 +31,8 @@ public class JPAJTATest extends OgmJpaTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.MONGODB, GridDialectType.CASSANDRA },
-			comment = "MongoDB and Cassandra tests runs w/o transaction manager"
+			value = { GridDialectType.MONGODB, GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
+			comment = "MongoDB, Cassandra and Hot Rod tests run w/o transaction manager"
 	)
 	public void testBootstrapAndCRUD() throws Exception {
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/massindex/SimpleEntityMassIndexingTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/massindex/SimpleEntityMassIndexingTest.java
@@ -10,9 +10,12 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
+
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -98,19 +101,24 @@ public class SimpleEntityMassIndexingTest extends OgmTestCase {
 		}
 	}
 
-	private void startAndWaitMassIndexing(Class<?> entityType) throws InterruptedException {
+	private void startAndWaitMassIndexing(Class<?> entityType) throws InterruptedException, IOException {
 		FullTextSession session = Search.getFullTextSession( openSession() );
 		session.createIndexer( entityType ).purgeAllOnStart( true ).startAndWait();
-		int numDocs = session.getSearchFactory().getIndexReaderAccessor().open( entityType ).numDocs();
-		session.close();
+		final int numDocs;
+		try ( IndexReader indexReader = session.getSearchFactory().getIndexReaderAccessor().open( entityType ) ) {
+			numDocs = indexReader.numDocs();
+		}
 		assertThat( numDocs ).isGreaterThan( 0 );
 	}
 
-	private void purgeAll(Class<?> entityType) {
+	private void purgeAll(Class<?> entityType) throws IOException {
 		FullTextSession session = Search.getFullTextSession( openSession() );
 		session.purgeAll( entityType );
 		session.flushToIndexes();
-		int numDocs = session.getSearchFactory().getIndexReaderAccessor().open( entityType ).numDocs();
+		final int numDocs;
+		try ( IndexReader indexReader = session.getSearchFactory().getIndexReaderAccessor().open( entityType ) ) {
+			numDocs = indexReader.numDocs();
+		}
 		session.close();
 		assertThat( numDocs ).isEqualTo( 0 );
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/optimisticlocking/OptimisticLockingExtraTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/optimisticlocking/OptimisticLockingExtraTest.java
@@ -35,7 +35,7 @@ import org.junit.rules.ExpectedException;
  * @author Gunnar Morling
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "list - bag semantics unsupported (no primary key)"
 )
 public class OptimisticLockingExtraTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/optimisticlocking/OptimisticLockingTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/optimisticlocking/OptimisticLockingTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.ogm.utils.GridDialectType.COUCHDB;
 import static org.hibernate.ogm.utils.GridDialectType.EHCACHE;
 import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
 import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
@@ -105,7 +106,7 @@ public class OptimisticLockingTest extends OgmTestCase {
 	 */
 	@Test
 	@SkipByGridDialect(
-			value = { HASHMAP, INFINISPAN, EHCACHE, NEO4J_EMBEDDED, NEO4J_REMOTE, COUCHDB, CASSANDRA, REDIS_JSON, REDIS_HASH },
+			value = { HASHMAP, INFINISPAN, INFINISPAN_REMOTE, EHCACHE, NEO4J_EMBEDDED, NEO4J_REMOTE, COUCHDB, CASSANDRA, REDIS_JSON, REDIS_HASH },
 			comment = "Note that CouchDB has its own optimistic locking scheme, handled by the dialect itself."
 	)
 	public void updatingEntityUsingOldVersionCausesExceptionUsingAtomicFindAndUpdate() throws Throwable {
@@ -152,7 +153,7 @@ public class OptimisticLockingTest extends OgmTestCase {
 	 */
 	@Test
 	@SkipByGridDialect(
-			value = { HASHMAP, INFINISPAN, EHCACHE, NEO4J_EMBEDDED, NEO4J_REMOTE, COUCHDB, CASSANDRA, REDIS_JSON, REDIS_HASH },
+			value = { HASHMAP, INFINISPAN, INFINISPAN_REMOTE, EHCACHE, NEO4J_EMBEDDED, NEO4J_REMOTE, COUCHDB, CASSANDRA, REDIS_JSON, REDIS_HASH },
 			comment = "Note that CouchDB has its own optimistic locking scheme, handled by the dialect itself."
 	)
 	public void deletingEntityUsingOldVersionCausesExceptionUsingAtomicFindAndDelete() throws Throwable {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/CompositeIdQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/CompositeIdQueriesTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.ogm.utils.GridDialectType.COUCHDB;
 import static org.hibernate.ogm.utils.GridDialectType.EHCACHE;
 import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
 import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_JSON;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
 import static org.hibernate.ogm.utils.SessionHelper.asProjectionResults;
@@ -43,7 +44,7 @@ import org.junit.rules.ExpectedException;
  * @author Davide D'Alto
  */
 @SkipByGridDialect(
-	value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH },
+	value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, INFINISPAN_REMOTE, REDIS_JSON, REDIS_HASH },
 	comment = "Hibernate Search does not store properties of the @EmbeddedId by default in the index, it requires the use of @FieldBridge."
 			+ "It is also not sufficient to add a custom field bridge because the properties of the embedded id won't be recognized as properties of the entity."
 			+ "There is a JIRA to keep track of this: OGM-849")

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithAssociationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithAssociationsTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.ogm.utils.GridDialectType.COUCHDB;
 import static org.hibernate.ogm.utils.GridDialectType.EHCACHE;
 import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
 import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_JSON;
 import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
@@ -33,7 +34,7 @@ import org.junit.Test;
  * @author Guillaume Smet
  */
 @SkipByGridDialect(
-		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH },
+		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH, INFINISPAN_REMOTE },
 		comment = "We need a QueryParserService to be able to perform these queries.")
 public class QueriesWithAssociationsTest extends OgmJpaTestCase {
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedCollectionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedCollectionTest.java
@@ -38,7 +38,8 @@ import org.junit.rules.ExpectedException;
  * @author Gunnar Morling
  * @author Davide D'Alto
  */
-@SkipByGridDialect(value = GridDialectType.CASSANDRA, comment = "Bag semantics not supported by Cassandra backend")
+@SkipByGridDialect(value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
+	comment = "Bag semantics not supported by backends which require a primary key")
 public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@TestSessionFactory
@@ -139,7 +140,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionsOfPropertyInEmbeddedCollection() throws Exception {
@@ -149,7 +150,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionsOfEmbeddedInEmbeddedCollection() throws Exception {
@@ -159,7 +160,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionsOfEmbeddedInEmbeddedCollectionWithNull() throws Exception {
@@ -169,7 +170,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionsOfPropertiesInEmbeddedCollection() throws Exception {
@@ -181,7 +182,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionsOfPropertiesInEmbeddedCollectionWithInnerJoin() throws Exception {
@@ -195,7 +196,7 @@ public class QueriesWithEmbeddedCollectionTest extends OgmTestCase {
 
 	@Test
 	@SkipByGridDialect(
-			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
+			value = { GridDialectType.CASSANDRA, GridDialectType.COUCHDB, GridDialectType.EHCACHE, GridDialectType.HASHMAP, GridDialectType.INFINISPAN, GridDialectType.INFINISPAN_REMOTE, GridDialectType.REDIS_JSON, GridDialectType.REDIS_HASH },
 			comment = "Hibernate Search cannot project multiple values from the same field at the moment" )
 	@SkipByDatastoreProvider(value = DatastoreProviderType.FONGO, comment = "OGM-835 - needs a Fongo upgrade (once available)")
 	public void testProjectionWithMultipleAssociations() throws Exception {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithEmbeddedTest.java
@@ -34,7 +34,7 @@ import org.junit.rules.ExpectedException;
  * @author Davide D'Alto
  */
 @SkipByGridDialect(
-		value = { GridDialectType.CASSANDRA },
+		value = { GridDialectType.CASSANDRA, GridDialectType.INFINISPAN_REMOTE },
 		comment = "Collection of embeddeds - bag semantics unsupported (no primary key)"
 )
 public class QueriesWithEmbeddedTest extends OgmTestCase {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithToOnePropertyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/QueriesWithToOnePropertyTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.ogm.utils.GridDialectType.COUCHDB;
 import static org.hibernate.ogm.utils.GridDialectType.EHCACHE;
 import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
 import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
 import static org.hibernate.ogm.utils.GridDialectType.REDIS_JSON;
 
@@ -28,7 +29,7 @@ import org.junit.Test;
  * @author Guillaume Smet
  */
 @SkipByGridDialect(
-		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, REDIS_JSON, REDIS_HASH },
+		value = { CASSANDRA, COUCHDB, EHCACHE, HASHMAP, INFINISPAN, INFINISPAN_REMOTE, REDIS_JSON, REDIS_HASH },
 		comment = "We need a QueryParserService to be able to perform these queries.")
 public class QueriesWithToOnePropertyTest extends OgmJpaTestCase {
 

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectTestHelperType.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectTestHelperType.java
@@ -25,6 +25,7 @@ public enum GridDialectTestHelperType {
 	},
 
 	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.utils.InfinispanTestHelper" ),
+	INFINISPAN_REMOTE( "org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteTestHelper" ),
 	EHCACHE( "org.hibernate.ogm.datastore.ehcache.utils.EhcacheTestHelper" ),
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.utils.MongoDBTestHelper" ),
 	NEO4J( "org.hibernate.ogm.datastore.neo4j.utils.Neo4jTestHelper" ),

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
@@ -21,6 +21,8 @@ public enum GridDialectType {
 
 	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.InfinispanDialect", false, false),
 
+	INFINISPAN_REMOTE( "org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect", true, false ),
+
 	EHCACHE( "org.hibernate.ogm.datastore.ehcache.EhcacheDialect", false, false ),
 
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.MongoDBDialect", true, true ),

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -189,7 +189,9 @@ public class TestHelper {
 	}
 
 	public static void dropSchemaAndDatabase(EntityManagerFactory emf) {
-		dropSchemaAndDatabase( ( (HibernateEntityManagerFactory) emf ).getSessionFactory() );
+		if ( emf != null ) {
+			dropSchemaAndDatabase( ( (HibernateEntityManagerFactory) emf ).getSessionFactory() );
+		}
 	}
 
 	public static void dropSchemaAndDatabase(SessionFactory sessionFactory) {

--- a/infinispan-remote/pom.xml
+++ b/infinispan-remote/pom.xml
@@ -246,6 +246,33 @@
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                            </archive>
+                            <excludes>
+                                <exclude>**/hibernate.properties</exclude>
+                                <exclude>**/log4j.properties</exclude>
+                                <exclude>**/findInterrupt.btm</exclude>
+                                <exclude>protoschema-expectations/**</exclude>
+                                <exclude>org/hibernate/ogm/datastore/infinispanremote/test/**/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/infinispan-remote/pom.xml
+++ b/infinispan-remote/pom.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.ogm</groupId>
+        <artifactId>hibernate-ogm-parent</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Hibernate OGM for Infinispan over Hot Rod</name>
+    <description>Persist objects in Infinispan over Hot Rod, the remote client protocol of Infinispan</description>
+
+    <properties>
+        <jdkTargetForProcessor>1.8</jdkTargetForProcessor>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.ogm</groupId>
+            <artifactId>hibernate-ogm-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- "provided" is used as "compile-only" here; It's NOT needed at runtime -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-dsl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.hql</groupId>
+            <artifactId>hibernate-hql-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-hotrod</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-hotrod</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.ogm</groupId>
+            <artifactId>hibernate-ogm-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.takari.junit</groupId>
+            <artifactId>takari-cpsuite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Allow using Java8 code as Java8 is the requirement for Infinispan 8 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                   <forkMode>once</forkMode>
+                    <excludes>
+                        <!-- Skip a long-running test of a prototype class -->
+                        <exclude>**/ClusteredConcurrentTimestampRegionTestCase.java</exclude>
+                    </excludes>
+                     <!--
+                          java.net.preferIPv4Stack :
+                             There are problems with multicast and IPv6 on some
+                          OS/JDK combos, so we tell Java to use IPv4. If you
+                          have problems with multicast when running the tests
+                          you can try setting this to 'false', although typically
+                          that won't be helpful.
+
+                          jgroups.ping.timeout=500 :
+                             Tell JGroups to only wait a short time for PING
+                          responses before determining coordinator. Speeds cluster
+                          formation during integration tests. (This is too
+                          low a value for a real system; only use for tests.)
+
+                          jgroups.udp.enable_bundling=false :
+                             Disable the JGroups message bundling feature
+                          to speed tests and avoid FLUSH issue
+                           -->
+                    <argLine>-Djgroups.bind_addr=${jgroups.bind_addr} -Dhibernate.test.validatefailureexpected=true -Djava.net.preferIPv4Stack=true -Djgroups.ping.timeout=500 -Djgroups.ping.num_initial_members=1 -Djgroups.udp.enable_bundling=false</argLine>
+                    <skipExec>${skipUnitTests}</skipExec>
+                    <!-- Apache Lucene uses assertions which currently fail on JDK9: -->
+                    <!-- not sure yet how that is going to be resolved, but it's not an OGM problem. -->
+                    <enableAssertions>false</enableAssertions>
+                    <dependenciesToScan>
+                        <dependency>org.hibernate.ogm:hibernate-ogm-core</dependency>
+                    </dependenciesToScan>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.hibernate.ogm.datastore.infinispanremote.utils.HotrodServerLifecycle</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <showWarnings>true</showWarnings>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                    <!-- Annotation processor is run as an independent step -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <skipUnitTests>false</skipUnitTests>
+            </properties>
+        </profile>
+     </profiles>
+</project>

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDataStoreConfiguration.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDataStoreConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote;
+
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemoteGlobalContext;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl.InfinispanRemoteEntityContextImpl;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl.InfinispanRemoteGlobalContextImpl;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl.InfinispanRemotePropertyContextImpl;
+import org.hibernate.ogm.datastore.spi.DatastoreConfiguration;
+import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
+
+/**
+ * Allows to configure options specific to the Infinispan Remote data store.
+ */
+public class InfinispanRemoteDataStoreConfiguration implements DatastoreConfiguration<InfinispanRemoteGlobalContext> {
+
+	@Override
+	public InfinispanRemoteGlobalContext getConfigurationBuilder(ConfigurationContext context) {
+		return context.createGlobalContext( InfinispanRemoteGlobalContextImpl.class, InfinispanRemoteEntityContextImpl.class, InfinispanRemotePropertyContextImpl.class );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
@@ -1,0 +1,380 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.ProtoStreamMappingAdapter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.ProtostreamAssociationMappingAdapter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedTuple;
+import org.hibernate.AssertionFailure;
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.datastore.map.impl.MapAssociationSnapshot;
+import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
+import org.hibernate.ogm.dialect.spi.AssociationContext;
+import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
+import org.hibernate.ogm.dialect.spi.BaseGridDialect;
+import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
+import org.hibernate.ogm.dialect.spi.ModelConsumer;
+import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.AssociationKey;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.model.key.spi.RowKey;
+import org.hibernate.ogm.model.spi.Association;
+import org.hibernate.ogm.model.spi.AssociationOperation;
+import org.hibernate.ogm.model.spi.AssociationOperationType;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.infinispan.client.hotrod.MetadataValue;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.query.dsl.FilterConditionContext;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryBuilder;
+import org.infinispan.query.dsl.QueryFactory;
+
+/**
+ *  Some implementation notes for evolution:
+ *
+ *  - QueryableGridDialect can't be implemented as "native queries" in Hot Rod are DSL based
+ *    and have no String representation; this might change as Hot Rod exposes the underlying
+ *    query representation which is similar to HQL; alternatively we could look at exposing
+ *    native queries in some way other than a String.
+ *
+ *  - OptimisticLockingAwareGridDialect can't be implemented as it requires an atomic replace
+ *    operation on a subset of the columns, while atomic operations in Hot Rod have to involve
+ *    either the full value or the version metadata of Infinispan's VersionedValue.
+ *
+ *  - IdentityColumnAwareGridDialect can't work out of the box. I suspect we could do this but
+ *    would need extending the Infinispan server deployment with some extension such as a
+ *    custom script to be invoked from the client.
+ *
+ *  - BatchableGridDialect could probably be implemented.
+ *
+ * @author Sanne Grinovero
+ */
+public class InfinispanRemoteDialect<EK,AK,ISK> extends BaseGridDialect implements MultigetGridDialect {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private final InfinispanRemoteDatastoreProvider provider;
+
+	public InfinispanRemoteDialect(InfinispanRemoteDatastoreProvider provider) {
+		this.provider = Objects.requireNonNull( provider );
+	}
+
+	@Override
+	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+		final String cacheName = key.getTable();
+		ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		ProtostreamId idBuffer = mapper.createIdPayload( key.getColumnNames(), key.getColumnValues() );
+		VersionedValue<ProtostreamPayload> v = mapper.withinCacheEncodingContext( c -> c.getVersioned( idBuffer ) );
+		if ( v == null ) {
+			return null;
+		}
+		ProtostreamPayload payload = v.getValue();
+		if ( payload == null ) {
+			return null;
+		}
+		long version = v.getVersion();
+		VersionedTuple versionedTuple = payload.toVersionedTuple();
+		versionedTuple.setVersion( version );
+		return versionedTuple;
+	}
+
+	@Override
+	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+		return new VersionedTuple( true );
+	}
+
+	@Override
+	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+		VersionedTuple versionedTuple = (VersionedTuple) tuple;
+		final String cacheName = key.getTable();
+		log.debugf( "insertOrUpdateTuple for key '%s' on cache '%s'", key, cacheName );
+		ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		ProtostreamPayload valuePayload = mapper.createValuePayload( versionedTuple );
+		ProtostreamId idBuffer = mapper.createIdPayload( key.getColumnNames(), key.getColumnValues() );
+		boolean optimisticLockFailed;
+		if ( versionedTuple.isBeingInserted() ) {
+			optimisticLockFailed = null != mapper.withinCacheEncodingContext( c -> c.putIfAbsent( idBuffer, valuePayload ) );
+			if ( optimisticLockFailed ) {
+				throw new TupleAlreadyExistsException( key.getMetadata(), tuple );
+			}
+		}
+		else {
+			mapper.withinCacheEncodingContext( c -> c.put( idBuffer, valuePayload ) );
+		}
+	}
+
+	@Override
+	public void removeTuple(EntityKey key, TupleContext tupleContext) {
+		final String cacheName = key.getTable();
+		log.debugf( "removeTuple for key '%s' on cache '%s'", key, cacheName );
+		ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		ProtostreamId idBuffer = mapper.createIdPayload( key.getColumnNames(), key.getColumnValues() );
+		mapper.withinCacheEncodingContext( c -> c.remove( idBuffer ) );
+	}
+
+	@Override
+	public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
+		Map<RowKey,Map<String, Object>> results = loadRowKeysByQuery( key );
+		return new Association( new MapAssociationSnapshot( results ) );
+	}
+
+	private Map<RowKey, Map<String, Object>> loadRowKeysByQuery(AssociationKey key) {
+		final String cacheName = key.getTable();
+		ProtostreamAssociationMappingAdapter mapper = provider.getCollectionsDataMapper( cacheName );
+		return mapper.withinCacheEncodingContext( c -> {
+			QueryFactory queryFactory = Search.getQueryFactory( c );
+			final String[] columnNames = key.getColumnNames();
+			QueryBuilder qb = queryFactory.from( ProtostreamPayload.class );
+			FilterConditionContext bqEnd = null;
+			boolean firstIteration = true;
+			for ( int i = 0; i < columnNames.length; i++ ) {
+				String fieldName = mapper.convertColumnNameToFieldName( columnNames[i] );
+				if ( firstIteration ) {
+					bqEnd = qb.having( fieldName ).eq( key.getColumnValues()[i] );
+					firstIteration = false;
+				}
+				else {
+					bqEnd = bqEnd.and().having( fieldName ).eq( key.getColumnValues()[i] );
+				}
+			}
+			Query query = bqEnd.toBuilder().build();
+			Map<RowKey,Map<String, Object>> resultsCollector = new HashMap<>();
+			try ( CloseableIterator<Entry<Object,Object>> iterator = c.retrieveEntriesByQuery( query, null, 100 ) ) {
+				while ( iterator.hasNext() ) {
+					Entry<Object,Object> e  = iterator.next();
+					ProtostreamPayload value = ( (ProtostreamPayload) e.getValue() );
+					Map<String, Object> entryObject = value.toMap();
+					RowKey entryKey = value.asRowKey( key );
+					resultsCollector.put( entryKey, entryObject );
+				}
+			}
+			return resultsCollector;
+		} );
+	}
+
+	@Override
+	public Association createAssociation(AssociationKey key, AssociationContext associationContext) {
+		Map<RowKey, Map<String, Object>> associationMap = new HashMap<RowKey, Map<String,Object>>();
+		return new Association( new MapAssociationSnapshot( associationMap ) );
+	}
+
+	@Override
+	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
+		final String cacheName = key.getTable();
+		final ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		final boolean embeddedInEntity = associatonTypeIsForeignKeyEmbeddedInEntity( key, association, mapper );
+		if ( embeddedInEntity ) {
+			insertOrUpdateAssociationEmbeddedInEntity( key, association, associationContext, mapper, cacheName );
+		}
+		else {
+			insertOrUpdateAssociationMappedAsDedicatedEntries( key, association, associationContext, mapper, cacheName );
+		}
+	}
+
+	private void insertOrUpdateAssociationMappedAsDedicatedEntries(AssociationKey key, Association association, AssociationContext associationContext,
+			ProtoStreamMappingAdapter mapper, String cacheName) {
+		log.debugf( "insertOrUpdateAssociation for key '%s' on cache '%s', mapped as dedicated entries in ad-hoc table", key, cacheName );
+		final List<AssociationOperation> operations = association.getOperations();
+		for ( AssociationOperation ao : operations ) {
+			AssociationOperationType type = ao.getType();
+			RowKey rowKey = ao.getKey();
+			ProtostreamId idBuffer = mapper.createIdPayload( rowKey.getColumnNames(), rowKey.getColumnValues() );
+			switch ( type ) {
+				case PUT:
+					ProtostreamPayload valuePayloadForPut = mapper.createValuePayload( ao.getValue() );
+					mapper.withinCacheEncodingContext( c -> c.put( idBuffer, valuePayloadForPut ) );
+					break;
+				case REMOVE:
+					mapper.withinCacheEncodingContext( c -> c.remove( idBuffer ) );
+					break;
+				case CLEAR:
+					throw new AssertionFailure( "Request for CLEAR operation on an association mapped to dedicated entries. Makes no sense?" );
+			}
+		}
+	}
+
+	private void insertOrUpdateAssociationEmbeddedInEntity(AssociationKey key, Association association, AssociationContext associationContext,
+			ProtoStreamMappingAdapter mapper, String cacheName) {
+		log.debugf( "insertOrUpdateAssociation for key '%s' on cache '%s', mapped as in-entity foreign keys", key, cacheName );
+		final List<AssociationOperation> operations = association.getOperations();
+		for ( AssociationOperation ao : operations ) {
+			AssociationOperationType type = ao.getType();
+			RowKey rowKey = ao.getKey();
+			Tuple sourceTuple = ao.getValue();
+			ProtostreamId idBuffer = mapper.createIdPayload( rowKey.getColumnNames(), rowKey.getColumnValues() );
+			Tuple targetTuple;
+			ProtostreamPayload existingPayload = mapper.withinCacheEncodingContext( c -> c.get( idBuffer ) );
+			if ( existingPayload == null ) {
+				targetTuple = new Tuple();
+			}
+			else {
+				targetTuple = existingPayload.toTuple();
+			}
+			switch ( type ) {
+				case PUT:
+					for ( String columnName : rowKey.getColumnNames() ) {
+						targetTuple.put( columnName, sourceTuple.get( columnName ) );
+					}
+					ProtostreamPayload valuePayloadForPut = mapper.createValuePayload( targetTuple );
+					mapper.withinCacheEncodingContext( c -> c.put( idBuffer, valuePayloadForPut ) );
+					break;
+				case REMOVE:
+					for ( String columnName : key.getColumnNames() ) {
+						targetTuple.remove( columnName );
+					}
+					ProtostreamPayload valuePayloadForRemove = mapper.createValuePayload( targetTuple );
+					mapper.withinCacheEncodingContext( c -> c.put( idBuffer, valuePayloadForRemove ) );
+					break;
+				case CLEAR:
+					throw new AssertionFailure( "Request for CLEAR operation on an association mapped as foreign key embedded an an entity. Makes no sense?" );
+			}
+		}
+	}
+
+	private boolean associatonTypeIsForeignKeyEmbeddedInEntity(AssociationKey key, Association association, ProtoStreamMappingAdapter mapper) {
+		//if a RowKey includes all columns making up the Table's PK then the whole row is to be deleted (A "bridge" table)
+		//Otherwise, tuple operations must be applied to the properties of the Entity
+		List<AssociationOperation> operations = association.getOperations();
+		if ( operations.isEmpty() ) {
+			//Result doesn't matter as there are no operations to apply
+			return false;
+		}
+		else {
+			RowKey rowKey = operations.get( 0 ).getKey();
+			return mapper.columnSetExceedsIdRequirements( rowKey.getColumnNames() );
+		}
+	}
+
+	@Override
+	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
+		Map<RowKey, Map<String, Object>> rowsMap = loadRowKeysByQuery( key );
+		final String cacheName = key.getTable();
+		log.debugf( "removeAssociation for key '%s' on cache '%s'", key, cacheName );
+		final ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		for ( RowKey rowKey : rowsMap.keySet() ) {
+			ProtostreamId idBuffer = mapper.createIdPayload( rowKey.getColumnNames(), rowKey.getColumnValues() );
+			mapper.withinCacheEncodingContext( c -> c.remove( idBuffer ) ) ;
+		}
+	}
+
+	@Override
+	public boolean isStoredInEntityStructure(AssociationKeyMetadata associationKeyMetadata, AssociationTypeContext associationTypeContext) {
+		return false;
+	}
+
+	@Override
+	public Number nextValue(NextValueRequest request) {
+		return provider.getSequenceHandler().getSequenceValue( request );
+	}
+
+	@Override
+	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+		final String cacheName = entityKeyMetadata.getTable();
+		ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+		VersionedValue<ProtostreamPayload> v = mapper.withinCacheEncodingContext( c -> {
+			//TODO extract the batch constant to an option?
+			try ( CloseableIterator<Entry<Object,MetadataValue<Object>>> iterator
+					= c.retrieveEntriesWithMetadata( null, 100 ) ) {
+				while ( iterator.hasNext() ) {
+					Entry<Object, MetadataValue<Object>> next = iterator.next();
+					ProtostreamPayload obj = (ProtostreamPayload) next.getValue().getValue();
+					long version = next.getValue().getVersion();
+					VersionedTuple tuple = obj.toVersionedTuple();
+					tuple.setVersion( version );
+					consumer.consume( tuple );
+				}
+			}
+			return null;
+		} );
+	}
+
+	@Override
+	public DuplicateInsertPreventionStrategy getDuplicateInsertPreventionStrategy(EntityKeyMetadata entityKeyMetadata) {
+		//We can implement duplicate insert detection by this by using Infinispan's putIfAbsent
+		//support and verifying the return on any insert
+		//TODO Not implemented yet as Hot Rod's support for atomic operations is complex, so default to the naive impl;
+		// In particular:
+		// - CAS operations such as putIfAbsent require Caches to use Transactions on the server (but the Hot Rod client can't participate)
+		// - Multi-Get and Multi-Put operations don't honour the Version API
+		return DuplicateInsertPreventionStrategy.LOOK_UP;
+	}
+
+	@Override
+	public boolean supportsSequences() {
+		//For reasons to keep this to 'false' see implementation comments on HotRodSequenceHandler
+		return false;
+	}
+
+	// [Optional] implement MultigetGridDialect:
+	@Override
+	public List<Tuple> getTuples(EntityKey[] keys, TupleContext tupleContext) {
+		Objects.requireNonNull( keys );
+		if ( keys.length == 0 ) {
+			return Collections.emptyList();
+		}
+		else if ( keys.length == 1 ) {
+			return Collections.singletonList( getTuple( keys[0], tupleContext ) );
+		}
+		else {
+			final String cacheName = keys[0].getTable();
+			final ProtoStreamMappingAdapter mapper = provider.getDataMapperForCache( cacheName );
+			final Map<EntityKey,ProtostreamId> keyConversionMatch = new HashMap<>();
+			final Set<ProtostreamId> convertedKeys = new HashSet<>();
+			for ( EntityKey ek : keys ) {
+				if ( ek == null ) {
+					continue;
+				}
+				assert ek.getTable().equals( cacheName ) : "The javadoc comment promised batches would be loaded from the same table";
+				ProtostreamId idBuffer = mapper.createIdPayload( ek.getColumnNames(), ek.getColumnValues() );
+				keyConversionMatch.put( ek, idBuffer );
+				convertedKeys.add( idBuffer );
+			}
+			final Map<ProtostreamId, ProtostreamPayload> loadedBulk = mapper.withinCacheEncodingContext( c -> {
+				//TODO getAll doesn't support versioned entries ?!
+				return c.getAll( convertedKeys );
+			} );
+
+			final List<Tuple> results = new ArrayList<>( keys.length );
+			for ( int i = 0; i < keys.length; i++ ) {
+				EntityKey originalKey = keys[i];
+				if ( originalKey == null ) {
+					results.add( null );
+					continue;
+				}
+				ProtostreamId protostreamId = keyConversionMatch.get( originalKey );
+				ProtostreamPayload payload = loadedBulk.get( protostreamId );
+				if ( payload == null ) {
+					results.add( null );
+					continue;
+				}
+				results.add( payload.toTuple() );
+			}
+			return results;
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteProperties.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.ogm.datastore.keyvalue.cfg.KeyValueStoreProperties;
+
+/**
+ * Properties for configuring the Infinispan Remote datastore via {@code persistence.xml} or
+ * {@link StandardServiceRegistryBuilder}.
+ */
+public final class InfinispanRemoteProperties implements KeyValueStoreProperties {
+
+	/**
+	 * The configuration property to use as key to define a custom configuration resource
+	 * for the Hot Rod (Infinispan remote) client.
+	 */
+	public static final String CONFIGURATION_RESOURCE_NAME = "hibernate.ogm.infinispan_remote.configuration_resource_name";
+
+	/**
+	 * You can inject an instance of {@link org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaCapture} into
+	 * the configuration properties to capture the generated Protobuf schema.
+	 * Useful for testing, or to dump the schema somewhere else.
+	 */
+	public static final String SCHEMA_CAPTURE_SERVICE = "hibernate.ogm.infinispan_remote.schema_capture_service";
+
+	/**
+	 * You can inject an instance of {@link org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaOverride} into
+	 * the configuration properties to override the Protobuf schema being generated.
+	 * This will not affect how entities are encoded, so the alternative schema must be compatible.
+	 */
+	public static final String SCHEMA_OVERRIDE_SERVICE = "hibernate.ogm.infinispan_remote.schema_override_service";
+
+	/**
+	 * The configuration property key to configure the package name to be used in Protobuf generated schemas.
+	 */
+	public static final String SCHEMA_PACKAGE_NAME = "hibernate.ogm.infinispan_remote.schema_package_name";
+
+	/**
+	 * The default package name for Protobuf schemas. Override using SCHEMA_PACKAGE_NAME.
+	 * @see #SCHEMA_PACKAGE_NAME
+	 */
+	public static final String DEFAULT_SCHEMA_PACKAGE_NAME = "HibernateOGMGenerated";
+
+	private InfinispanRemoteProperties() {
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.configuration.impl;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaCapture;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaOverride;
+import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * Configuration for {@link InfinispanRemoteProperties}.
+ */
+public class InfinispanRemoteConfiguration {
+
+	private static final Log log = LoggerFactory.make();
+
+	private URL configurationResource;
+
+	private SchemaCapture schemaCaptureService;
+
+	private SchemaOverride schemaOverrideService;
+
+	private String schemaPackageName;
+
+	/**
+	 * The location of the configuration file.
+	 *
+	 * @see InfinispanRemoteProperties#CONFIGURATION_RESOURCE_NAME
+	 * @return might be the name of the file (too look it up in the class path) or an URL to a file.
+	 */
+	public URL getConfigurationResourceUrl() {
+		return configurationResource;
+	}
+
+	public SchemaCapture getSchemaCaptureService() {
+		return schemaCaptureService;
+	}
+
+	public SchemaOverride getSchemaOverrideService() {
+		return schemaOverrideService;
+	}
+
+	public String getSchemaPackageName() {
+		return schemaPackageName;
+	}
+
+	/**
+	 * Initialize the internal values form the given {@link Map}.
+	 *
+	 * @param configurationMap
+	 *            The values to use as configuration
+	 * @param serviceRegistry
+	 */
+	public void initConfiguration(Map<?, ?> configurationMap, ServiceRegistryImplementor serviceRegistry) {
+		ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		ConfigurationPropertyReader propertyReader = new ConfigurationPropertyReader( configurationMap, classLoaderService );
+
+		this.configurationResource = propertyReader
+				.property( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, URL.class )
+				.getValue();
+
+		this.schemaCaptureService = propertyReader
+				.property( InfinispanRemoteProperties.SCHEMA_CAPTURE_SERVICE, SchemaCapture.class )
+				.instantiate()
+				.getValue();
+
+		this.schemaOverrideService = propertyReader
+				.property( InfinispanRemoteProperties.SCHEMA_OVERRIDE_SERVICE, SchemaOverride.class )
+				.instantiate()
+				.getValue();
+
+		this.schemaPackageName = propertyReader
+				.property( InfinispanRemoteProperties.SCHEMA_PACKAGE_NAME, String.class )
+				.withDefault( InfinispanRemoteProperties.DEFAULT_SCHEMA_PACKAGE_NAME )
+				.getValue();
+
+		log.tracef( "Initializing Infinispan Hot Rod client from configuration file at '%1$s'", configurationResource );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/AssociationCacheOperation.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/AssociationCacheOperation.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamAssociationPayload;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.infinispan.client.hotrod.RemoteCache;
+
+@FunctionalInterface
+public interface AssociationCacheOperation<T> {
+
+	T doOnCache(RemoteCache<ProtostreamId,ProtostreamAssociationPayload> c);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/CacheOperation.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/CacheOperation.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.infinispan.client.hotrod.RemoteCache;
+
+@FunctionalInterface
+public interface CacheOperation<T> {
+
+	T doOnCache(RemoteCache<ProtostreamId,ProtostreamPayload> c);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+import org.hibernate.ogm.datastore.infinispanremote.configuration.impl.InfinispanRemoteConfiguration;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+
+public class HotRodClientBuilder {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private InfinispanRemoteConfiguration config;
+
+	private HotRodClientBuilder() {
+		//not to be created directly
+	}
+
+	public static HotRodClientBuilder builder() {
+		return new HotRodClientBuilder();
+	}
+
+	public HotRodClientBuilder withConfiguration(InfinispanRemoteConfiguration config) {
+		this.config = config;
+		return this;
+	}
+
+	public RemoteCacheManager build() {
+		return new RemoteCacheManager(
+				new ConfigurationBuilder()
+					.classLoader( HotRodClientBuilder.class.getClassLoader() )
+					.withProperties( getHotRodConfigurationProperties() )
+					.marshaller( new OgmProtoStreamMarshaller() )
+					.build() );
+	}
+
+	private Properties getHotRodConfigurationProperties() {
+		if ( config != null ) {
+			URL configurationResourceUrl = config.getConfigurationResourceUrl();
+			if ( configurationResourceUrl == null ) {
+				throw log.hotrodClientConfigurationMissing();
+			}
+			Properties p = new Properties();
+			try ( InputStream openStream = configurationResourceUrl.openStream() ) {
+				p.load( openStream );
+			}
+			catch (IOException e) {
+				throw log.failedLoadingHotRodConfigurationProperties( e );
+			}
+			return p;
+		}
+		else {
+			throw log.hotrodClientConfigurationMissing();
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
@@ -24,6 +24,8 @@ public class HotRodClientBuilder {
 
 	private InfinispanRemoteConfiguration config;
 
+	private OgmProtoStreamMarshaller marshaller;
+
 	private HotRodClientBuilder() {
 		//not to be created directly
 	}
@@ -32,8 +34,9 @@ public class HotRodClientBuilder {
 		return new HotRodClientBuilder();
 	}
 
-	public HotRodClientBuilder withConfiguration(InfinispanRemoteConfiguration config) {
+	public HotRodClientBuilder withConfiguration(InfinispanRemoteConfiguration config, OgmProtoStreamMarshaller marshaller) {
 		this.config = config;
+		this.marshaller = marshaller;
 		return this;
 	}
 
@@ -42,7 +45,7 @@ public class HotRodClientBuilder {
 				new ConfigurationBuilder()
 					.classLoader( HotRodClientBuilder.class.getClassLoader() )
 					.withProperties( getHotRodConfigurationProperties() )
-					.marshaller( new OgmProtoStreamMarshaller() )
+					.marshaller( marshaller )
 					.build() );
 	}
 

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/InfinispanRemoteDatastoreProvider.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/InfinispanRemoteDatastoreProvider.java
@@ -1,0 +1,192 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect;
+import org.hibernate.ogm.datastore.infinispanremote.configuration.impl.InfinispanRemoteConfiguration;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.SchemaDefinitions;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamSerializerSetup;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.impl.sequences.HotRodSequenceHandler;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaCapture;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaOverride;
+import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.service.spi.Configurable;
+import org.hibernate.service.spi.ServiceRegistryAwareService;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.spi.Startable;
+import org.hibernate.service.spi.Stoppable;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+
+/**
+ * @author Sanne Grinovero
+ */
+public class InfinispanRemoteDatastoreProvider extends BaseDatastoreProvider
+				implements Startable, Stoppable, Configurable, ServiceRegistryAwareService {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	// Only available during configuration
+	private InfinispanRemoteConfiguration config;
+
+	// The Hot Rod client; maintains TCP connections to the datagrid.
+	private RemoteCacheManager hotrodClient;
+
+	//Useful to allow people to dump the generated schema,
+	//we use it to capture the schema in tests too.
+	private SchemaCapture schemaCapture;
+
+	private ServiceRegistryImplementor serviceRegistry;
+
+	private SchemaOverride schemaOverrideService;
+
+	private Set<String> mappedCacheNames;
+
+	//For each cache we have a schema and a set of encoders/decoders to the generated protobuf schema
+	private Map<String,ProtoDataMapper> perCacheSchemaMappers;
+
+	private HotRodSequenceHandler sequences;
+
+	private SchemaDefinitions sd;
+
+	private String schemaPackageName;
+
+	@Override
+	public Class<? extends GridDialect> getDefaultDialect() {
+		return InfinispanRemoteDialect.class;
+	}
+
+	@Override
+	public void start() {
+		hotrodClient = HotRodClientBuilder.builder().withConfiguration( config ).build();
+		hotrodClient.start();
+		config = null; //no longer needed
+	}
+
+	public RemoteCacheManager getRemoteCacheManager() {
+		return hotrodClient;
+	}
+
+	@Override
+	public void stop() {
+		hotrodClient.stop();
+	}
+
+	@Override
+	public void configure(Map configurationValues) {
+		this.config = new InfinispanRemoteConfiguration();
+		this.config.initConfiguration( configurationValues, serviceRegistry );
+		this.schemaCapture = config.getSchemaCaptureService();
+		this.schemaOverrideService = config.getSchemaOverrideService();
+		this.schemaPackageName = config.getSchemaPackageName();
+	}
+
+	@Override
+	public void injectServices(ServiceRegistryImplementor serviceRegistry) {
+		this.serviceRegistry = serviceRegistry;
+	}
+
+	@Override
+	public Class<? extends SchemaDefiner> getSchemaDefinerType() {
+		return ProtobufSchemaInitializer.class;
+	}
+
+	public void registerSchemaDefinitions(SchemaDefinitions sd) {
+		this.sd = sd;
+		sd.validateSchema();
+		RemoteCache<String,String> protobufCache = getProtobufCache();
+		//FIXME make this name configurable & give it a sensible default:
+		final String generatedProtobufName = "Hibernate_OGM_Generated_schema.proto";
+		sd.deploySchema( generatedProtobufName, protobufCache, schemaCapture, schemaOverrideService );
+		this.sequences = new HotRodSequenceHandler( this, sd.getSequenceDefinitions() );
+		setMappedCacheNames( sd );
+		startAndValidateCaches();
+		perCacheSchemaMappers = sd.generateSchemaMappingAdapters( this, sd );
+	}
+
+	private void startAndValidateCaches() {
+		Set<String> failedCacheNames = new TreeSet<String>();
+		mappedCacheNames.forEach( cacheName -> {
+			RemoteCache<?,?> cache = hotrodClient.getCache( cacheName );
+			if ( cache == null ) {
+				failedCacheNames.add( cacheName );
+			}
+		} );
+		if ( failedCacheNames.size() > 1 ) {
+			throw log.expectedCachesNotDefined( failedCacheNames );
+		}
+		else if ( failedCacheNames.size() == 1 ) {
+			throw log.expectedCacheNotDefined( failedCacheNames.iterator().next() );
+		}
+	}
+
+	private void setMappedCacheNames(Set<String> tableNames) {
+		this.mappedCacheNames = Collections.unmodifiableSet( new HashSet( tableNames ) );
+	}
+
+	private void setMappedCacheNames(SchemaDefinitions sd) {
+		this.mappedCacheNames = sd.getTableNames();
+	}
+
+	private RemoteCache<String, String> getProtobufCache() {
+		return getCache( ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME );
+	}
+
+	@Override
+	public boolean allowsTransactionEmulation() {
+		// Hot Rod doesn't support "true" transaction yet
+		return true;
+	}
+
+	public String getProtobufPackageName() {
+		return schemaPackageName;
+	}
+
+	public Set<String> getMappedCacheNames() {
+		return mappedCacheNames;
+	}
+
+	public ProtoStreamMappingAdapter getDataMapperForCache(String cacheName) {
+		return perCacheSchemaMappers.get( cacheName );
+	}
+
+	public ProtostreamAssociationMappingAdapter getCollectionsDataMapper(String cacheName) {
+		return perCacheSchemaMappers.get( cacheName );
+	}
+
+	public HotRodSequenceHandler getSequenceHandler() {
+		return this.sequences;
+	}
+
+	public SerializationContext getSerializationContextForSequences(SequenceTableDefinition std) {
+		//This method is here so that we can cache / reuse these contexts ?
+		return ProtostreamSerializerSetup.buildSerializationContextForSequences( sd, std );
+	}
+
+	public <K, V> RemoteCache<K, V> getCache(String cacheName) {
+		RemoteCache<K,V> cache = hotrodClient.getCache( cacheName );
+		if ( cache == null ) {
+			throw log.expectedCacheNotDefined( cacheName );
+		}
+		return cache;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtoStreamMappingAdapter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtoStreamMappingAdapter.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.model.spi.Tuple;
+
+public interface ProtoStreamMappingAdapter {
+
+	ProtostreamPayload createValuePayload(Tuple tuple);
+
+	ProtostreamId createIdPayload(String[] columnNames, Object[] columnValues);
+
+	<T> T withinCacheEncodingContext(CacheOperation<T> function);
+
+	boolean columnSetExceedsIdRequirements(String[] associationIdColumns);
+
+	String[] listIdColumnNames();
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtobufSchemaInitializer.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtobufSchemaInitializer.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import java.util.Iterator;
+
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Table;
+import org.hibernate.mapping.Value;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.SchemaDefinitions;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.TableDefinition;
+import org.hibernate.ogm.datastore.spi.BaseSchemaDefiner;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata;
+import org.hibernate.ogm.type.spi.GridType;
+import org.hibernate.ogm.type.spi.TypeTranslator;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.type.Type;
+
+/**
+ * Create and/or validate the protobuf schema definitions on the Infinispan grid.
+ */
+public class ProtobufSchemaInitializer extends BaseSchemaDefiner {
+
+	@Override
+	public void initializeSchema(SchemaDefinitionContext context) {
+		ServiceRegistryImplementor serviceRegistry = context.getSessionFactory().getServiceRegistry();
+		TypeTranslator typeTranslator = serviceRegistry.getService( TypeTranslator.class );
+		InfinispanRemoteDatastoreProvider datastoreProvider = (InfinispanRemoteDatastoreProvider) serviceRegistry.getService( DatastoreProvider.class );
+		String protobufPackageName = datastoreProvider.getProtobufPackageName();
+		SchemaDefinitions sd = new SchemaDefinitions( protobufPackageName );
+		for ( Namespace namespace : context.getDatabase().getNamespaces() ) {
+			for ( Table table : namespace.getTables() ) {
+				if ( table.isPhysicalTable() ) {
+					createTableDefinition( context.getSessionFactory(), sd, table, typeTranslator, protobufPackageName );
+				}
+			}
+		}
+		for ( IdSourceKeyMetadata iddSourceKeyMetadata : context.getAllIdSourceKeyMetadata() ) {
+			sd.createSequenceSchemaDefinition( iddSourceKeyMetadata, datastoreProvider.getProtobufPackageName() );
+		}
+		datastoreProvider.registerSchemaDefinitions( sd );
+	}
+
+	private void createTableDefinition(SessionFactoryImplementor sessionFactory, SchemaDefinitions sd,
+			Table table, TypeTranslator typeTranslator, String protobufPackageName) {
+		TableDefinition td = new TableDefinition( table.getName(), protobufPackageName );
+		if ( table.hasPrimaryKey() ) {
+			for ( Column pkColumn : table.getPrimaryKey().getColumns() ) {
+				String name = pkColumn.getName();
+				//We only collect the column names, as the Type assigned to PrimaryKey columns
+				//is not the one of the kind we need.
+				//We need the ones defined by getColumnIterator, which we collect in the next
+				//step when collecting all column definitions.
+				td.markAsPrimaryKey( name );
+			}
+		}
+		Iterator<Column> columnIterator = table.getColumnIterator();
+		while ( columnIterator.hasNext() ) {
+			Column column = columnIterator.next();
+			Value value = column.getValue();
+			Type type = value.getType();
+			if ( type.isAssociationType() ) {
+				type = type.getSemiResolvedType( sessionFactory );
+				if ( type.isComponentType() ) {
+					int index = column.getTypeIndex();
+					type = ( (org.hibernate.type.ComponentType) type ).getSubtypes()[index];
+				}
+			}
+			else if ( type.isComponentType() ) {
+				int index = column.getTypeIndex();
+				type = ( (org.hibernate.type.ComponentType) column.getValue().getType() ).getSubtypes()[index];
+			}
+			GridType gridType = typeTranslator.getType( type );
+			td.addColumnnDefinition( column, gridType, type );
+		}
+		sd.registerTableDefinition( td );
+	}
+
+	@Override
+	public void validateMapping(SchemaDefinitionContext context) {
+		//TODO something interesting to do here?
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtostreamAssociationMappingAdapter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/ProtostreamAssociationMappingAdapter.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamAssociationPayload;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+
+public interface ProtostreamAssociationMappingAdapter {
+
+	ProtostreamAssociationPayload createAssociationPayload(EntityKey key, VersionedAssociation tuple, TupleContext tupleContext);
+
+	ProtostreamId createIdPayload(String[] columnNames, Object[] columnValues);
+
+	<T> T withinCacheEncodingContext(AssociationCacheOperation<T> function);
+
+	String convertColumnNameToFieldName(String string);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/VersionedAssociation.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/VersionedAssociation.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.model.spi.Association;
+import org.hibernate.ogm.model.spi.AssociationSnapshot;
+
+
+public class VersionedAssociation extends Association {
+
+	private long version;
+
+	public VersionedAssociation() {
+		super();
+	}
+
+	public VersionedAssociation(AssociationSnapshot snapshot) {
+		super( snapshot );
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/VersionedTuple.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/VersionedTuple.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl;
+
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.TupleSnapshot;
+
+public final class VersionedTuple extends Tuple {
+
+	private long version;
+	private final boolean beingInserted;
+
+	public VersionedTuple(boolean beingInserted) {
+		super();
+		this.beingInserted = beingInserted;
+	}
+
+	public VersionedTuple(TupleSnapshot snapshot) {
+		super( snapshot );
+		this.beingInserted = false;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	public boolean isBeingInserted() {
+		return beingInserted;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BaseProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BaseProtofieldWriter.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public abstract class BaseProtofieldWriter<T> implements ProtofieldWriter<T> {
+
+	protected final int fieldNumber;
+	protected final String name;
+	protected final String columnName;
+	protected final boolean nullable;
+	protected final ProtofieldEncoder<T> writingFunction;
+	protected final ProtofieldDecoder<T> readingFunction;
+
+	public BaseProtofieldWriter(int fieldLabel, String fieldName, boolean nullable, String columnName,
+			ProtofieldEncoder<T> writingFunction, ProtofieldDecoder<T> readingFunction) {
+		this.fieldNumber = fieldLabel;
+		this.name = fieldName;
+		this.columnName = columnName;
+		this.nullable = nullable;
+		this.readingFunction = readingFunction;
+		this.writingFunction = NullableProtofieldEncoder.makeNullableFieldEncoder( writingFunction, nullable );
+	}
+
+	@Override
+	public void writeTo(ProtoStreamWriter outProtobuf, T value) throws IOException {
+		writingFunction.encode( outProtobuf, value );
+	}
+
+	@Override
+	public T read(ProtoStreamReader reader) throws IOException {
+		return readingFunction.read( reader );
+	}
+
+	@Override
+	public void exportProtobufFieldDefinition(StringBuilder sb) {
+		if ( nullable ) {
+			sb.append( "\n\toptional " );
+		}
+		else {
+			sb.append( "\n\trequired " );
+		}
+		sb.append( getProtobufTypeName() )
+			.append( " " )
+			.append( name )
+			.append( " = " )
+			.append( fieldNumber )
+			.append( ";" );
+	}
+
+	protected abstract String getProtobufTypeName();
+
+	@Override
+	public String getColumnName() {
+		return columnName;
+	}
+
+	@Override
+	public String getProtobufName() {
+		return name;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BigDecimalProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BigDecimalProtofieldWriter.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * A BigDecimal is encoded as a byte array after converting to a BigInteger.
+ * The byte array conversion of BigInteger is well defined.
+ *
+ * @see java.math.BigInteger#toByteArray
+ */
+public class BigDecimalProtofieldWriter extends BaseProtofieldWriter<BigDecimal> implements ProtofieldWriter<BigDecimal> {
+
+	public BigDecimalProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, BigDecimal value) -> outProtobuf.writeBytes( name, value.toBigInteger().toByteArray() ),
+				(ProtoStreamReader reader) -> {
+					byte[] readBytes = reader.readBytes( name );
+					if ( readBytes != null ) {
+						BigInteger bi = new BigInteger( readBytes );
+						BigDecimal bd = new BigDecimal( bi );
+						return bd;
+					}
+					return null;
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "bytes";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BigIntegerProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BigIntegerProtofieldWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.math.BigInteger;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * A BigInteger is encoded as a byte array.
+ * The byte array conversion of BigInteger is well defined.
+ *
+ * @see java.math.BigInteger#toByteArray
+ */
+public class BigIntegerProtofieldWriter extends BaseProtofieldWriter<BigInteger> implements ProtofieldWriter<BigInteger> {
+
+	public BigIntegerProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, BigInteger value) -> outProtobuf.writeBytes( name, value.toByteArray() ),
+				(ProtoStreamReader reader) -> {
+					byte[] readBytes = reader.readBytes( name );
+					if ( readBytes != null ) {
+						return new BigInteger( readBytes );
+					}
+					return null;
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "bytes";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BooleanProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/BooleanProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public class BooleanProtofieldWriter extends BaseProtofieldWriter<Boolean> implements ProtofieldWriter<Boolean> {
+
+	public BooleanProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Boolean value) -> outProtobuf.writeBoolean( name, value ),
+				(ProtoStreamReader reader) -> reader.readBoolean( name )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "bool";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ByteProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ByteProtofieldWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * There is no explicit "byte" support in Protostream.
+ * Decided to encode it as a byte array type; on reading a longer sequence it will be truncated as we only read the first byte.
+ */
+public class ByteProtofieldWriter extends BaseProtofieldWriter<Byte> implements ProtofieldWriter<Byte> {
+
+	public ByteProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Byte value) -> {
+					byte[] array = { value.byteValue() };
+					outProtobuf.writeBytes( name, array );
+				},
+				(ProtoStreamReader reader) -> {
+					byte[] array = reader.readBytes( name );
+					if ( array != null && array.length > 0 ) {
+						return Byte.valueOf( array[0] );
+					}
+					return null;
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "bytes";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CalendarDateProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CalendarDateProtofieldWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.util.Calendar;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public class CalendarDateProtofieldWriter extends BaseProtofieldWriter<Calendar> implements ProtofieldWriter<Calendar> {
+
+	public CalendarDateProtofieldWriter(int tag, final String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Calendar value) -> outProtobuf.writeLong( name, value.getTimeInMillis() ),
+				(ProtoStreamReader reader) -> {
+					//TODO should we map this as a composite object, to encode both the utcTimestamp and the timezone?
+					Long utcTimestamp = reader.readLong( name );
+					if ( utcTimestamp != null ) {
+						Calendar c = Calendar.getInstance();
+						c.setTimeInMillis( utcTimestamp );
+						return c;
+					}
+					else {
+						return null;
+					}
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "int64";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CharacterProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CharacterProtofieldWriter.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * There is no explicit "char" support in Protostream.
+ * Decided to encode it as a 'string' type; on reading a longer string will be truncated as we only read the first character.
+ */
+public class CharacterProtofieldWriter extends BaseProtofieldWriter<Character> implements ProtofieldWriter<Character> {
+
+	public CharacterProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Character value) -> outProtobuf.writeString( name, "" + value ),
+				(ProtoStreamReader reader) -> {
+					String valueAsString = reader.readString( name );
+					if ( valueAsString != null && valueAsString.length() > 0 ) {
+						return valueAsString.charAt( 0 );
+					}
+					return null;
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "string";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CompositeProtobufCoDec.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/CompositeProtobufCoDec.java
@@ -1,0 +1,185 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedAssociation;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.MainOgmCoDec;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamAssociationPayload;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class CompositeProtobufCoDec implements MainOgmCoDec {
+
+	private final String tableName;
+	private final String protobufTypeName;
+	private final String protobufIdTypeName;
+	private final RemoteCache remoteCache;
+	private final ProtofieldWriterSet keyFields;
+	private final ProtofieldWriterSet valueFields;
+	private final SchemaDefinitions sd;
+
+	public CompositeProtobufCoDec(String tableName, String protobufTypeName, String protobufIdTypeName, ProtofieldWriterSet keyFields, ProtofieldWriterSet valueFields, RemoteCache remoteCache, SchemaDefinitions sd) {
+		this.tableName = tableName;
+		this.protobufTypeName = protobufTypeName;
+		this.protobufIdTypeName = protobufIdTypeName;
+		this.remoteCache = remoteCache;
+		this.keyFields = keyFields;
+		this.valueFields = valueFields;
+		this.sd = sd;
+	}
+
+	@Override
+	public RemoteCache getLinkedCache() {
+		return remoteCache;
+	}
+
+	@Override
+	public ProtostreamId readProtostreamId(ProtoStreamReader reader) throws IOException {
+		final int size = keyFields.size();
+		final String[] columnNames = new String[size];
+		final Object[] columnValues = new Object[size];
+		for ( int i = 0; i < size; i++ ) {
+			final UnsafeProtofield protoField = keyFields.getDecoderByListOrder( i );
+			columnNames[i] = protoField.getColumnName();
+			columnValues[i] = protoField.read( reader );
+		}
+		return createIdPayload( columnNames, columnValues );
+	}
+
+	@Override
+	public ProtostreamId createIdPayload(String[] columnNames, Object[] columnValues) {
+		assert verifyAllColumnNamesArePartOfId( columnNames );
+		return new ProtostreamId( columnNames, columnValues );
+	}
+
+	private boolean verifyAllColumnNamesArePartOfId(String[] columnNames) {
+		for ( String name : columnNames ) {
+			if ( ! keyFields.columnNameExists( name ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public void writeIdTo(ProtoStreamWriter writer, ProtostreamId id) throws IOException {
+		final int size = id.columnNames.length;
+		for ( int i = 0; i < size; i++ ) {
+			final String columnName = id.columnNames[i];
+			UnsafeProtofield protofieldWriter = keyFields.getDecoderByColumnName( columnName );
+			if ( protofieldWriter == null ) {
+				//Sometimes the Association Key contains columns beyond the strictly required ones for the key
+				continue;
+			}
+			protofieldWriter.writeTo( writer, id.columnValues[i] );
+		}
+	}
+
+	@Override
+	public ProtostreamPayload readPayloadFrom(ProtoStreamReader reader) throws IOException {
+		final int size = valueFields.size();
+		Map mapTuple = new HashMap<>( size );
+		for ( int i = 0; i < size; i++ ) {
+			final UnsafeProtofield protoField = valueFields.getDecoderByListOrder( i );
+			final String column = protoField.getColumnName();
+			final Object value = protoField.read( reader );
+			if ( value != null ) {
+				mapTuple.put( column, value );
+			}
+		}
+		MapTupleSnapshot loadedSnapshot = new MapTupleSnapshot( mapTuple );
+		return new ProtostreamPayload( loadedSnapshot );
+	}
+
+	@Override
+	public void writePayloadTo(ProtoStreamWriter writer, ProtostreamPayload payload) {
+		//N.B. we iterate in order by tag number of the protobuf field, as this affects encoding performance
+		//This implies we might be requesting columns which are not defined in the payload
+		valueFields.forEachProtostreamMappedField( f -> {
+			Object columnValue = payload.getColumnValue( f.getColumnName() );
+			if ( columnValue != null ) {
+				f.writeTo( writer, columnValue );
+			}
+		} );
+	}
+
+	@Override
+	public ProtostreamPayload createValuePayload(Tuple tuple) {
+		return new ProtostreamPayload( tuple );
+	}
+
+	@Override
+	public String getProtobufTypeName() {
+		return protobufTypeName;
+	}
+
+	@Override
+	public String getIdProtobufTypeName() {
+		return protobufIdTypeName;
+	}
+
+	@Override
+	public ProtostreamAssociationPayload createAssociationPayload(EntityKey key, VersionedAssociation assoc, TupleContext tupleContext) {
+		return new ProtostreamAssociationPayload( assoc );
+	}
+
+	@Override
+	public String convertColumnNameToFieldName(String columnName) {
+		return valueFields.getDecoderByColumnName( columnName ).getProtobufName();
+	}
+
+	/**
+	 * Checks that both conditions hold true:
+	 * the listed columns are sufficient to create and ID (a primary key)
+	 * and exceed the requirement: there's at least one additional column
+	 * to narrow down the selection.
+	 * ASSUMPTION: not expecting duplicates among the columnNames.
+	 */
+	@Override
+	public boolean columnSetExceedsIdRequirements(String[] columnNames) {
+		assert namesAreUnique( columnNames );
+		int keySetSize = keyFields.size();
+		//First check that we have a larger set:
+		if ( columnNames.length <= keySetSize ) {
+			return false;
+		}
+		//Now check that we cover at least all same names of the required PK column names:
+		int columnsOfPK = 0;
+		for ( String columnName : columnNames ) {
+			if ( keyFields.columnNameExists( columnName ) ) {
+				columnsOfPK++;
+			}
+		}
+		return columnsOfPK == keySetSize;
+	}
+
+	private boolean namesAreUnique(String[] columnNames) {
+		HashSet<String> existing = new HashSet<>();
+		for ( String name : columnNames ) {
+			existing.add( name );
+		}
+		return columnNames.length == existing.size();
+	}
+
+	@Override
+	public String[] listIdColumnNames() {
+		return keyFields.getColumnNames();
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/DateProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/DateProtofieldWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.util.Date;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public class DateProtofieldWriter extends BaseProtofieldWriter<Date> implements ProtofieldWriter<Date> {
+
+	public DateProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Date value) -> outProtobuf.writeLong( name, value.getTime() ),
+				(ProtoStreamReader reader) -> {
+					Long utcTimestamp = reader.readLong( name );
+					if ( utcTimestamp != null ) {
+						Date d = new Date();
+						d.setTime( utcTimestamp );
+						return d;
+					}
+					else {
+						return null;
+					}
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "int64";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/DoubleProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/DoubleProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class DoubleProtofieldWriter extends BaseProtofieldWriter<Double> implements ProtofieldWriter<Double> {
+
+	public DoubleProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Double value) -> outProtobuf.writeDouble( name, value ),
+				(ProtoStreamReader reader) -> reader.readDouble( name )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "double";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/EnumProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/EnumProtofieldWriter.java
@@ -1,0 +1,136 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * Protostream requires us to pass the actual type from the mapped Enum,
+ * but OGM pre-maps these to String so se have to re-hydrate it from
+ * String to map it to native enums.
+ * See also: https://developers.google.com/protocol-buffers/docs/proto#enum
+ * @author Sanne Grinovero
+ */
+public class EnumProtofieldWriter implements ProtofieldWriter<Enum> {
+
+	private final int tag;
+	private final String name;
+	private final Class<? extends Enum> type;
+	private final Enum[] enumConstants;
+	private final String columnName;
+	private final boolean nullable;
+
+	public EnumProtofieldWriter(int tag, String name, boolean nullable, Class<? extends Enum> type, String columnName) {
+		this.tag = tag;
+		this.name = name;
+		this.nullable = nullable;
+		this.columnName = columnName;
+		this.enumConstants = type.getEnumConstants();
+		this.type = type;
+	}
+
+	@Override
+	public void writeTo(ProtoStreamWriter outProtobuf, Enum value) throws IOException {
+		outProtobuf.writeObject( name, value, type );
+	}
+
+	@Override
+	public Enum read(ProtoStreamReader reader) throws IOException {
+		return reader.readObject( name, type );
+	}
+
+	@Override
+	public void collectTypeDefinitions(TypeDeclarationsCollector typesDefCollector) {
+		typesDefCollector.createTypeDefinition( new EnumTypeDefinition( type ) );
+	};
+
+	@Override
+	public void exportProtobufFieldDefinition(StringBuilder sb) {
+		if ( nullable ) {
+			sb.append( "\n\toptional " );
+		}
+		else {
+			sb.append( "\n\trequired " );
+		}
+		sb.append( type.getSimpleName() );
+		sb.append( " " );
+		sb.append( name );
+		sb.append( " = " );
+		sb.append( tag );
+		sb.append( ";" );
+	}
+
+	@Override
+	public String getColumnName() {
+		return columnName;
+	}
+
+	@Override
+	public String getProtobufName() {
+		return name;
+	}
+
+	private static final class EnumTypeDefinition implements TypeDefinition {
+
+		private final Class<? extends Enum> type;
+
+		public EnumTypeDefinition(Class<? extends Enum> type) {
+			if ( type == null ) {
+				throw new NullPointerException( "The 'type' parameter shall not be null" );
+			}
+			this.type = type;
+		}
+
+		@Override
+		public void exportProtobufTypeDefinition(StringBuilder sb) {
+			Enum[] enumConstants = type.getEnumConstants();
+			sb.append( "\nenum " );
+			sb.append( type.getSimpleName() );
+			sb.append( " {" );
+			for ( int i = 0; i < enumConstants.length; i++ ) {
+				sb.append( "\n\t" );
+				sb.append( enumConstants[i].name() );
+				sb.append( " = " );
+				sb.append( i );
+				sb.append( ";" );
+			}
+			sb.append( "\n}\n" );
+		}
+
+		@Override
+		public String getTypeName() {
+			return type.getSimpleName();
+		}
+
+		@Override
+		public int hashCode() {
+			return type.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			else if ( obj == null ) {
+				return false;
+			}
+			else if ( EnumTypeDefinition.class != obj.getClass() ) {
+				return false;
+			}
+			else {
+				EnumTypeDefinition other = (EnumTypeDefinition) obj;
+				return type.equals( other.type );
+			}
+		}
+
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/FloatProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/FloatProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class FloatProtofieldWriter extends BaseProtofieldWriter<Float> implements ProtofieldWriter<Float> {
+
+	public FloatProtofieldWriter(int fieldNumber, String name, boolean nullable, String columnName) {
+		super( fieldNumber, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Float value) -> outProtobuf.writeFloat( name, value ),
+				(ProtoStreamReader reader) -> reader.readFloat( name )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "float";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/IntegerProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/IntegerProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class IntegerProtofieldWriter extends BaseProtofieldWriter<Integer> implements ProtofieldWriter<Integer> {
+
+	public IntegerProtofieldWriter(int fieldNumber, String name, boolean nullable, String columnName) {
+		super( fieldNumber, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Integer value) -> outProtobuf.writeInt( name, value ),
+				(ProtoStreamReader reader) -> reader.readInt( name )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "int32";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/LongProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/LongProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class LongProtofieldWriter extends BaseProtofieldWriter<Long> implements ProtofieldWriter<Long> {
+
+	public LongProtofieldWriter(final int tag, final String name, final boolean nullable, final String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Long value) -> outProtobuf.writeLong( name, value ),
+				(ProtoStreamReader reader) -> reader.readLong( name )
+			);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "int64";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/NullableProtofieldEncoder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/NullableProtofieldEncoder.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public class NullableProtofieldEncoder {
+
+	/**
+	 * Wrap a ProtofieldEncoder function into another ProtofieldEncoder which adds it capabilities
+	 * to deal with encoding of optional (nullable) values.
+	 * @param baseEncoder the ProtofieldEncoder to use normally
+	 * @param isNullable if true we'll wrap it, otherwise the baseEncoder is returned untouched.
+	 * @return
+	 */
+	static <T> ProtofieldEncoder<T> makeNullableFieldEncoder(final ProtofieldEncoder<T> baseEncoder, final boolean isNullable) {
+		if ( isNullable ) {
+			return (ProtoStreamWriter outProtobuf, T value) -> {
+				if ( value != null ) {
+					baseEncoder.encode( outProtobuf, value );
+				}
+			};
+		}
+		else {
+			return baseEncoder;
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/PrimitiveBytearrayProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/PrimitiveBytearrayProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public class PrimitiveBytearrayProtofieldWriter extends BaseProtofieldWriter<byte[]> implements ProtofieldWriter<byte[]> {
+
+	public PrimitiveBytearrayProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, byte[] value) -> outProtobuf.writeBytes( name, value ),
+				(ProtoStreamReader reader) -> reader.readBytes( name )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "bytes";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldDecoder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldDecoder.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+
+@FunctionalInterface
+public interface ProtofieldDecoder<T> {
+
+	T read(ProtoStreamReader reader) throws IOException;
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldEncoder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldEncoder.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+@FunctionalInterface
+public interface ProtofieldEncoder<T> {
+
+	void encode(ProtoStreamWriter outProtobuf, T value) throws IOException;
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldWriter.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public interface ProtofieldWriter<T> {
+
+	void writeTo(ProtoStreamWriter outProtobuf, T value) throws IOException;
+
+	T read(ProtoStreamReader reader) throws IOException;
+
+	void exportProtobufFieldDefinition(StringBuilder sb);
+
+	String getColumnName();
+
+	String getProtobufName();
+
+	default void collectTypeDefinitions(TypeDeclarationsCollector typesDefCollector) {
+		// The default implementation is a no-op
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldWriterSet.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ProtofieldWriterSet.java
@@ -1,0 +1,222 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamMappedField;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.ProtobufFieldConsumer;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.ProtobufTypeConsumer;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SanitationUtils;
+import org.hibernate.ogm.type.descriptor.impl.AttributeConverterGridTypeDescriptorAdaptor;
+import org.hibernate.ogm.type.descriptor.impl.GridTypeDescriptor;
+import org.hibernate.ogm.type.impl.AttributeConverterGridTypeAdaptor;
+import org.hibernate.ogm.type.impl.BigDecimalType;
+import org.hibernate.ogm.type.impl.BigIntegerType;
+import org.hibernate.ogm.type.impl.BooleanType;
+import org.hibernate.ogm.type.impl.ByteType;
+import org.hibernate.ogm.type.impl.CalendarDateType;
+import org.hibernate.ogm.type.impl.CalendarType;
+import org.hibernate.ogm.type.impl.CharacterType;
+import org.hibernate.ogm.type.impl.DateType;
+import org.hibernate.ogm.type.impl.DoubleType;
+import org.hibernate.ogm.type.impl.EntityType;
+import org.hibernate.ogm.type.impl.EnumType;
+import org.hibernate.ogm.type.impl.FloatType;
+import org.hibernate.ogm.type.impl.IntegerType;
+import org.hibernate.ogm.type.impl.LongType;
+import org.hibernate.ogm.type.impl.NumericBooleanType;
+import org.hibernate.ogm.type.impl.PrimitiveByteArrayType;
+import org.hibernate.ogm.type.impl.SerializableAsByteArrayType;
+import org.hibernate.ogm.type.impl.ShortType;
+import org.hibernate.ogm.type.impl.StringType;
+import org.hibernate.ogm.type.impl.TimeType;
+import org.hibernate.ogm.type.impl.TimestampType;
+import org.hibernate.ogm.type.impl.TrueFalseType;
+import org.hibernate.ogm.type.impl.UUIDType;
+import org.hibernate.ogm.type.impl.UrlType;
+import org.hibernate.ogm.type.impl.YesNoType;
+import org.hibernate.ogm.type.spi.GridType;
+import org.hibernate.type.Type;
+
+public class ProtofieldWriterSet {
+
+	//Counter to assign unique Tag ids in protobuf. First to be assigned is '1'.
+	private int uniqueTagAssigningCounter = 0;
+	private List<UnsafeProtofield> orderedFields = new ArrayList<>();
+	private Map<String,UnsafeProtofield> fieldsPerORMName = new HashMap<>();
+	private Map<String,UnsafeProtofield> fieldsPerProtobufName = new HashMap<>();
+
+	public void addMapping(String ormMappedName, GridType gridType, Type ormType, boolean nullable) {
+		final String name = SanitationUtils.convertNameSafely( ormMappedName );
+		uniqueTagAssigningCounter++;
+		gridType = extractGridTypeOnRecursiveTypes( gridType, ormType );
+		if ( gridType instanceof StringType ) {
+			add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof IntegerType ) {
+			add( new IntegerProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof LongType ) {
+			add( new LongProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof DoubleType ) {
+			add( new DoubleProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof UUIDType ) {
+			add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof CalendarDateType ) {
+			add( new CalendarDateProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof CalendarType ) {
+			//TODO same as CalendarDateType ?
+			add( new CalendarDateProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof DateType  ) {
+			add( new DateProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof TimestampType ) {
+			//TODO same as DateType?
+			add( new DateProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof TimeType ) {
+			//TODO same as DateType?
+			add( new DateProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof PrimitiveByteArrayType  ) {
+			add( new PrimitiveBytearrayProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof SerializableAsByteArrayType ) {
+			//TODO same as PrimitiveByteArrayType?
+			add( new PrimitiveBytearrayProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof CharacterType ) {
+			add( new CharacterProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof ByteType ) {
+			add( new ByteProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof BooleanType ) {
+			add( new BooleanProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof TrueFalseType ) {
+			add( new CharacterProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof YesNoType ) {
+			add( new CharacterProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof NumericBooleanType ) {
+			add( new IntegerProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof BigDecimalType ) {
+			add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof UrlType ) {
+			add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof ShortType ) {
+			add( new ShortProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof BigIntegerType ) {
+			add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof FloatType ) {
+			add( new FloatProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+		}
+		else if ( gridType instanceof EnumType ) {
+			EnumType etype = (EnumType) gridType;
+			if ( etype.isOrdinal() ) {
+				add( new IntegerProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+			}
+			else {
+				add( new StringProtofieldWriter( uniqueTagAssigningCounter, name, nullable, ormMappedName ) );
+				/* FIXME Alternative: Support of native Enum mapping in protobuf:
+				if ( ormType instanceof CustomType ) {
+					CustomType customOrmType = (CustomType) ormType;
+					UserType userType = customOrmType.getUserType();
+					org.hibernate.type.EnumType enumtype = (org.hibernate.type.EnumType) userType;
+					Class returnedClass = enumtype.returnedClass();
+					add( new EnumProtofieldWriter( uniqueTagAssigningCounter, name, nullable, returnedClass, ormMappedName ) );
+				}
+				else {
+					throw new AssertionFailure( "Type not implemented yet! " );
+				} */
+			}
+		}
+		else if ( gridType instanceof EntityType ) {
+			throw new AssertionFailure( "EntityType not implemented yet! " + gridType.getName()  );
+		}
+		else {
+			throw new AssertionFailure( "Type not implemented yet! " + gridType.getName()  );
+		}
+	}
+
+	private GridType extractGridTypeOnRecursiveTypes(GridType gridType, Type ormType) {
+		if ( gridType instanceof AttributeConverterGridTypeAdaptor ) {
+			AttributeConverterGridTypeAdaptor acgta = (AttributeConverterGridTypeAdaptor) gridType;
+			GridTypeDescriptor descriptor = acgta.getGridTypeDescriptor();
+			if ( descriptor instanceof AttributeConverterGridTypeDescriptorAdaptor ) {
+				AttributeConverterGridTypeDescriptorAdaptor internalType = (AttributeConverterGridTypeDescriptorAdaptor) descriptor;
+				return internalType.unwrapTargetGridType();
+			}
+		}
+		return gridType;
+	}
+
+	public void forEachProtobufFieldExporter(ProtobufFieldConsumer action) {
+		orderedFields.forEach( action );
+	}
+
+	public void forEach(ProtobufTypeConsumer action) {
+		orderedFields.forEach( action );
+	}
+
+	public void forEachProtostreamMappedField(Consumer<ProtostreamMappedField> action) {
+		orderedFields.forEach( action );
+	}
+
+	private void add(ProtofieldWriter unsafeWriter) {
+		UnsafeProtofield wrapped = new UnsafeProtofield( unsafeWriter );
+		UnsafeProtofield previous = fieldsPerORMName.put( unsafeWriter.getColumnName(), wrapped );
+		if ( previous != null ) {
+			throw new AssertionFailure( "Duplicate or ambiguous property: '" + unsafeWriter.getColumnName() );
+		}
+		previous = fieldsPerProtobufName.put( wrapped.getProtobufName(), wrapped );
+		if ( previous != null ) {
+			throw new AssertionFailure( "Duplicate or ambiguous property after convertion to Protobuf requirements: '"
+					+ wrapped.getProtobufName() + "'" );
+		}
+		orderedFields.add( wrapped );
+	}
+
+	public int size() {
+		return orderedFields.size();
+	}
+
+	public UnsafeProtofield getDecoderByListOrder(int i) {
+		return orderedFields.get( i );
+	}
+
+	public UnsafeProtofield getDecoderByColumnName(String columnName) {
+		return fieldsPerORMName.get( columnName );
+	}
+
+	public boolean columnNameExists(String columnName) {
+		return fieldsPerORMName.containsKey( columnName );
+	}
+
+	public String[] getColumnNames() {
+		return fieldsPerORMName.keySet().toArray( new String[0] );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/SchemaDefinitions.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/SchemaDefinitions.java
@@ -1,0 +1,134 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.TableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaCapture;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaOverride;
+import org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.protostream.FileDescriptorSource;
+
+public class SchemaDefinitions {
+
+	private static final Log LOG = LoggerFactory.getLogger();
+
+	private final String packageName;
+	private final Map<String,TableDefinition> definitionsByTableName = new HashMap<>();
+	private final Map<IdSourceKeyMetadata, SequenceTableDefinition> idSchemaPerMetadata = new HashMap<>();
+	private final Map<String, SequenceTableDefinition> idSchemaPerName = new HashMap<>();
+
+	//guarded by synchronization on this
+	private String cachedSchema = null;
+
+	public SchemaDefinitions(String packageName) {
+		this.packageName = packageName;
+	}
+
+	// N.B. all messages to the server need to be wrapped in /org/infinispan/protostream/message-wrapping.proto
+	// (both the schema definitions and the key/value pairs)
+	// This resource is defined in the Protostream jar.
+	// Typically this is transparently handled by using the Protostream codecs but be aware of it when bypassing Protostream.
+
+	public void deploySchema(String generatedProtobufName, RemoteCache<String, String> protobufCache, SchemaCapture schemaCapture, SchemaOverride schemaOverrideService) {
+		final String generatedProtoschema = schemaOverrideService == null ? generateProtoschema() : schemaOverrideService.createProtobufSchema();
+		try {
+			protobufCache.put( generatedProtobufName, generatedProtoschema );
+			LOG.successfullSchemaDeploy( generatedProtobufName );
+		}
+		catch (HotRodClientException hrce) {
+			throw LOG.errorAtSchemaDeploy( generatedProtobufName, hrce );
+		}
+		if ( schemaCapture != null ) {
+			schemaCapture.put( generatedProtobufName, generatedProtoschema );
+		}
+	}
+
+	private synchronized String generateProtoschema() {
+		if ( cachedSchema != null ) {
+			return cachedSchema;
+		}
+		TypeDeclarationsCollector typesDefCollector = new TypeDeclarationsCollector();
+		StringBuilder sb = new StringBuilder( 400 );
+		sb.append( "package " ).append( packageName ).append( ";\n" );
+		idSchemaPerMetadata.forEach( ( k, v ) -> v.exportProtobufEntry( sb ) );
+		definitionsByTableName.forEach( ( k, v ) -> v.collectTypeDefinitions( typesDefCollector ) );
+		typesDefCollector.exportProtobufEntries( sb );
+		definitionsByTableName.forEach( ( k, v ) -> v.exportProtobufEntry( sb ) );
+		String fullSchema = sb.toString();
+		LOG.generatedSchema( fullSchema );
+		this.cachedSchema = fullSchema;
+		return fullSchema;
+	}
+
+	public void registerTableDefinition(TableDefinition td) {
+		TableDefinition previous = definitionsByTableName.put( td.getTableName(), td );
+		if ( previous != null ) {
+			throw new AssertionFailure( "There should be no duplicate table definitions" );
+		}
+	}
+
+	public Set<String> getTableNames() {
+		Set<String> unionSet = new HashSet<>();
+		unionSet.addAll(  definitionsByTableName.keySet() );
+		unionSet.addAll(  idSchemaPerName.keySet() );
+		return Collections.unmodifiableSet( unionSet );
+	}
+
+	public Map<String,ProtoDataMapper> generateSchemaMappingAdapters(InfinispanRemoteDatastoreProvider provider, SchemaDefinitions sd) {
+		Map<String,ProtoDataMapper> adaptersCollector = new HashMap<>();
+		definitionsByTableName.forEach( ( k, v ) ->
+			adaptersCollector.put( k, v.createProtoDataMapper( provider.getCache( k ), sd ) )
+			);
+		return Collections.unmodifiableMap( adaptersCollector );
+	}
+
+	public FileDescriptorSource asFileDescriptorSource() throws IOException {
+		FileDescriptorSource source = new FileDescriptorSource();
+		StringReader stringReader = new StringReader( generateProtoschema() );
+		source.addProtoFile( "ogm-generated", stringReader );
+		return source;
+	}
+
+	public void createSequenceSchemaDefinition(IdSourceKeyMetadata idSourceKeyMetadata, String protobufPackageName) {
+		SequenceTableDefinition std = new SequenceTableDefinition( idSourceKeyMetadata, protobufPackageName );
+		SequenceTableDefinition previous = idSchemaPerMetadata.put( idSourceKeyMetadata, std );
+		if ( previous != null ) {
+			throw new AssertionFailure( "There should be no duplicate definitions for SequenceTableDefinition instances" );
+		}
+		previous = idSchemaPerName.put( std.getName(), std );
+		if ( previous != null ) {
+			throw new AssertionFailure( "There should be no duplicate definitions for SequenceTableDefinition instances" );
+		}
+	}
+
+	public Map<String, SequenceTableDefinition> getSequenceDefinitions() {
+		return Collections.unmodifiableMap( idSchemaPerName );
+	}
+
+	public void validateSchema() {
+		for ( TableDefinition td : definitionsByTableName.values() ) {
+			td.validate();
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/SchemaDefinitions.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/SchemaDefinitions.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper;
 import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
 import org.hibernate.ogm.datastore.infinispanremote.impl.schema.TableDefinition;
@@ -94,10 +95,11 @@ public class SchemaDefinitions {
 		return Collections.unmodifiableSet( unionSet );
 	}
 
-	public Map<String,ProtoDataMapper> generateSchemaMappingAdapters(InfinispanRemoteDatastoreProvider provider, SchemaDefinitions sd) {
+	public Map<String,ProtoDataMapper> generateSchemaMappingAdapters(InfinispanRemoteDatastoreProvider provider,
+			SchemaDefinitions sd, OgmProtoStreamMarshaller marshaller) {
 		Map<String,ProtoDataMapper> adaptersCollector = new HashMap<>();
 		definitionsByTableName.forEach( ( k, v ) ->
-			adaptersCollector.put( k, v.createProtoDataMapper( provider.getCache( k ), sd ) )
+			adaptersCollector.put( k, v.createProtoDataMapper( provider.getCache( k ), sd, marshaller ) )
 			);
 		return Collections.unmodifiableMap( adaptersCollector );
 	}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ShortProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/ShortProtofieldWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * Short instances are best encoded as int32, but we throw an exception if the read value doesn't
+ * actually fit in the acceptable ranges for a Short.
+ */
+public final class ShortProtofieldWriter extends BaseProtofieldWriter<Short> implements ProtofieldWriter<Short> {
+
+	private static final Log LOG = LoggerFactory.getLogger();
+
+	public ShortProtofieldWriter(int fieldNumber, String name, boolean nullable, String columnName) {
+		super( fieldNumber, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, Short value) -> outProtobuf.writeInt( name, value ),
+				(ProtoStreamReader reader) -> {
+					Integer readInt = reader.readInt( name );
+					if ( readInt != null ) {
+						int truncated = Math.min( Math.max( readInt, Short.MIN_VALUE ), Short.MAX_VALUE );
+						if ( truncated != readInt ) {
+							throw LOG.truncatingShortOnRead( readInt, name );
+						}
+						return (short) truncated;
+					}
+					return null;
+				}
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "int32";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/StringProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/StringProtofieldWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class StringProtofieldWriter extends BaseProtofieldWriter<String> implements ProtofieldWriter<String> {
+
+	public StringProtofieldWriter(final int tag, String name, boolean nullable, final String columnName) {
+		super( tag, name, nullable, columnName,
+			(ProtoStreamWriter outProtobuf, String value) -> outProtobuf.writeString( name, value ),
+			(ProtoStreamReader reader) -> reader.readString( name )
+			);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "string";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/TypeDeclarationsCollector.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/TypeDeclarationsCollector.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+
+/**
+ */
+public class TypeDeclarationsCollector {
+
+	private final Map<String,TypeDefinition> namedTypeDefs = new HashMap<>();
+
+	public void exportProtobufEntries(StringBuilder sb) {
+		namedTypeDefs.forEach( ( k, v ) -> v.exportProtobufTypeDefinition( sb ) );
+	}
+
+	public void createTypeDefinition(TypeDefinition newDef) {
+		TypeDefinition previous = namedTypeDefs.put( newDef.getTypeName(), newDef );
+		if ( previous != null && ! previous.equals( newDef ) ) {
+			//TODO clarify this message or deal with it
+			throw new HibernateException( "Conflicting type definition" );
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/TypeDefinition.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/TypeDefinition.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+/**
+ * Implementations should also implement equals() so that
+ * we can validate against conflicting types being defined:
+ * the name should be unique, but it is possible that multiple types
+ * will attempt to register a same-named but different type definition,
+ * and this should be reported as an error.
+ * For example, for enums we generate types using the short name of the
+ * class; ignoring package name that might be ambiguous.
+ *
+ * @author Sanne Grinovero
+ */
+public interface TypeDefinition {
+
+	void exportProtobufTypeDefinition(StringBuilder sb);
+
+	String getTypeName();
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UUIDProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UUIDProtofieldWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.util.UUID;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * UUID are commonly encoded as 'string' in Protobuf
+ */
+public final class UUIDProtofieldWriter extends BaseProtofieldWriter<UUID> implements ProtofieldWriter<UUID> {
+
+	public UUIDProtofieldWriter(int tag, String name, boolean nullable, String columnName) {
+		super( tag, name, nullable, columnName,
+				(ProtoStreamWriter outProtobuf, UUID value) -> outProtobuf.writeString( name, value.toString() ),
+				(ProtoStreamReader reader) -> UUID.fromString( reader.readString( name ) )
+				);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "string";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UnsafeProtofield.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UnsafeProtofield.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamMappedField;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.ProtobufFieldExporter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.ProtobufTypeExporter;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+/**
+ * Catching all IOException cases makes usage of lambdas inconvenient.
+ * Wrap all ProtofieldWriter instances with this for convenience.
+ */
+final class UnsafeProtofield<T> implements ProtobufFieldExporter, ProtobufTypeExporter, ProtostreamMappedField<T> {
+
+	private final ProtofieldWriter<T> delegate;
+
+	UnsafeProtofield(ProtofieldWriter<T> delegate) {
+		Objects.requireNonNull( delegate );
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void writeTo(ProtoStreamWriter outProtobuf, T value) {
+		try {
+			delegate.writeTo( outProtobuf, value );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	@Override
+	public T read(ProtoStreamReader reader) {
+		try {
+			return delegate.read( reader );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	@Override
+	public String getColumnName() {
+		return delegate.getColumnName();
+	}
+
+	@Override
+	public String getProtobufName() {
+		return delegate.getProtobufName();
+	}
+
+	@Override
+	public void exportProtobufFieldDefinition(StringBuilder sb) {
+		delegate.exportProtobufFieldDefinition( sb );
+	}
+
+	@Override
+	public void collectTypeDefinitions(TypeDeclarationsCollector typesDefCollector) {
+		delegate.collectTypeDefinitions( typesDefCollector );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UrlProtofieldWriter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protobuf/UrlProtofieldWriter.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protobuf;
+
+import java.net.URL;
+
+import org.hibernate.type.descriptor.java.UrlTypeDescriptor;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public final class UrlProtofieldWriter extends BaseProtofieldWriter<URL> implements ProtofieldWriter<URL> {
+
+	public UrlProtofieldWriter(final int tag, String name, boolean nullable, final String columnName) {
+		super( tag, name, nullable, columnName,
+			(ProtoStreamWriter outProtobuf, URL value) -> outProtobuf.writeString( name, UrlTypeDescriptor.INSTANCE.toString( value ) ),
+			(ProtoStreamReader reader) -> {
+				String readString = reader.readString( name );
+				if ( readString != null ) {
+					return UrlTypeDescriptor.INSTANCE.fromString( readString );
+				}
+				return null;
+			}
+			);
+	}
+
+	@Override
+	protected String getProtobufTypeName() {
+		return "string";
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/IdMessageMarshaller.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/IdMessageMarshaller.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.infinispan.protostream.MessageMarshaller;
+
+
+public class IdMessageMarshaller implements MessageMarshaller<ProtostreamId> {
+
+	private final MainOgmCoDec ogmEncoder;
+
+	public IdMessageMarshaller(MainOgmCoDec ogmEncoder) {
+		this.ogmEncoder = Objects.requireNonNull( ogmEncoder );
+	}
+
+	@Override
+	public Class<ProtostreamId> getJavaClass() {
+		return ProtostreamId.class;
+	}
+
+	@Override
+	public String getTypeName() {
+		return ogmEncoder.getIdProtobufTypeName();
+	}
+
+	@Override
+	public ProtostreamId readFrom(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException {
+		return ogmEncoder.readProtostreamId( reader );
+	}
+
+	@Override
+	public void writeTo(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, ProtostreamId id) throws IOException {
+		ogmEncoder.writeIdTo( writer, id );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/MainOgmCoDec.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/MainOgmCoDec.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.io.IOException;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedAssociation;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.infinispan.client.hotrod.RemoteCache;
+
+public interface MainOgmCoDec {
+
+	RemoteCache getLinkedCache();
+
+	ProtostreamId readProtostreamId(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException;
+
+	void writeIdTo(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, ProtostreamId id) throws IOException;
+
+	ProtostreamPayload readPayloadFrom(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException;
+
+	void writePayloadTo(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, ProtostreamPayload payload) throws IOException;
+
+	ProtostreamId createIdPayload(String[] columnNames, Object[] columnValues);
+
+	ProtostreamPayload createValuePayload(Tuple tuple);
+
+	ProtostreamAssociationPayload createAssociationPayload(EntityKey key, VersionedAssociation tuple, TupleContext tupleContext);
+
+	String getProtobufTypeName();
+
+	String getIdProtobufTypeName();
+
+	String convertColumnNameToFieldName(String string);
+
+	boolean columnSetExceedsIdRequirements(String[] columnNames);
+
+	String[] listIdColumnNames();
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/OgmProtoStreamMarshaller.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/OgmProtoStreamMarshaller.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.protostream.SerializationContext;
+
+
+/**
+ * The original ProtoStreamMarshaller expects 1:1 mapping between a Java class
+ * and a protostream schema. We need flexibility to override this by providing
+ * a custom org.infinispan.protostream.SerializationContext, but also we
+ * need to extend org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller
+ * to maintain general encoding compatibility and server side query capabilities.
+ *
+ * There's only one instance of OgmProtoStreamMarshaller for the whole Hot Rod Client;
+ * that means all our parallel Session are using the same marshaller#
+ * yet concurrently I need it to instruct which schema to use for a specific IO operation.
+ * A typical Infinispan client app would have a different Class registered in the marshaller
+ * for each entity; we don't have this luxury, or I'd have to bytecode-generate a Class
+ * definition for each "Table" we want to map.
+ *
+ * Note: see the implementation of
+ * org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller.getSerializationContext(RemoteCacheManager)
+ * to understand why it's important to extend it.
+ */
+public final class OgmProtoStreamMarshaller extends ProtoStreamMarshaller {
+
+	//FIXME all static threadlocals should die
+	// See https://hibernate.atlassian.net/browse/OGM-1163
+	private static final ThreadLocal<SerializationContext> currentSerializationContext = new ThreadLocal<>();
+
+	public OgmProtoStreamMarshaller() {
+	}
+
+	@Override
+	public SerializationContext getSerializationContext() {
+		return currentSerializationContext.get();
+	}
+
+	public static void setCurrentSerializationContext(SerializationContext sc) {
+		currentSerializationContext.set( sc );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/OgmProtoStreamMarshaller.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/OgmProtoStreamMarshaller.java
@@ -30,9 +30,7 @@ import org.infinispan.protostream.SerializationContext;
  */
 public final class OgmProtoStreamMarshaller extends ProtoStreamMarshaller {
 
-	//FIXME all static threadlocals should die
-	// See https://hibernate.atlassian.net/browse/OGM-1163
-	private static final ThreadLocal<SerializationContext> currentSerializationContext = new ThreadLocal<>();
+	private final ThreadLocal<SerializationContext> currentSerializationContext = new ThreadLocal<>();
 
 	public OgmProtoStreamMarshaller() {
 	}
@@ -42,7 +40,7 @@ public final class OgmProtoStreamMarshaller extends ProtoStreamMarshaller {
 		return currentSerializationContext.get();
 	}
 
-	public static void setCurrentSerializationContext(SerializationContext sc) {
+	public void setCurrentSerializationContext(SerializationContext sc) {
 		currentSerializationContext.set( sc );
 	}
 

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/PayloadMessageMarshaller.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/PayloadMessageMarshaller.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.infinispan.protostream.MessageMarshaller;
+
+public class PayloadMessageMarshaller implements MessageMarshaller<ProtostreamPayload> {
+
+	private final MainOgmCoDec ogmEncoder;
+
+	public PayloadMessageMarshaller(MainOgmCoDec ogmEncoder) {
+		this.ogmEncoder = Objects.requireNonNull( ogmEncoder );
+	}
+
+	@Override
+	public Class<ProtostreamPayload> getJavaClass() {
+		return ProtostreamPayload.class;
+	}
+
+	@Override
+	public String getTypeName() {
+		return ogmEncoder.getProtobufTypeName();
+	}
+
+	@Override
+	public ProtostreamPayload readFrom(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException {
+		return ogmEncoder.readPayloadFrom( reader );
+	}
+
+	@Override
+	public void writeTo(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, ProtostreamPayload payload) throws IOException {
+		ogmEncoder.writePayloadTo( writer, payload );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtoDataMapper.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtoDataMapper.java
@@ -24,8 +24,10 @@ public final class ProtoDataMapper implements ProtoStreamMappingAdapter, Protost
 
 	private final SerializationContext serContext;
 	private final MainOgmCoDec delegate;
+	private final OgmProtoStreamMarshaller marshaller;
 
-	public ProtoDataMapper(MainOgmCoDec delegate, SerializationContext serContext) throws DescriptorParserException, IOException {
+	public ProtoDataMapper(MainOgmCoDec delegate, SerializationContext serContext, OgmProtoStreamMarshaller marshaller) throws DescriptorParserException, IOException {
+		this.marshaller = marshaller;
 		this.delegate = Objects.requireNonNull( delegate );
 		this.serContext = Objects.requireNonNull( serContext );
 	}
@@ -48,22 +50,22 @@ public final class ProtoDataMapper implements ProtoStreamMappingAdapter, Protost
 	@Override
 	public <T> T withinCacheEncodingContext(CacheOperation<T> function) {
 		try {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			marshaller.setCurrentSerializationContext( serContext );
 			return (T) function.doOnCache( delegate.getLinkedCache() );
 		}
 		finally {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+			marshaller.setCurrentSerializationContext( null );
 		}
 	}
 
 	@Override
 	public <T> T withinCacheEncodingContext(AssociationCacheOperation<T> function) {
 		try {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			marshaller.setCurrentSerializationContext( serContext );
 			return (T) function.doOnCache( delegate.getLinkedCache() );
 		}
 		finally {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+			marshaller.setCurrentSerializationContext( null );
 		}
 	}
 

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtoDataMapper.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtoDataMapper.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.AssociationCacheOperation;
+import org.hibernate.ogm.datastore.infinispanremote.impl.CacheOperation;
+import org.hibernate.ogm.datastore.infinispanremote.impl.ProtoStreamMappingAdapter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.ProtostreamAssociationMappingAdapter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedAssociation;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.infinispan.protostream.DescriptorParserException;
+import org.infinispan.protostream.SerializationContext;
+
+public final class ProtoDataMapper implements ProtoStreamMappingAdapter, ProtostreamAssociationMappingAdapter {
+
+	private final SerializationContext serContext;
+	private final MainOgmCoDec delegate;
+
+	public ProtoDataMapper(MainOgmCoDec delegate, SerializationContext serContext) throws DescriptorParserException, IOException {
+		this.delegate = Objects.requireNonNull( delegate );
+		this.serContext = Objects.requireNonNull( serContext );
+	}
+
+	@Override
+	public ProtostreamPayload createValuePayload(Tuple tuple) {
+		return delegate.createValuePayload( tuple );
+	}
+
+	@Override
+	public ProtostreamAssociationPayload createAssociationPayload(EntityKey key, VersionedAssociation tuple, TupleContext tupleContext) {
+		return delegate.createAssociationPayload( key, tuple, tupleContext );
+	}
+
+	@Override
+	public ProtostreamId createIdPayload(String[] columnNames, Object[] columnValues) {
+		return delegate.createIdPayload( columnNames, columnValues );
+	}
+
+	@Override
+	public <T> T withinCacheEncodingContext(CacheOperation<T> function) {
+		try {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			return (T) function.doOnCache( delegate.getLinkedCache() );
+		}
+		finally {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+		}
+	}
+
+	@Override
+	public <T> T withinCacheEncodingContext(AssociationCacheOperation<T> function) {
+		try {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			return (T) function.doOnCache( delegate.getLinkedCache() );
+		}
+		finally {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+		}
+	}
+
+	@Override
+	public String convertColumnNameToFieldName(String string) {
+		return delegate.convertColumnNameToFieldName( string );
+	}
+
+	@Override
+	public boolean columnSetExceedsIdRequirements(String[] columnNames) {
+		return delegate.columnSetExceedsIdRequirements( columnNames );
+	}
+
+	@Override
+	public String toString() {
+		return "ProtoDataMapper[cacheName='" + delegate.getLinkedCache().getName() + "']";
+	}
+
+	@Override
+	public String[] listIdColumnNames() {
+		return delegate.listIdColumnNames();
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamAssociationPayload.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamAssociationPayload.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.util.Objects;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedAssociation;
+import org.hibernate.ogm.datastore.map.impl.MapAssociationSnapshot;
+
+public final class ProtostreamAssociationPayload {
+
+	//One and only one of the following fields will be initialized:
+	private final MapAssociationSnapshot loadedSnapshot;
+	private final VersionedAssociation association;
+
+	public ProtostreamAssociationPayload(MapAssociationSnapshot loadedSnapshot) {
+		this.loadedSnapshot = Objects.requireNonNull( loadedSnapshot );
+		this.association = null;
+	}
+
+	public ProtostreamAssociationPayload(VersionedAssociation tuple) {
+		this.association = Objects.requireNonNull( tuple );
+		this.loadedSnapshot = null;
+	}
+
+	public VersionedAssociation toAssociation() {
+		if ( association != null ) {
+			return association;
+		}
+		else {
+			return new VersionedAssociation( loadedSnapshot );
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamId.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamId.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.hibernate.ogm.model.key.spi.RowKey;
+
+public final class ProtostreamId {
+
+	public final NamedValue[] namedValues;
+	//Redundant information for convenience, as we might need to represent in either form:
+	public final String[] columnNames;
+	public final Object[] columnValues;
+
+	public ProtostreamId(String[] columnNames, Object[] columnValues) {
+		this.columnNames = columnNames;
+		this.columnValues = columnValues;
+		Objects.requireNonNull( columnNames );
+		Objects.requireNonNull( columnValues );
+		if ( columnNames.length != columnValues.length ) {
+			throw new IllegalArgumentException( "The size of the arrays of the two parameters is required to be the same" );
+		}
+		namedValues = new NamedValue[ columnNames.length ];
+		for ( int i = 0; i < columnNames.length; i++ ) {
+			namedValues[i] = new NamedValue( columnNames[i], columnValues[i] );
+		}
+	}
+
+	public RowKey toRowKey() {
+		return new RowKey( columnNames, columnValues );
+	}
+
+	public static final class NamedValue {
+		public final String columnName;
+		public final Object columnValue;
+		public NamedValue(String columnName, Object columnValue) {
+			this.columnName = Objects.requireNonNull( columnName );
+			this.columnValue = columnValue;
+		}
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + columnName.hashCode();
+			result = prime * result + ( ( columnValue == null ) ? 0 : columnValue.hashCode() );
+			return result;
+		}
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( NamedValue.class != obj.getClass() ) {
+				return false;
+			}
+			NamedValue other = (NamedValue) obj;
+			if ( ! columnName.equals( other.columnName ) ) {
+				return false;
+			}
+			if ( columnValue == null ) {
+				if ( other.columnValue != null ) {
+					return false;
+				}
+			}
+			else if ( ! columnValue.equals( other.columnValue ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode( namedValues );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( ProtostreamId.class != obj.getClass() ) {
+			return false;
+		}
+		ProtostreamId other = (ProtostreamId) obj;
+		if ( ! Arrays.equals( namedValues, other.namedValues ) ) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamMappedField.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamMappedField.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+
+public interface ProtostreamMappedField<T> extends ProtostreamReadWriteable<T> {
+
+	String getColumnName();
+
+	String getProtobufName();
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamPayload.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamPayload.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.ogm.datastore.infinispanremote.impl.VersionedTuple;
+import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
+import org.hibernate.ogm.model.key.spi.AssociationKey;
+import org.hibernate.ogm.model.key.spi.RowKey;
+import org.hibernate.ogm.model.spi.Tuple;
+
+public final class ProtostreamPayload {
+
+	//One and only one of the following fields will be initialized:
+	private final MapTupleSnapshot loadedSnapshot;
+	private final Tuple tuple;
+
+	public ProtostreamPayload(MapTupleSnapshot loadedSnapshot) {
+		this.loadedSnapshot = Objects.requireNonNull( loadedSnapshot );
+		this.tuple = null;
+	}
+
+	public ProtostreamPayload(Tuple tuple) {
+		this.tuple = Objects.requireNonNull( tuple );
+		this.loadedSnapshot = null;
+	}
+
+	public void forEach(BiConsumer<String, Object> actionOnNamedTouples) {
+		if ( loadedSnapshot != null ) {
+			loadedSnapshot.getMap().forEach( actionOnNamedTouples );
+		}
+		else {
+			for ( String column : tuple.getColumnNames() ) {
+				Object object = tuple.get( column );
+				actionOnNamedTouples.accept( column, object );
+			}
+		}
+	}
+
+	public Tuple toTuple() {
+		if ( loadedSnapshot != null ) {
+			return new VersionedTuple( loadedSnapshot );
+		}
+		else {
+			return tuple;
+		}
+	}
+
+	public VersionedTuple toVersionedTuple() {
+		if ( loadedSnapshot != null ) {
+			return new VersionedTuple( loadedSnapshot );
+		}
+		else if ( tuple instanceof VersionedTuple ) {
+			return (VersionedTuple) tuple;
+		}
+		else {
+			throw new AssertionFailure( "toVersionedTuple() can only be used on just loaded instances" );
+		}
+	}
+
+	public Object getColumnValue(String columnName) {
+		if ( tuple != null ) {
+			return tuple.get( columnName );
+		}
+		else {
+			return loadedSnapshot.get( columnName );
+		}
+	}
+
+	public Map<String, Object> toMap() {
+		if ( loadedSnapshot != null ) {
+			return loadedSnapshot.getMap();
+		}
+		else {
+			MapTupleSnapshot tupleSnapshot = (MapTupleSnapshot) tuple.getSnapshot();
+			return tupleSnapshot.getMap();
+		}
+	}
+
+	public RowKey asRowKey(AssociationKey key) {
+		String[] columnNames = key.getMetadata().getRowKeyColumnNames();
+		Object[] columnValues = new Object[columnNames.length];
+		for ( int i = 0; i < columnNames.length; i++ ) {
+			String columnName = columnNames[i];
+			columnValues[i] = getColumnValue( columnName );
+		}
+		return new RowKey( columnNames, columnValues );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamReadWriteable.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamReadWriteable.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamReader;
+import org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter;
+
+public interface ProtostreamReadWriteable<T> {
+
+	void writeTo(ProtoStreamWriter outProtobuf, T value);
+
+	T read(ProtoStreamReader reader);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamSerializerSetup.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/protostream/ProtostreamSerializerSetup.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.protostream;
+
+import java.io.IOException;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.SchemaDefinitions;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.impl.sequences.SequenceIdMarshaller;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.infinispan.protostream.DescriptorParserException;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.config.Configuration;
+import org.infinispan.protostream.impl.SerializationContextImpl;
+
+public class ProtostreamSerializerSetup {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private ProtostreamSerializerSetup() {
+		//Not to be constructed
+	}
+
+	public static SerializationContext buildSerializationContext(
+			SchemaDefinitions sd, MainOgmCoDec delegate) throws DescriptorParserException, IOException {
+		Configuration cfg = new Configuration.Builder().setLogOutOfSequenceReads( true ).build();
+		SerializationContextImpl serContext = new SerializationContextImpl( cfg );
+		IdMessageMarshaller idM = new IdMessageMarshaller( delegate );
+		PayloadMessageMarshaller valueM = new PayloadMessageMarshaller( delegate );
+		try {
+			serContext.registerProtoFiles( sd.asFileDescriptorSource() );
+		}
+		catch (DescriptorParserException | IOException e) {
+			throw log.errorAtProtobufParsing( e );
+		}
+		serContext.registerMarshaller( idM );
+		serContext.registerMarshaller( valueM );
+		return serContext;
+	}
+
+	public static SerializationContext buildSerializationContextForSequences(
+			SchemaDefinitions sd, SequenceTableDefinition std) {
+		Configuration cfg = new Configuration.Builder().setLogOutOfSequenceReads( true ).build();
+		SerializationContextImpl serContext = new SerializationContextImpl( cfg );
+		try {
+			serContext.registerProtoFiles( sd.asFileDescriptorSource() );
+		}
+		catch (DescriptorParserException | IOException e) {
+			throw log.errorAtProtobufParsing( e );
+		}
+		SequenceIdMarshaller idM = new SequenceIdMarshaller( std );
+		serContext.registerMarshaller( idM );
+		return serContext;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufEntryExporter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufEntryExporter.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+
+public interface ProtobufEntryExporter {
+
+	void exportProtobufEntry(StringBuilder output);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufFieldConsumer.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufFieldConsumer.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+import java.util.function.Consumer;
+
+public interface ProtobufFieldConsumer extends Consumer<ProtobufFieldExporter> {
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufFieldExporter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufFieldExporter.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+public interface ProtobufFieldExporter {
+
+	void exportProtobufFieldDefinition(StringBuilder sb);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufTypeConsumer.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufTypeConsumer.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+import java.util.function.Consumer;
+
+public interface ProtobufTypeConsumer extends Consumer<ProtobufTypeExporter> {
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufTypeExporter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/ProtobufTypeExporter.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.TypeDeclarationsCollector;
+
+public interface ProtobufTypeExporter {
+
+	void collectTypeDefinitions(TypeDeclarationsCollector typesDefCollector);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/SanitationUtils.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/SanitationUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+public class SanitationUtils {
+
+	public static String convertNameSafely(String name) {
+		if ( name.indexOf( '.' ) != -1 ) {
+			return name.replace( '.', '_' );//TODO verify against introducing ambiguities
+		}
+		else {
+			return name;
+		}
+	}
+
+	public static String toProtobufIdName(String name) {
+		return name + "_id";
+	}
+
+	public static String qualify(final String name, final String protobufPackageName) {
+		if ( protobufPackageName == null ) {
+			return name;
+		}
+		else {
+			return protobufPackageName + '.' + name;
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/SequenceTableDefinition.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/SequenceTableDefinition.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+import java.io.IOException;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.LongProtofieldWriter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.ProtofieldWriter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.StringProtofieldWriter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.sequences.SequenceId;
+import org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata;
+
+public final class SequenceTableDefinition implements ProtobufEntryExporter {
+
+	private final String messageName;
+	private final String idMessageName;
+	private final String keyColumnName;
+	private final String valueColumnName;
+	private final LongProtofieldWriter valueEncoder;
+	private final StringProtofieldWriter sequenceNameEncoder;
+	private final String protobufPackageName;
+
+	public SequenceTableDefinition(IdSourceKeyMetadata idSourceKeyMetadata, String protobufPackageName) {
+		this.protobufPackageName = protobufPackageName;
+		this.messageName = inferMessageName( idSourceKeyMetadata );
+		this.idMessageName = SanitationUtils.toProtobufIdName( messageName );
+		this.keyColumnName = SanitationUtils.convertNameSafely( idSourceKeyMetadata.getKeyColumnName() );
+		this.valueColumnName = SanitationUtils.convertNameSafely( idSourceKeyMetadata.getValueColumnName() );
+		this.sequenceNameEncoder = new StringProtofieldWriter( 1,
+				keyColumnName, false, idSourceKeyMetadata.getKeyColumnName() );
+		this.valueEncoder = new LongProtofieldWriter( 2,
+				valueColumnName, false, idSourceKeyMetadata.getValueColumnName() );
+	}
+
+	private static String inferMessageName(IdSourceKeyMetadata idSourceKeyMetadata) {
+		return SanitationUtils.convertNameSafely( idSourceKeyMetadata.getName() );
+	}
+
+	@Override
+	public void exportProtobufEntry(StringBuilder sb) {
+		exportMessage( idMessageName, sequenceNameEncoder, sb );
+		exportMessage( messageName, valueEncoder, sb );
+	}
+
+	private static void exportMessage(String messageName, ProtofieldWriter<?> encoder, StringBuilder sb) {
+		sb.append( "\nmessage " ).append( messageName ).append( " {" );
+		encoder.exportProtobufFieldDefinition( sb );
+		sb.append( "\n}\n" );
+	}
+
+	public String getName() {
+		return messageName;
+	}
+
+	public SequenceId readSequenceId(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException {
+		String read = sequenceNameEncoder.read( reader );
+		return new SequenceId( read );
+	}
+
+	public void writeSequenceId(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, SequenceId t) throws IOException {
+		sequenceNameEncoder.writeTo( writer, t.getSegmentName() );
+	}
+
+	public String getQualifiedIdMessageName() {
+		return SanitationUtils.qualify( idMessageName, protobufPackageName );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/TableDefinition.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/TableDefinition.java
@@ -15,6 +15,7 @@ import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.CompositeProto
 import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.ProtofieldWriterSet;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.SchemaDefinitions;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.TypeDeclarationsCollector;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamSerializerSetup;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
@@ -74,13 +75,14 @@ public final class TableDefinition implements ProtobufTypeExporter, ProtobufEntr
 		valueComponents.forEach( v -> v.collectTypeDefinitions( typesDefCollector ) );
 	}
 
-	public ProtoDataMapper createProtoDataMapper(RemoteCache remoteCache, SchemaDefinitions sd) {
+	public ProtoDataMapper createProtoDataMapper(RemoteCache remoteCache,
+			SchemaDefinitions sd, OgmProtoStreamMarshaller marshaller) {
 		try {
 			CompositeProtobufCoDec codec = new CompositeProtobufCoDec( tableName,
 					qualify( protobufTypeName ), qualify( protobufIdTypeName ),
 					keyComponents, valueComponents, remoteCache, sd );
 			SerializationContext serializationContext = ProtostreamSerializerSetup.buildSerializationContext( sd, codec );
-			return new ProtoDataMapper( codec, serializationContext );
+			return new ProtoDataMapper( codec, serializationContext, marshaller );
 		}
 		catch (DescriptorParserException | IOException e) {
 			throw new RuntimeException( e );

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/TableDefinition.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/TableDefinition.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.schema;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.CompositeProtobufCoDec;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.ProtofieldWriterSet;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.SchemaDefinitions;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protobuf.TypeDeclarationsCollector;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamSerializerSetup;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.type.spi.GridType;
+import org.hibernate.type.Type;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.protostream.DescriptorParserException;
+import org.infinispan.protostream.SerializationContext;
+
+public final class TableDefinition implements ProtobufTypeExporter, ProtobufEntryExporter {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private final String tableName;
+	private final String protobufTypeName;
+	private final String protobufIdTypeName;
+	private final String protobufPackageName;
+	private final ProtofieldWriterSet keyComponents = new ProtofieldWriterSet();
+	private final ProtofieldWriterSet valueComponents = new ProtofieldWriterSet();
+	private final Set<String> pkColumnNames = new HashSet<>();
+
+	public TableDefinition(String name, String protobufPackageName) {
+		this.tableName = name;
+		this.protobufTypeName = SanitationUtils.convertNameSafely( name );
+		this.protobufIdTypeName = SanitationUtils.toProtobufIdName( protobufTypeName );
+		this.protobufPackageName = protobufPackageName;
+	}
+
+	public void addColumnnDefinition(Column column, GridType gridType, Type ormType) {
+		//final boolean nullable = column.isNullable(); //Seems not reliable for FKs, don't use this to determine nullability.
+		final String name = column.getName();
+		if ( pkColumnNames.contains( name ) ) {
+			keyComponents.addMapping( name, gridType, ormType, false );
+			valueComponents.addMapping( name, gridType, ormType, false );
+		}
+		else {
+			valueComponents.addMapping( name, gridType, ormType, true );
+		}
+	}
+
+	@Override
+	public void exportProtobufEntry(StringBuilder output) {
+		exportProtobufEntry( protobufIdTypeName, keyComponents, output );
+		exportProtobufEntry( protobufTypeName, valueComponents, output );
+	}
+
+	private void exportProtobufEntry(String typeName, ProtofieldWriterSet fields, StringBuilder sb) {
+		sb.append( "\nmessage " ).append( typeName ).append( " {" );
+		fields.forEachProtobufFieldExporter( v -> v.exportProtobufFieldDefinition( sb ) );
+		sb.append( "\n}\n" );
+	}
+
+	@Override
+	public void collectTypeDefinitions(TypeDeclarationsCollector typesDefCollector) {
+		keyComponents.forEach( v -> v.collectTypeDefinitions( typesDefCollector ) );
+		valueComponents.forEach( v -> v.collectTypeDefinitions( typesDefCollector ) );
+	}
+
+	public ProtoDataMapper createProtoDataMapper(RemoteCache remoteCache, SchemaDefinitions sd) {
+		try {
+			CompositeProtobufCoDec codec = new CompositeProtobufCoDec( tableName,
+					qualify( protobufTypeName ), qualify( protobufIdTypeName ),
+					keyComponents, valueComponents, remoteCache, sd );
+			SerializationContext serializationContext = ProtostreamSerializerSetup.buildSerializationContext( sd, codec );
+			return new ProtoDataMapper( codec, serializationContext );
+		}
+		catch (DescriptorParserException | IOException e) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	private String qualify(final String name) {
+		return SanitationUtils.qualify( name, protobufPackageName );
+	}
+
+	public String getTableName() {
+		return tableName;
+	}
+
+	public void markAsPrimaryKey(String name) {
+		pkColumnNames.add( name );
+	}
+
+	public void validate() {
+		//This is triggered by certain Bag collection types:
+		//we can't support mapping w/o a primary key
+		//as they can't be mapped on a K/V system.
+		//The user can avoid the error by picking some ordering strategy.
+		if ( pkColumnNames.isEmpty() ) {
+			throw log.tableHasNoPrimaryKey( tableName );
+		}
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequenceHandler.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequenceHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.dialect.spi.NextValueRequest;
+
+/**
+ * Both IdSourceType.SEQUENCE and IdSourceType.TABLE are treated the same, essentially as a TABLE.
+ * With Hot Rod mapping, a TABLE maps to a Cache, so we can store multiple "sequences" in the same
+ * Cache by identifying each one by name. Each name is a key, so depending on perspective you
+ * might consider these as a named SEQUENCE rather than a TABLE strategy.
+ *
+ * We don't write primitives to the Cache but wrap them in proper Protobuf mapped messages to
+ * ensure to avoid conflicts with other mapped elements and to apply the column names of user's choice.
+ *
+ * The org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect#supportsSequences
+ * method returns 'false' so that we don't need a new Cache for each single sequence.
+ *
+ * See https://github.com/infinispan/infinispan/blob/master/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplaceWithVersionConcurrencyTest.java
+ *
+ * @see org.hibernate.ogm.model.key.spi.IdSourceKeyMetadata.IdSourceType
+ * @author Sanne Grinovero
+ */
+public class HotRodSequenceHandler {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private final InfinispanRemoteDatastoreProvider provider;
+	private final ConcurrentMap<String,SequencesPerCache> sequencesPerCache = new ConcurrentHashMap<>();
+	private final Map<String, SequenceTableDefinition> idSchemaPerName;
+
+	public HotRodSequenceHandler(
+			InfinispanRemoteDatastoreProvider infinispanRemoteDatastoreProvider,
+			Map<String, SequenceTableDefinition> idSchemaPerName) {
+		this.provider = infinispanRemoteDatastoreProvider;
+		this.idSchemaPerName = idSchemaPerName;
+	}
+
+	public Number getSequenceValue(NextValueRequest request) {
+		final String cacheName = request.getKey().getMetadata().getName();
+		final SequencesPerCache sequencesSet = sequencesPerCache.computeIfAbsent( cacheName, ( k ) -> {
+			SequenceTableDefinition sequenceTableDefinition = idSchemaPerName.get( cacheName );
+			if ( sequenceTableDefinition == null ) {
+				throw log.valueRequestedForUnknownSequence( request.getKey().getTable(), request.getKey().getColumnValue() );
+			}
+			return new SequencesPerCache(
+					provider,
+					sequenceTableDefinition,
+					provider.getCache( cacheName )
+			);
+		}
+		);
+		return sequencesSet.getSequenceValue( request );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequenceHandler.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequenceHandler.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
 import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
@@ -40,12 +41,15 @@ public class HotRodSequenceHandler {
 	private final InfinispanRemoteDatastoreProvider provider;
 	private final ConcurrentMap<String,SequencesPerCache> sequencesPerCache = new ConcurrentHashMap<>();
 	private final Map<String, SequenceTableDefinition> idSchemaPerName;
+	private final OgmProtoStreamMarshaller marshaller;
 
 	public HotRodSequenceHandler(
 			InfinispanRemoteDatastoreProvider infinispanRemoteDatastoreProvider,
+			OgmProtoStreamMarshaller marshaller,
 			Map<String, SequenceTableDefinition> idSchemaPerName) {
 		this.provider = infinispanRemoteDatastoreProvider;
 		this.idSchemaPerName = idSchemaPerName;
+		this.marshaller = marshaller;
 	}
 
 	public Number getSequenceValue(NextValueRequest request) {
@@ -58,7 +62,8 @@ public class HotRodSequenceHandler {
 			return new SequencesPerCache(
 					provider,
 					sequenceTableDefinition,
-					provider.getCache( cacheName )
+					provider.getCache( cacheName ),
+					marshaller
 			);
 		}
 		);

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequencer.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequencer.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.protostream.SerializationContext;
+
+/**
+ * This implements the atomic operations to model a source for named sequences.
+ * The SequenceId represents the name of this sequence and is specific to a Remote Cache.
+ *
+ * The implementation uses optimistic locking and currently has no fallback strategy:
+ * this is not suited for high contention scenarios. Not least, the Hot Rod client
+ * API doesn't allow to issue both the CAS operation and return the new version
+ * in case of failure, so the failure of an optimistic replace operation needs
+ * to re-read the version, introducing additional delays and making further
+ * failures more likely.
+ *
+ * TODO: see OGM-1161 to discuss options.
+ *
+ * @author Sanne Grinovero
+ */
+public final class HotRodSequencer {
+
+	private static final Log log = LoggerFactory.getLogger();
+
+	private final RemoteCache<SequenceId, Long> remoteCache;
+	private final SerializationContext serContext;
+	private final int increment;
+	private final SequenceId id;
+
+	private long lastKnownVersion = -1;
+	private Long lastKnownRemoteValue = null;
+
+	HotRodSequencer(
+			RemoteCache<SequenceId, Long> remoteCache,
+			SequenceTableDefinition sequenceTableDefinition,
+			NextValueRequest initialRequest,
+			SerializationContext serContext) {
+				this.remoteCache = remoteCache;
+				this.increment = initialRequest.getIncrement();
+				this.serContext = serContext;
+				this.id = new SequenceId( initialRequest.getKey().getColumnValue() );
+	}
+
+	Number getSequenceValue(NextValueRequest request) {
+		try {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			return getSequenceValueInternal( request );
+		}
+		finally {
+			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+		}
+	}
+
+	private synchronized Number getSequenceValueInternal(NextValueRequest request) {
+		if ( lastKnownRemoteValue == null ) {
+			Long initialValue = (long) request.getInitialValue();
+			Long previous = remoteCache.putIfAbsent( id, initialValue );
+			//Side effects: initialize fields with first known values from remote
+			getRemoteVersion();
+			if ( previous == null ) {
+				//if the putIfAbsent CAS was successfull, we can return already
+				return lastKnownRemoteValue;
+			}
+		}
+		//now to CAS:
+		int casCycle = 0;
+		while ( true ) {
+			//TODO introduce a safety net against excessive spinning?
+			//See https://hibernate.atlassian.net/browse/OGM-1161
+			Long targetValue = Long.valueOf( lastKnownRemoteValue.longValue() + increment );
+			boolean done = attemptCASWriteValue( targetValue );
+			if ( done ) {
+				return targetValue;
+			}
+			else {
+				//On failure of CAS, refresh what we know about the remote version and value:
+				getRemoteVersion();
+				casCycle++;
+				if ( casCycle % 10 == 0 ) {
+					log.excessiveCasForSequencer( id.getSegmentName() );
+				}
+			}
+		}
+	}
+
+	private boolean attemptCASWriteValue(final Long targetValue) {
+		boolean success = remoteCache.replaceWithVersion( id, targetValue, lastKnownVersion );
+		if ( success ) {
+			lastKnownVersion++;
+			lastKnownRemoteValue = targetValue;
+		}
+		return success;
+	}
+
+	private void getRemoteVersion() {
+		VersionedValue<Long> versioned = remoteCache.getVersioned( id );
+		if ( versioned == null ) {
+			//Critical failure (only happens if the Infinispan servers lost data)
+			//TODO
+		}
+		lastKnownVersion = versioned.getVersion();
+		lastKnownRemoteValue = (Long) versioned.getValue();
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequencer.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequencer.java
@@ -36,6 +36,7 @@ public final class HotRodSequencer {
 
 	private final RemoteCache<SequenceId, Long> remoteCache;
 	private final SerializationContext serContext;
+	private final OgmProtoStreamMarshaller marshaller;
 	private final int increment;
 	private final SequenceId id;
 
@@ -46,20 +47,22 @@ public final class HotRodSequencer {
 			RemoteCache<SequenceId, Long> remoteCache,
 			SequenceTableDefinition sequenceTableDefinition,
 			NextValueRequest initialRequest,
-			SerializationContext serContext) {
+			SerializationContext serContext,
+			OgmProtoStreamMarshaller marshaller) {
 				this.remoteCache = remoteCache;
 				this.increment = initialRequest.getIncrement();
 				this.serContext = serContext;
+				this.marshaller = marshaller;
 				this.id = new SequenceId( initialRequest.getKey().getColumnValue() );
 	}
 
 	Number getSequenceValue(NextValueRequest request) {
 		try {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( serContext );
+			marshaller.setCurrentSerializationContext( serContext );
 			return getSequenceValueInternal( request );
 		}
 		finally {
-			OgmProtoStreamMarshaller.setCurrentSerializationContext( null );
+			marshaller.setCurrentSerializationContext( null );
 		}
 	}
 

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequenceId.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequenceId.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import java.util.Objects;
+
+public final class SequenceId {
+
+	private final String segmentName;
+
+	public SequenceId(String segmentName) {
+		this.segmentName =  Objects.requireNonNull( segmentName );
+	}
+
+	public String getSegmentName() {
+		return segmentName;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequenceIdMarshaller.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequenceIdMarshaller.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import java.io.IOException;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.infinispan.protostream.MessageMarshaller;
+
+public final class SequenceIdMarshaller implements MessageMarshaller<SequenceId> {
+
+	private final String typeName;
+	private final SequenceTableDefinition std;
+
+	public SequenceIdMarshaller(SequenceTableDefinition std) {
+		this.typeName = std.getQualifiedIdMessageName();
+		this.std = std;
+	}
+
+	@Override
+	public Class<? extends SequenceId> getJavaClass() {
+		return SequenceId.class;
+	}
+
+	@Override
+	public String getTypeName() {
+		return typeName;
+	}
+
+	@Override
+	public SequenceId readFrom(org.infinispan.protostream.MessageMarshaller.ProtoStreamReader reader) throws IOException {
+		return std.readSequenceId( reader );
+	}
+
+	@Override
+	public void writeTo(org.infinispan.protostream.MessageMarshaller.ProtoStreamWriter writer, SequenceId t) throws IOException {
+		std.writeSequenceId( writer, t );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequencesCacheOperation.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequencesCacheOperation.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import org.infinispan.client.hotrod.RemoteCache;
+
+@FunctionalInterface
+public interface SequencesCacheOperation<T> {
+
+	T doOnCache(RemoteCache<SequenceId, Long> c);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequencesPerCache.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/SequencesPerCache.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.impl.sequences;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDefinition;
+import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.model.key.spi.IdSourceKey;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.protostream.SerializationContext;
+
+public class SequencesPerCache {
+
+	private final RemoteCache<SequenceId, Long> remoteCache;
+	private final SequenceTableDefinition sequenceTableDefinition;
+	private final ConcurrentMap<IdSourceKey,HotRodSequencer> sequencers = new ConcurrentHashMap<>();
+	private final SerializationContext serializationContext;
+
+	SequencesPerCache(
+			InfinispanRemoteDatastoreProvider provider,
+			SequenceTableDefinition sequenceTableDefinition,
+			RemoteCache<SequenceId, Long> remoteCache) {
+		this.sequenceTableDefinition = Objects.requireNonNull( sequenceTableDefinition );
+		this.remoteCache = Objects.requireNonNull( remoteCache );
+		this.serializationContext = provider.getSerializationContextForSequences( sequenceTableDefinition );
+	}
+
+	public Number getSequenceValue(NextValueRequest request) {
+		IdSourceKey key = request.getKey();
+		HotRodSequencer sequencer = sequencers.computeIfAbsent( key,  v -> {
+			return new HotRodSequencer( remoteCache, sequenceTableDefinition, request, serializationContext );
+		} );
+		return sequencer.getSequenceValue( request );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.logging.impl;
+
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.hibernate.HibernateException;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.FormatWith;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Log messages and exceptions of the Infinispan Remote dialect.
+ * The id range reserved for this dialect is 1701-1800.
+ */
+@MessageLogger(projectCode = "OGM")
+public interface Log extends org.hibernate.ogm.util.impl.Log {
+
+	@Message(id = 1701, value = "The Hot Rod client configuration was not defined")
+	HibernateException hotrodClientConfigurationMissing();
+
+	@Message(id = 1702, value = "Could not load the Hot Rod client configuration properties")
+	HibernateException failedLoadingHotRodConfigurationProperties(@Cause IOException e);
+
+	@Message(id = 1703, value = "Protobuf schema '%s' successfully deployed")
+	@LogMessage(level = INFO)
+	void successfullSchemaDeploy(String protobufName);
+
+	@Message(id = 1704, value = "Error deploying Protobuf schema '%s' to the server")
+	HibernateException errorAtSchemaDeploy(String generatedProtobufName, @Cause Exception schemaDeployError);
+
+	@Message(id = 1705, value = "Generated schema: \n===========\n%s\n===========\n")
+	@LogMessage(level = INFO)
+	void generatedSchema(String fullSchema);
+
+	@Message(id = 1706, value = "Can not read value '%d' as a char for protobuf field '%s' as it's out of range for a Short type")
+	HibernateException truncatingShortOnRead(int readInt, String name);
+
+	@Message(id = 1707, value = "Requested value for an unknown sequence on table '%s', segment '%s'")
+	HibernateException valueRequestedForUnknownSequence(String table, String columnValue);
+
+	@Message(id = 1708, value = "Error during parse of Protobuf schema")
+	HibernateException errorAtProtobufParsing(@Cause Exception e);
+
+	@Message(id = 1709, value = "The remote cache '%s' was expected to exist but is not defined on the server")
+	HibernateException expectedCacheNotDefined(String cacheName);
+
+	@Message(id = 1710, value = "The remote caches '%s' were expected to exist but are not defined on the server")
+	HibernateException expectedCachesNotDefined(@FormatWith(StringSetFormatter.class) Set<String> cacheNames);
+
+	@Message(id = 1711, value = "This domain model would cause table '%s' to be generated without a primary key." +
+			"This is not supported on an Infinispan Remote dialect: check that your embedded collections have a proper ordering definition." )
+	HibernateException tableHasNoPrimaryKey(String tableName);
+
+	@Message(id = 1712, value = "Sequence generator '%s' has been retrying optimistic CAS operations 10 times. "
+			+ "This is considered high contention and has a significant performance impact;"
+			+ " consider using a different id type, like UUID or application assigned.")
+	@LogMessage(level = WARN)
+	void excessiveCasForSequencer(String segmentName);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/LoggerFactory.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/LoggerFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.logging.impl;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Factory for obtaining {@link Logger} instances.
+ */
+public class LoggerFactory {
+
+	private static final CallerProvider callerProvider = new CallerProvider();
+
+	public static Log getLogger() {
+		return Logger.getMessageLogger( Log.class, callerProvider.getCallerClass().getCanonicalName() );
+	}
+
+	private static class CallerProvider extends SecurityManager {
+
+		public Class<?> getCallerClass() {
+			return getClassContext()[2];
+		}
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/StringSetFormatter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/StringSetFormatter.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.logging.impl;
+
+import java.util.Set;
+
+public final class StringSetFormatter {
+
+	private final Set<String> names;
+
+	public StringSetFormatter(Set<String> names) {
+		this.names = names;
+	}
+
+	@Override
+	public String toString() {
+		return names.toString();
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemoteEntityContext.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemoteEntityContext.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation;
+
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.KeyValueStoreEntityContext;
+
+/**
+ * Allows to configure Infinispan Remote specific options applying on a global level.
+ * These options may be overridden for single properties.
+ *
+ * @author Gunnar Morling
+ */
+public interface InfinispanRemoteEntityContext extends KeyValueStoreEntityContext<InfinispanRemoteEntityContext, InfinispanRemotePropertyContext> {
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemoteGlobalContext.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemoteGlobalContext.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation;
+
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.KeyValueStoreGlobalContext;
+
+/**
+ * Allows to configure Infinispan Remote specific options applying on a global level.
+ * These options may be overridden for single entities or properties.
+ *
+ * @author Gunnar Morling
+ */
+public interface InfinispanRemoteGlobalContext extends KeyValueStoreGlobalContext<InfinispanRemoteGlobalContext, InfinispanRemoteEntityContext> {
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemotePropertyContext.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/InfinispanRemotePropertyContext.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation;
+
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.KeyValueStorePropertyContext;
+
+/**
+ * Allows to configure Infinispan Remote specific options for a single property.
+ *
+ * @author Gunnar Morling
+ */
+public interface InfinispanRemotePropertyContext extends KeyValueStorePropertyContext<InfinispanRemoteEntityContext, InfinispanRemotePropertyContext> {
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemoteEntityContextImpl.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemoteEntityContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemoteEntityContext;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemotePropertyContext;
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.spi.BaseKeyValueStoreEntityContext;
+import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
+
+/**
+ * Converts Infinispan Remote entity-level options.
+ *
+ * @author Gunnar Morling
+ */
+public abstract class InfinispanRemoteEntityContextImpl extends BaseKeyValueStoreEntityContext<InfinispanRemoteEntityContext, InfinispanRemotePropertyContext> implements
+		InfinispanRemoteEntityContext {
+
+	public InfinispanRemoteEntityContextImpl(ConfigurationContext context) {
+		super( context );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemoteGlobalContextImpl.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemoteGlobalContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemoteEntityContext;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemoteGlobalContext;
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.spi.BaseKeyValueStoreGlobalContext;
+import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
+
+/**
+ * Converts global Infinispan Remote options.
+ *
+ * @author Gunnar Morling
+ */
+public abstract class InfinispanRemoteGlobalContextImpl extends BaseKeyValueStoreGlobalContext<InfinispanRemoteGlobalContext, InfinispanRemoteEntityContext> implements
+		InfinispanRemoteGlobalContext {
+
+	public InfinispanRemoteGlobalContextImpl(ConfigurationContext context) {
+		super( context );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemotePropertyContextImpl.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/options/navigation/impl/InfinispanRemotePropertyContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.options.navigation.impl;
+
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemoteEntityContext;
+import org.hibernate.ogm.datastore.infinispanremote.options.navigation.InfinispanRemotePropertyContext;
+import org.hibernate.ogm.datastore.keyvalue.options.navigation.spi.BaseKeyValueStorePropertyContext;
+import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
+
+/**
+ * Converts Infinispan Remote property-level options.
+ *
+ * @author Gunnar Morling
+ */
+public abstract class InfinispanRemotePropertyContextImpl extends BaseKeyValueStorePropertyContext<InfinispanRemoteEntityContext, InfinispanRemotePropertyContext> implements
+		InfinispanRemotePropertyContext {
+
+	public InfinispanRemotePropertyContextImpl(ConfigurationContext context) {
+		super( context );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/MapSchemaCapture.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/MapSchemaCapture.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.spi.schema;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class MapSchemaCapture implements SchemaCapture {
+
+	private final Map<String,String> map = new HashMap<>();
+
+	@Override
+	public void put(String generatedProtobufName, String generatedProtoschema) {
+		map.put( generatedProtobufName, generatedProtoschema );
+	}
+
+	public Map<String, String> asMap() {
+		return Collections.unmodifiableMap( map );
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/ProvidedSchemaOverride.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/ProvidedSchemaOverride.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.spi.schema;
+
+public final class ProvidedSchemaOverride implements SchemaOverride {
+
+	private final String schema;
+
+	public ProvidedSchemaOverride(String schema) {
+		this.schema = schema;
+	}
+
+	@Override
+	public String createProtobufSchema() {
+		return schema;
+	}
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/SchemaCapture.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/SchemaCapture.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.spi.schema;
+
+public interface SchemaCapture {
+
+	void put(String generatedProtobufName, String generatedProtoschema);
+
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/SchemaOverride.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/spi/schema/SchemaOverride.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.spi.schema;
+
+public interface SchemaOverride {
+
+	String createProtobufSchema();
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/ProtoBufSchemaTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/ProtoBufSchemaTest.java
@@ -1,0 +1,124 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.ogm.backendtck.associations.collection.unidirectional.Cloud;
+import org.hibernate.ogm.backendtck.associations.collection.unidirectional.SnowFlake;
+import org.hibernate.ogm.backendtck.id.Actor;
+import org.hibernate.ogm.backendtck.simpleentity.Helicopter;
+import org.hibernate.ogm.backendtck.simpleentity.Hero;
+import org.hibernate.ogm.backendtck.simpleentity.Hypothesis;
+import org.hibernate.ogm.backendtck.simpleentity.SuperHero;
+import org.hibernate.ogm.backendtck.type.Bookmark;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.MapSchemaCapture;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.ProvidedSchemaOverride;
+import org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaOverride;
+import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
+import org.hibernate.ogm.utils.TestHelper;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProtoBufSchemaTest {
+
+	private static final String DEFAULT_SCHEMA_NAME = "Hibernate_OGM_Generated_schema.proto";
+
+	/**
+	 * All protobuf files used for these tests should be nicely organized in a resource directory
+	 */
+	private static final String RESOURCES_NAME_PREFIX = "protoschema-expectations/";
+
+	/**
+	 * Name of UTF-8 Charset
+	 */
+	private static final String CHARSET_UTF8 = "UTF-8";
+
+	@Rule
+	public RemoteHotRodServerRule hotRodServer = new RemoteHotRodServerRule();
+
+	@Test
+	public void testingBasicCrudSchemaGeneration() throws IOException {
+		assertSchemaEquals( "Hypothesis_Helicopter.protobuf", Hypothesis.class, Helicopter.class );
+	}
+
+	@Test
+	public void testingSchemaGenerationWithJoins() throws IOException {
+		assertSchemaEquals( "Cloud_SnowFlake.protobuf", Cloud.class, SnowFlake.class );
+	}
+
+	@Test
+	public void testingSchemaGenerationInheritance() throws IOException {
+		assertSchemaEquals( "Hero_SuperHero.protobuf", Hero.class, SuperHero.class );
+	}
+
+	@Test
+	public void testingSequenceTableSchemaGeneration() throws IOException {
+		assertSchemaEquals( "sequenceTableGenerationTest.protobuf", Actor.class );
+	}
+
+	@Test
+	public void testingAllTypesSchemaGeneration() throws IOException {
+		assertSchemaEquals( "allTypesGenerationTest.protobuf", Bookmark.class );
+	}
+
+	@Test
+	public void illegalSchemaGetsRefused() throws IOException {
+		SchemaOverride enforcedSchema = new ProvidedSchemaOverride( readResourceAsString( "IllegalFormat.protobuf" ) );
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_remote" );
+		settings.put( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, "hotrod-client-testingconfiguration.properties" );
+		settings.put( InfinispanRemoteProperties.SCHEMA_OVERRIDE_SERVICE, enforcedSchema );
+		try {
+			try ( SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings, Hypothesis.class, Helicopter.class ) ) {
+				Assert.fail( "This should have refused to boot as the Protobuf schema is illegal" );
+			}
+		}
+		catch (HibernateException he) {
+			Assert.assertTrue( "Unexpected exception message", he.getMessage().startsWith( "OGM001704" ) );
+		}
+	}
+
+	private void assertSchemaEquals(String resourceName, Class<?>... types) throws IOException {
+		MapSchemaCapture schemaCapture = new MapSchemaCapture();
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_remote" );
+		settings.put( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, "hotrod-client-testingconfiguration.properties" );
+		settings.put( InfinispanRemoteProperties.SCHEMA_CAPTURE_SERVICE, schemaCapture );
+		final String generatedSchema;
+		try ( SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings, types ) ) {
+			generatedSchema = schemaCapture.asMap().get( DEFAULT_SCHEMA_NAME );
+		}
+		Assert.assertNotNull( generatedSchema );
+		final String expectedProtobufSchema = readResourceAsString( resourceName );
+		Assert.assertEquals( expectedProtobufSchema, generatedSchema );
+	}
+
+	private String readResourceAsString(String resourceName) throws IOException {
+		try ( InputStream resourceAsStream = ProtoBufSchemaTest.class.getClassLoader().getResourceAsStream( RESOURCES_NAME_PREFIX + resourceName ) ) {
+			Assert.assertNotNull( resourceAsStream );
+			StringBuilder buffer = new StringBuilder();
+			String line;
+			BufferedReader reader = new BufferedReader( new InputStreamReader( resourceAsStream, CHARSET_UTF8 ) );
+			while ( ( line = reader.readLine() ) != null ) {
+				buffer.append( line ).append( "\n" );
+			}
+			return buffer.toString();
+		}
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/WrongConfigurationBootTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/WrongConfigurationBootTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteTestHelper;
+import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
+import org.hibernate.ogm.utils.TestHelper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Verify we provide useful information in case the configuration file is not found.
+ *
+ * @author Sanne Grinovero (C) 2016 Red Hat Inc.
+ */
+public class WrongConfigurationBootTest {
+
+	@Rule
+	public RemoteHotRodServerRule hotRodServer = new RemoteHotRodServerRule();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testHotrodConnectionEstablished() {
+		tryBoot( "hotrod-client-testingconfiguration.properties" );
+	}
+
+	@Test
+	public void testIllegalConfigurationReported() throws Throwable {
+		final String configurationName = "does-not-exist-configuration-file.properties";
+		thrown.expect( HibernateException.class );
+		thrown.expectMessage( "Invalid URL given for configuration property '"
+				+ InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME
+				+ "': " + configurationName + "; The specified resource could not be found." );
+		try {
+			tryBoot( configurationName );
+		}
+		catch (Exception e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * @param configurationResourceName The Infinispan configuration resource to use to try booting OGM
+	 */
+	private void tryBoot(String configurationResourceName) {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_remote" );
+		settings.put( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, configurationResourceName );
+
+		SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings );
+
+		if ( sessionFactory != null ) {
+			try {
+				// trigger service initialization, and also verifies it actually uses Infinispan:
+				InfinispanRemoteTestHelper.getProvider( sessionFactory );
+			}
+			finally {
+				sessionFactory.close();
+			}
+		}
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/HotrodServerLifecycle.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/HotrodServerLifecycle.java
@@ -1,0 +1,85 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.utils;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunListener.ThreadSafe;
+
+/**
+ * This JUnit listener is registered in the Maven build as a global listener,
+ * making sure that the Hot Rod server is running and ready to serve
+ * requests when running the testsuite.
+ * As an alternative RemoteHotRodServerRule can be used as a JUnit Rule.
+ *
+ * @author Sanne Grinovero
+ */
+@ThreadSafe
+public class HotrodServerLifecycle extends RunListener {
+
+	private volatile RemoteHotRodServerRule server;
+
+	@Override
+	public void testRunStarted(Description description) throws Exception {
+		printEvent( "Test suite start detected" );
+		if ( server == null ) {
+			startHotRodServer();
+		}
+	}
+
+	@Override
+	public void testRunFinished(Result result) throws Exception {
+		if ( server != null ) {
+			printEvent( "Test suite end detected" );
+			shutdownServer();
+		}
+	}
+
+	@Override
+	public void testFinished(Description description) throws Exception {
+		if ( server != null ) {
+			// I'd like to do this, but in some cases currently OGM's tests
+			// are bit always fully independent in the same class.
+			// Not least, this would wipe out the schema.
+			//	resetServer();
+		}
+	}
+
+	private synchronized void resetServer() throws Exception {
+		if ( server != null ) {
+			server.resetHotRodServerState();
+			printEvent( "Hot Rod server has been reset" );
+		}
+	}
+
+	private synchronized void startHotRodServer() {
+		if ( server == null ) {
+			server = new RemoteHotRodServerRule();
+			try {
+				printEvent( "Starting HotRod Server" );
+				server.before();
+			}
+			catch (Throwable e) {
+				throw new RuntimeException( e );
+			}
+		}
+	}
+
+	private synchronized void shutdownServer() {
+		final RemoteHotRodServerRule serverLocal = server;
+		if ( serverLocal != null ) {
+			printEvent( "Terminating HotRod Server" );
+			serverLocal.after();
+		}
+	}
+
+	private void printEvent(String message) {
+		System.out.println( getClass().getCanonicalName() + ": " + message );
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteBackendTckHelper.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteBackendTckHelper.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.utils;
+
+import org.junit.ClassRule;
+import org.junit.extensions.cpsuite.ClasspathSuite;
+import org.junit.runner.RunWith;
+
+/**
+ * Helper class allowing you to run all or any specified subset of test available on the classpath.
+ *
+ * This method is for example useful to run all or parts of the <i>backendtck</i>.
+ *
+ * @author Hardy Ferentschik
+ * @author Sanne Grinovero
+ */
+@RunWith(ClasspathSuite.class)
+@ClasspathSuite.ClassnameFilters({ ".*CollectionUnidirectionalTest" })
+public class InfinispanRemoteBackendTckHelper {
+
+	@ClassRule
+	public static RemoteHotRodServerRule hotrodServer = new RemoteHotRodServerRule();
+
+	/**
+	 * Useful to occasionally start the Hot Rod server explicitly
+	 * and leave it running in background
+	 */
+	public static void main(String[] args) throws Throwable {
+		RemoteHotRodServerRule manualServerStart = new RemoteHotRodServerRule();
+		manualServerStart.before();
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
@@ -1,0 +1,203 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDataStoreConfiguration;
+import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect;
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.ProtoStreamMappingAdapter;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.datastore.spi.DatastoreConfiguration;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.key.spi.RowKey;
+import org.hibernate.ogm.persister.impl.OgmCollectionPersister;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.ogm.persister.impl.SingleTableOgmEntityPersister;
+import org.hibernate.ogm.utils.GridDialectTestHelper;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.persister.entity.EntityPersister;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+import org.infinispan.query.dsl.Query;
+
+/**
+ * @author Sanne Grinovero (C) 2015 Red Hat Inc.
+ */
+public class InfinispanRemoteTestHelper implements GridDialectTestHelper {
+
+	@Override
+	public long getNumberOfAssociations(Session session) {
+		return getNumberOfAssociations( session.getSessionFactory() );
+	}
+
+	@Override
+	public long getNumberOfAssociations(SessionFactory sessionFactory) {
+		final InfinispanRemoteDatastoreProvider datastoreProvider = getProvider( sessionFactory );
+		final SessionFactoryImplementor sessionFactoryImplementor = getSessionFactoryImplementor( sessionFactory );
+		Collection<CollectionPersister> persisters = sessionFactoryImplementor.getCollectionPersisters().values();
+		long totalCount = 0;
+		for ( CollectionPersister ep : persisters ) {
+			OgmCollectionPersister persister = (OgmCollectionPersister) ep;
+			String tableName = persister.getTableName();
+			SingleTableOgmEntityPersister owningPersister = (SingleTableOgmEntityPersister) persister.getOwnerEntityPersister().getEntityPersister();
+			String ownerTableName = owningPersister.getTableName();
+			totalCount += countAssociations( tableName, ownerTableName, datastoreProvider );
+		}
+		return totalCount;
+	}
+
+	@Override
+	public boolean backendSupportsTransactions() {
+		return false;
+	}
+
+	@Override
+	public void dropSchemaAndDatabase(SessionFactory sessionFactory) {
+		final InfinispanRemoteDatastoreProvider datastoreProvider = getProvider( sessionFactory );
+		final Set<String> mappedCacheNames = datastoreProvider.getMappedCacheNames();
+		final List<NotifyingFuture<Void>> tasks = new ArrayList<>( mappedCacheNames.size() );
+		mappedCacheNames.forEach( cacheName -> {
+			RemoteCache<Object,Object> cache = datastoreProvider.getCache( cacheName );
+			if ( cache != null ) {
+				tasks.add( cache.clearAsync() );
+			}
+		}
+		);
+		//Now block and wait for all clear operation to be performed:
+		tasks.forEach( resetOperation -> {
+			try {
+				resetOperation.get();
+			}
+			catch (InterruptedException ie) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException( ie );
+			}
+			catch (ExecutionException ee) {
+				throw new RuntimeException( ee );
+			}
+		} );
+	}
+
+	@Override
+	public Map<String, String> getEnvironmentProperties() {
+		return null;
+	}
+
+	@Override
+	public long getNumberOfAssociations(SessionFactory sessionFactory, AssociationStorageType type) {
+		if ( type == AssociationStorageType.IN_ENTITY ) {
+			throw new IllegalArgumentException( "IN_ENTITY association storage type not supported" );
+		}
+		else {
+			return getNumberOfAssociations( sessionFactory );
+		}
+	}
+
+	@Override
+	public GridDialect getGridDialect(DatastoreProvider datastoreProvider) {
+		return new InfinispanRemoteDialect( (InfinispanRemoteDatastoreProvider) datastoreProvider );
+	}
+
+	@Override
+	public Class<? extends DatastoreConfiguration<?>> getDatastoreConfigurationType() {
+		return InfinispanRemoteDataStoreConfiguration.class;
+	}
+
+	@Override
+	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
+		final InfinispanRemoteDatastoreProvider datastoreProvider = getProvider( session );
+		ProtoStreamMappingAdapter mapper = datastoreProvider.getDataMapperForCache( key.getTable() );
+		ProtostreamId idBuffer = mapper.createIdPayload( key.getColumnNames(), key.getColumnValues() );
+		ProtostreamPayload payload = mapper.withinCacheEncodingContext( c -> c.get( idBuffer ) );
+		return payload.toMap();
+	}
+
+	private long countAssociations(String tableName, String ownerTableName, InfinispanRemoteDatastoreProvider datastoreProvider) {
+		final String[] ownerIdentifyingColumnNames = datastoreProvider.getDataMapperForCache( ownerTableName ).listIdColumnNames();
+		final ProtoStreamMappingAdapter mapper = datastoreProvider.getDataMapperForCache( tableName );
+		return mapper.withinCacheEncodingContext( c -> {
+			Query queryAll = Search.getQueryFactory( c ).from( ProtostreamPayload.class ).build();
+			Set<RowKey> resultsCollector = new HashSet<>();
+			try ( CloseableIterator<Entry<Object,Object>> iterator = c.retrieveEntriesByQuery( queryAll, null, 100 ) ) {
+				while ( iterator.hasNext() ) {
+					Entry<Object,Object> e  = iterator.next();
+					ProtostreamPayload value = ( (ProtostreamPayload) e.getValue() );
+					Map<String, Object> entryObject = value.toMap();
+					Object[] columnValues = new Object[ownerIdentifyingColumnNames.length];
+					for (int i = 0; i < columnValues.length; i++) {
+						columnValues[i] = entryObject.get( ownerIdentifyingColumnNames[i] );
+					}
+					RowKey entryKey = new RowKey( ownerIdentifyingColumnNames, columnValues );
+					resultsCollector.add( entryKey );
+				}
+			}
+			return (long) resultsCollector.size();
+		} );
+	}
+
+	@Override
+	public long getNumberOfEntities(SessionFactory sessionFactory) {
+		final InfinispanRemoteDatastoreProvider datastoreProvider = getProvider( sessionFactory );
+		final SessionFactoryImplementor sessionFactoryImplementor = getSessionFactoryImplementor( sessionFactory );
+		Collection<EntityPersister> persisters = sessionFactoryImplementor.getEntityPersisters().values();
+		final AtomicLong counter = new AtomicLong();
+		for ( EntityPersister ep : persisters ) {
+			OgmEntityPersister persister = (OgmEntityPersister) ep;
+			String tableName = persister.getTableName();
+			int increment = datastoreProvider.getCache( tableName ).size();
+			counter.addAndGet( increment );
+		}
+		return counter.get();
+	}
+
+	@Override
+	public long getNumberOfEntities(Session session) {
+		return getNumberOfEntities( session.getSessionFactory() );
+	}
+
+	// Various static helpers below:
+
+	private static SessionFactoryImplementor getSessionFactoryImplementor(Session session) {
+		return getSessionFactoryImplementor( session.getSessionFactory() );
+	}
+
+	private static SessionFactoryImplementor getSessionFactoryImplementor(SessionFactory sessionFactory) {
+		return ( (SessionFactoryImplementor) sessionFactory );
+	}
+
+	public static InfinispanRemoteDatastoreProvider getProvider(Session session) {
+		return getProvider( session.getSessionFactory() );
+	}
+
+	public static InfinispanRemoteDatastoreProvider getProvider(SessionFactory sessionFactory) {
+		DatastoreProvider provider = ( (SessionFactoryImplementor) sessionFactory ).getServiceRegistry().getService( DatastoreProvider.class );
+		if ( !( InfinispanRemoteDatastoreProvider.class.isInstance( provider ) ) ) {
+			throw new RuntimeException( "Not testing with Infinispan Remote, cannot extract underlying cache" );
+		}
+		return InfinispanRemoteDatastoreProvider.class.cast( provider );
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/RemoteHotRodServerRule.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/RemoteHotRodServerRule.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.utils;
+
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.util.FileLookupFactory;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+
+/**
+ * A JUnit rule which starts the Hot Rod server, and finally closes it.
+ *
+ * @author Sanne Grinovero
+ */
+public final class RemoteHotRodServerRule extends org.junit.rules.ExternalResource {
+
+	public static final String CACHEMANAGER_CONFIGURATION_RESOURCE = "hotrod-server-singleton.xml";
+	public static final int HOTRODSERVER_PORT = 11222;
+
+	/**
+	 * An atomic static flag to make it possible to reuse this class
+	 * both as a global JUnit listener and as a Rule, and avoid
+	 * starting the server twice.
+	 */
+	private static final AtomicBoolean running = new AtomicBoolean();
+
+	private EmbeddedCacheManager manager;
+	private HotRodServer hotRodServer;
+
+	@Override
+	public void before() throws Exception {
+		//Synchronize on the static field to defend against concurrent launches,
+		//e.g. the usage as JUnit Rule concurrently with the usage as global test listener in Surefire.
+		synchronized ( running ) {
+			if ( running.compareAndSet( false, true ) ) {
+				ConfigurationBuilderHolder cfgBuilder;
+				try ( InputStream inputStream = FileLookupFactory.newInstance()
+						.lookupFileStrict( CACHEMANAGER_CONFIGURATION_RESOURCE, RemoteHotRodServerRule.class.getClassLoader() ) ) {
+					cfgBuilder = new ParserRegistry().parse( inputStream );
+				}
+				manager = new DefaultCacheManager( cfgBuilder, true );
+				HotRodServerConfigurationBuilder hotRodServerConfigurationBuilder = new HotRodServerConfigurationBuilder()
+						.port( HOTRODSERVER_PORT )
+						.host( "localhost" );
+				hotRodServer = HotRodClientTestingUtil.startHotRodServer( manager, HOTRODSERVER_PORT, hotRodServerConfigurationBuilder );
+			}
+		}
+	}
+
+	@Override
+	public void after() {
+		synchronized ( running ) {
+			if ( hotRodServer != null ) {
+				running.set( false );
+				hotRodServer.stop();
+			}
+			TestingUtil.killCacheManagers( manager );
+		}
+	}
+
+	/**
+	 * Clears the state of all caches in the Infinispan server.
+	 * Warning: this wipes out both the data and the Protobuf schema.
+	 */
+	public void resetHotRodServerState() throws Exception {
+		synchronized ( running ) {
+			final EmbeddedCacheManager cm = manager;
+			if ( cm != null ) {
+				cm.getCacheNames().forEach(
+						name -> cm.getCache( name ).clear()
+					);
+			}
+		}
+	}
+
+}

--- a/infinispan-remote/src/test/resources/findInterrupt.btm
+++ b/infinispan-remote/src/test/resources/findInterrupt.btm
@@ -1,0 +1,8 @@
+# This is extremely useful to find issues with interaction with Infinispan
+
+RULE findInterrupt
+CLASS java.lang.Thread
+METHOD interrupt
+IF TRUE
+DO traceStack("found the caller!\n", 10)
+ENDRULE

--- a/infinispan-remote/src/test/resources/hibernate.properties
+++ b/infinispan-remote/src/test/resources/hibernate.properties
@@ -1,0 +1,9 @@
+#
+# Hibernate OGM, Domain model persistence for NoSQL datastores
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+hibernate.search.lucene_version=LUCENE_CURRENT
+hibernate.ogm.datastore.provider=infinispan_remote
+hibernate.ogm.infinispan_remote.configuration_resource_name=hotrod-client-testingconfiguration.properties

--- a/infinispan-remote/src/test/resources/hotrod-client-testingconfiguration.properties
+++ b/infinispan-remote/src/test/resources/hotrod-client-testingconfiguration.properties
@@ -1,0 +1,25 @@
+# hopefully this port is available
+infinispan.client.hotrod.server_list = 127.0.0.1:11222
+
+infinispan.client.hotrod.marshaller = org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller
+infinispan.client.hotrod.async_executor_factory = org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory
+infinispan.client.hotrod.default_executor_factory.pool_size = 1
+infinispan.client.hotrod.default_executor_factory.queue_size = 100
+infinispan.client.hotrod.tcp_no_delay = true
+infinispan.client.hotrod.tcp_keep_alive = false
+
+#TODO could we estimate these in advance from our knowledge of the data model?
+infinispan.client.hotrod.key_size_estimate = 64
+infinispan.client.hotrod.value_size_estimate = 512
+#This is critical: [FIXME check for this to be set?]
+infinispan.client.hotrod.force_return_values = true
+
+## below is connection pooling config
+maxActive=-1
+maxTotal = -1
+maxIdle = -1
+whenExhaustedAction = 1
+timeBetweenEvictionRunsMillis=120000
+minEvictableIdleTimeMillis=300000
+testWhileIdle = true
+minIdle = 1

--- a/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
+++ b/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
@@ -147,6 +147,7 @@
         <local-cache name="Race_Runners" />
         <local-cache name="Runner" />
         <local-cache name="Printer" />
+        <local-cache name="MagicCard" />
 
         <local-cache name="sequences" />
         <local-cache name="hibernate_sequences" />

--- a/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
+++ b/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+
+<!--
+    This is the testing configuration, running in LOCAL clustering mode to speedup tests.
+-->
+<infinispan
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+    xmlns="urn:infinispan:config:8.2">
+
+    <cache-container name="HibernateOGM-Testsuite" default-cache="DEFAULT" statistics="false">
+
+        <jmx duplicate-domains="true"/>
+
+        <!-- *************************** -->
+        <!--   Default cache settings    -->
+        <!-- *************************** -->
+        <local-cache name="DEFAULT">
+            <data-container
+                  key-equivalence="org.infinispan.commons.equivalence.ByteArrayEquivalence"
+                  value-equivalence="org.infinispan.commons.equivalence.ByteArrayEquivalence" />
+            <expiration interval="-1"/>
+        </local-cache>
+
+        <!-- Currently the needed caches need to be enabled server-side (can't be created from the client) -->
+        <local-cache name="Hypothesis" />
+        <local-cache name="Helicopter" />
+        <local-cache name="Cloud" />
+        <local-cache name="SnowFlake" />
+        <local-cache name="joinBackupSnowflakes" />
+        <local-cache name="joinProducedSnowflakes" />
+        <local-cache name="Insurance" />
+        <local-cache name="Song" />
+        <local-cache name="Actor" />
+        <local-cache name="CondominiumBuilding" />
+        <local-cache name="CondominiumBuilding_Condominium" />
+        <local-cache name="Tower" />
+        <local-cache name="tower_floor" />
+        <local-cache name="Condominium" />
+        <local-cache name="Floor" />
+        <local-cache name="Pulsar" />
+        <local-cache name="Planet" />
+        <local-cache name="StoryGame" />
+        <local-cache name="StoryGame_chaoticBranches" />
+        <local-cache name="StoryGame_neutralBranches" />
+        <local-cache name="StoryGame_evilBranch.additionalEndings" />
+        <local-cache name="StoryGame_goodBranch.additionalEndings" />
+        <local-cache name="Video" />
+        <local-cache name="Music" />
+        <local-cache name="Composer" />
+        <local-cache name="MakeupArtistWithCompositeKey" />
+        <local-cache name="MakeupArtist" />
+        <local-cache name="DistributedRevisionControl" />
+        <local-cache name="Feeling" />
+        <local-cache name="Bookmark" />
+        <local-cache name="Hero" />
+        <local-cache name="Court" />
+        <local-cache name="Member" />
+        <local-cache name="SalesGuy" />
+        <local-cache name="Brewery" />
+        <local-cache name="Beer" />
+        <local-cache name="JUG" />
+        <local-cache name="Employee" />
+        <local-cache name="Game" />
+        <local-cache name="SalesForce" />
+        <local-cache name="Employer" />
+        <local-cache name="BoardGame" />
+        <local-cache name="Movie" />
+        <local-cache name="Shipment" />
+        <local-cache name="IndexedLabel" />
+        <local-cache name="IndexedNews" />
+        <local-cache name="CoffeeMug" />
+        <local-cache name="Lid" />
+        <local-cache name="Tournament" />
+        <local-cache name="Director" />
+        <local-cache name="Director_Tournament" />
+        <local-cache name="Poem" />
+        <local-cache name="CommunityMember" />
+        <local-cache name="employee" />
+        <local-cache name="Galaxy_stars" />
+        <local-cache name="Galaxy" />
+        <local-cache name="Author" />
+        <local-cache name="Address" />
+        <local-cache name="User_PhoneNumber" />
+        <local-cache name="User" />
+        <local-cache name="AlTERNATIVE_PHONE_NUMBER" />
+        <local-cache name="Nicks" />
+        <local-cache name="User_Address" />
+        <local-cache name="PhoneNumber" />
+        <local-cache name="AlTERNATIVE_PRIORITY" />
+        <local-cache name="Enterprise_departments" />
+        <local-cache name="Enterprise" />
+        <local-cache name="Enterprise_revenueByDepartment" />
+        <local-cache name="News" />
+        <local-cache name="Label" />
+        <local-cache name="HeroClub_Hero" />
+        <local-cache name="Hero" />
+        <local-cache name="HeroClub" />
+        <local-cache name="Student" />
+        <local-cache name="Contact" />
+        <local-cache name="Product" />
+        <local-cache name="Zoo_animals" />
+        <local-cache name="Husband" />
+        <local-cache name="PolarCloud" />
+        <local-cache name="Account" />
+        <local-cache name="Order" />
+        <local-cache name="MultiAddressAccount" />
+        <local-cache name="Contact" />
+        <local-cache name="SingleBoardComputer" />
+        <local-cache name="ClassRoom" />
+        <local-cache name="ClassRoom_Student" />
+        <local-cache name="Wheel" />
+        <local-cache name="Basket" />
+        <local-cache name="Cavalier" />
+        <local-cache name="Zoo" />
+        <local-cache name="PolarCloud_SnowFlake" />
+        <local-cache name="AnnotatedCloud_SnowFlake" />
+        <local-cache name="Vehicule" />
+        <local-cache name="NetworkSwitch" />
+        <local-cache name="Horse" />
+        <local-cache name="PatchCable" />
+        <local-cache name="Wife" />
+        <local-cache name="AnnotatedCloud" />
+        <local-cache name="AccountWithPhone" />
+        <local-cache name="AccountWithPhone_phoneNumber.alternatives" />
+        <local-cache name="MultiAddressAccount_addresses" />
+        <local-cache name="Order_shippingAddress.phone.alternatives" />
+        <local-cache name="Basket_Product" />
+        <local-cache name="AccountOwner" />
+        <local-cache name="AccountOwner_BankAccount" />
+        <local-cache name="BankAccount" />
+        <local-cache name="Car" />
+        <local-cache name="Car_Tire" />
+        <local-cache name="Tire" />
+        <local-cache name="Child" />
+        <local-cache name="Father" />
+        <local-cache name="Father_child" />
+        <local-cache name="GrandMother" />
+        <local-cache name="GrandMother_grandChildren" />
+        <local-cache name="Race" />
+        <local-cache name="Race_Runners" />
+        <local-cache name="Runner" />
+        <local-cache name="Printer" />
+
+        <local-cache name="sequences" />
+        <local-cache name="hibernate_sequences" />
+
+    </cache-container>
+</infinispan>

--- a/infinispan-remote/src/test/resources/log4j.properties
+++ b/infinispan-remote/src/test/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Hibernate OGM, Domain model persistence for NoSQL datastores
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+log4j.rootLogger=debug, stdout
+
+log4j.logger.org.hibernate=info
+log4j.logger.org.hibernate.ogm=debug
+log4j.logger.org.infinispan=info
+log4j.logger.org.jgroups=info
+log4j.logger.com.arjuna=info
+#it's noisy:
+log4j.logger.org.infinispan.expiration=error
+log4j.logger.org.infinispan.client.hotrod.impl.iteration=error
+log4j.logger.io.netty=error

--- a/infinispan-remote/src/test/resources/protoschema-expectations/Cloud_SnowFlake.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/Cloud_SnowFlake.protobuf
@@ -1,0 +1,40 @@
+package HibernateOGMGenerated;
+
+message SnowFlake_id {
+	required string id = 1;
+}
+
+message SnowFlake {
+	required string id = 1;
+	optional string description = 2;
+}
+
+message joinBackupSnowflakes_id {
+	required string Cloud_id = 1;
+	required string backupSnowFlakes_id = 2;
+}
+
+message joinBackupSnowflakes {
+	required string Cloud_id = 1;
+	required string backupSnowFlakes_id = 2;
+}
+
+message joinProducedSnowflakes_id {
+	required string Cloud_id = 1;
+	required string producedSnowFlakes_id = 2;
+}
+
+message joinProducedSnowflakes {
+	required string Cloud_id = 1;
+	required string producedSnowFlakes_id = 2;
+}
+
+message Cloud_id {
+	required string id = 1;
+}
+
+message Cloud {
+	required string id = 1;
+	optional double length = 2;
+	optional string type = 3;
+}

--- a/infinispan-remote/src/test/resources/protoschema-expectations/Hero_SuperHero.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/Hero_SuperHero.protobuf
@@ -1,0 +1,11 @@
+package HibernateOGMGenerated;
+
+message Hero_id {
+	required string name = 1;
+}
+
+message Hero {
+	optional string DTYPE = 1;
+	required string name = 2;
+	optional string specialPower = 3;
+}

--- a/infinispan-remote/src/test/resources/protoschema-expectations/Hypothesis_Helicopter.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/Hypothesis_Helicopter.protobuf
@@ -1,0 +1,20 @@
+package HibernateOGMGenerated;
+
+message Helicopter_id {
+	required string UUID = 1;
+}
+
+message Helicopter {
+	required string UUID = 1;
+	optional string name = 2;
+}
+
+message Hypothesis_id {
+	required string id = 1;
+}
+
+message Hypothesis {
+	required string id = 1;
+	optional string description = 2;
+	optional int32 pos = 3;
+}

--- a/infinispan-remote/src/test/resources/protoschema-expectations/IllegalFormat.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/IllegalFormat.protobuf
@@ -1,0 +1,6 @@
+package HibernateOGMGenerated;
+
+message SnowFlake {
+	required string id = 1;
+	optional string description = 1;
+}

--- a/infinispan-remote/src/test/resources/protoschema-expectations/allTypesGenerationTest.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/allTypesGenerationTest.protobuf
@@ -1,0 +1,36 @@
+package HibernateOGMGenerated;
+
+message Bookmark_id {
+	required string id = 1;
+}
+
+message Bookmark {
+	required string id = 1;
+	optional string classifier = 2;
+	optional int32 classifierAsOrdinal = 3;
+	optional int64 creationCalendar = 4;
+	optional int64 creationDate = 5;
+	optional bytes data = 6;
+	optional string delimiter = 7;
+	optional string description = 8;
+	optional int64 destructionCalendar = 9;
+	optional int64 destructionDate = 10;
+	optional bytes displayMask = 11;
+	optional bool favourite = 12;
+	optional string isPrivate = 13;
+	optional string isRead = 14;
+	optional int32 isShared = 15;
+	optional bytes lob = 16;
+	optional bytes lobWithLong = 17;
+	optional string lobWithString = 18;
+	optional string serialNumber = 19;
+	optional string siteWeight = 20;
+	optional int32 stockCount = 21;
+	optional double taxPercentage = 22;
+	optional int64 updateTime = 23;
+	optional string url = 24;
+	optional int32 urlPort = 25;
+	optional int64 userId = 26;
+	optional string visitCount = 27;
+	optional float visitRatio = 28;
+}

--- a/infinispan-remote/src/test/resources/protoschema-expectations/sequenceTableGenerationTest.protobuf
+++ b/infinispan-remote/src/test/resources/protoschema-expectations/sequenceTableGenerationTest.protobuf
@@ -1,0 +1,19 @@
+package HibernateOGMGenerated;
+
+message hibernate_sequences_id {
+	required string sequence_name = 1;
+}
+
+message hibernate_sequences {
+	required int64 next_val = 2;
+}
+
+message Actor_id {
+	required int64 id = 1;
+}
+
+message Actor {
+	required int64 id = 1;
+	optional string bestMovieTitle = 2;
+	optional string name = 3;
+}

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
         <jboss.home>${project.build.directory}/wildfly-${version.wildfly}</jboss.home>
+        <infinispan-server.home>${project.build.directory}/infinispan-server-${infinispanVersion}</infinispan-server.home>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Skipping enforcer plug-in as AS/Arquillian cause several dependency
@@ -133,6 +134,17 @@
                                         <overWrite>false</overWrite>
                                         <outputDirectory>${jboss.home}/modules</outputDirectory>
                                     </artifactItem>
+                                    <!--
+                                      Currently these are (mistakenly?) included in the above package org.infinispan:infinispan-as-embedded-modules
+                                      See https://issues.jboss.org/browse/ISPN-7006
+                                    <artifactItem>
+                                        <groupId>org.infinispan</groupId>
+                                        <artifactId>infinispan-as-client-modules</artifactId>
+                                        <version>${infinispanVersion}</version>
+                                        <type>zip</type>
+                                        <overWrite>false</overWrite>
+                                        <outputDirectory>${jboss.home}/modules</outputDirectory>
+                                    </artifactItem> -->
                                     <artifactItem>
                                         <groupId>org.hibernate</groupId>
                                         <artifactId>hibernate-search-modules</artifactId>
@@ -171,6 +183,84 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-ogm-redis</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Dependencies for Hot Rod server bootstrap -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-hotrod</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-hotrod</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -446,6 +536,37 @@
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>hotrod-server</id>
+            <activation>
+                <property>
+                    <name>!skipHotRod</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>neo4j-integration-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>**/infinispanremote/*IT.java</include>
+                                    </includes>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodSearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodSearchIntegrationIT.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.integration.infinispanremote;
+
+import org.hibernate.ogm.test.integration.testcase.MagiccardsDatabaseScenario;
+import org.hibernate.ogm.test.integration.testcase.controller.MagicCardsCollectionBean;
+import org.hibernate.ogm.test.integration.testcase.model.MagicCard;
+import org.hibernate.ogm.test.integration.testcase.util.ModulesHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for the combination of Hibernate OGM and Hibernate Search modules on WildFly,
+ * using a remote Infinispan instance over Hot Rod.
+ *
+ * @author Sanne Grinovero
+ */
+@RunWith(Arquillian.class)
+public class HotRodSearchIntegrationIT extends MagiccardsDatabaseScenario {
+
+	@Deployment
+	public static Archive<?> createTestArchive() {
+		WebArchive webArchive = ShrinkWrap
+				.create( WebArchive.class, "modules-magic-searchit-hotrod.war" )
+				.addClasses( MagicCard.class, MagicCardsCollectionBean.class, HotRodSearchIntegrationIT.class, MagiccardsDatabaseScenario.class );
+		String persistenceXml = ModulesHelper.injectVariables( persistenceXml().exportAsString() );
+		webArchive.addAsResource( new StringAsset( persistenceXml ), "META-INF/persistence.xml" );
+		webArchive.addAsResource( "hotrod-client-testingconfiguration.properties", "hotrod-client-configuration.properties" );
+		ModulesHelper.addModulesDependencyDeclaration( webArchive, "org.hibernate.ogm:${hibernate-ogm.module.slot} services, org.hibernate.ogm.infinispan-remote:${hibernate-ogm.module.slot} services" );
+		return webArchive;
+	}
+
+	private static PersistenceDescriptor persistenceXml() {
+		return Descriptors.create( PersistenceDescriptor.class )
+				.version( "2.0" )
+				.createPersistenceUnit()
+					.name( "primary" )
+					.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
+					.getOrCreateProperties()
+						.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
+						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_remote" ).up()
+						.createProperty().name( "hibernate.ogm.infinispan_remote.configuration_resource_name" ).value( "hotrod-client-configuration.properties" ).up()
+						.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
+				.up().up();
+	}
+
+}

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodServerLifecycleManager.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodServerLifecycleManager.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.integration.infinispanremote;
+
+import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
+import org.jboss.arquillian.container.spi.event.container.AfterUnDeploy;
+import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
+import org.jboss.arquillian.container.spi.event.container.DeployerEvent;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.shrinkwrap.api.Archive;
+
+/**
+ * Arquillian extension to start/stop the Hot Rod Server
+ *
+ * @author Sanne Grinovero
+ */
+public class HotRodServerLifecycleManager implements org.jboss.arquillian.core.spi.LoadableExtension {
+
+	private final RemoteHotRodServerRule server = new RemoteHotRodServerRule();
+	private int startedContainers = 0;
+
+	public synchronized void startDatabase(@Observes BeforeDeploy event) {
+		if ( ! hotRodRequired( event ) ) {
+			return;
+		}
+		if ( startedContainers == 0 ) {
+			try {
+				server.before();
+				System.out.println( "Hot Rod Server started" );
+			}
+			catch (Exception e) {
+				System.err.println( "Failed to start Hot Rod Server" );
+				e.printStackTrace();
+			}
+			startedContainers++;
+		}
+	}
+
+	public synchronized void stopDatabase(@Observes AfterUnDeploy event) {
+		if ( ! hotRodRequired( event ) ) {
+			return;
+		}
+		startedContainers--;
+		if ( startedContainers == 0 ) {
+			server.after();
+			System.out.println( "Hot Rod Server was shut down" );
+		}
+	}
+
+	@Override
+	public void register(ExtensionBuilder builder) {
+		builder.observer( HotRodServerLifecycleManager.class );
+	}
+
+	private boolean hotRodRequired(DeployerEvent event) {
+		Archive<?> archive = event.getDeployment().getArchive();
+		return archive.contains( "/WEB-INF/classes/hotrod-client-configuration.properties" );
+	}
+
+}

--- a/integrationtest/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/integrationtest/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.hibernate.ogm.test.integration.infinispanremote.HotRodServerLifecycleManager

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -27,6 +27,7 @@
         <hibernate.ogm.jipijapa.module.slot>${project.version}</hibernate.ogm.jipijapa.module.slot>
         <hibernate.ogm.ehcache.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.ehcache.module.slot>
         <hibernate.ogm.infinispan.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.infinispan.module.slot>
+        <hibernate.ogm.infinispan-remote.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.infinispan-remote.module.slot>
         <hibernate.ogm.cassandra.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.cassandra.module.slot>
         <hibernate.ogm.mongodb.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.mongodb.module.slot>
         <hibernate.ogm.neo4j.module.slot>${hibernate.ogm.module.slot}</hibernate.ogm.neo4j.module.slot>
@@ -72,6 +73,11 @@
                     <artifactId>hibernate-search-engine</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-ogm-infinispan-remote</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hibernate.ogm</groupId>

--- a/modules/src/main/aliases/ogm/infinispan-remote/module.xml
+++ b/modules/src/main/aliases/ogm/infinispan-remote/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module-alias xmlns="urn:jboss:module:1.1"
+    name="org.hibernate.ogm.infinispan-remote" slot="main"
+    target-name="org.hibernate.ogm.infinispan-remote" target-slot="${hibernate.ogm.infinispan-remote.module.slot}" />

--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -45,8 +45,18 @@
              <filtered>true</filtered>
         </file>
         <file>
+             <source>${module.xml.basedir}/ogm/infinispan-remote/module.xml</source>
+             <outputDirectory>/org/hibernate/ogm/infinispan-remote/${hibernate.ogm.infinispan-remote.module.slot}</outputDirectory>
+             <filtered>true</filtered>
+        </file>
+        <file>
              <source>${module.xml.aliases.basedir}/ogm/infinispan/module.xml</source>
              <outputDirectory>/org/hibernate/ogm/infinispan/main</outputDirectory>
+             <filtered>true</filtered>
+        </file>
+        <file>
+             <source>${module.xml.aliases.basedir}/ogm/infinispan-remote/module.xml</source>
+             <outputDirectory>/org/hibernate/ogm/infinispan-remote/main</outputDirectory>
              <filtered>true</filtered>
         </file>
         <file>
@@ -165,6 +175,15 @@
             <unpack>false</unpack>
             <includes>
                 <include>org.hibernate.ogm:hibernate-ogm-infinispan</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>org/hibernate/ogm/infinispan-remote/${hibernate.ogm.infinispan-remote.module.slot}</outputDirectory>
+            <useTransitiveFiltering>false</useTransitiveFiltering>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.hibernate.ogm:hibernate-ogm-infinispan-remote</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/modules/src/main/modules/ogm/infinispan-remote/module.xml
+++ b/modules/src/main/modules/ogm/infinispan-remote/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate OGM, Domain model persistence for NoSQL datastores
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.ogm.infinispan-remote" slot="${hibernate.ogm.infinispan-remote.module.slot}">
+    <resources>
+        <resource-root path="hibernate-ogm-infinispan-remote-${project.version}.jar" />
+    </resources>
+    <dependencies>
+        <module name="org.hibernate.ogm" slot="${hibernate.ogm.module.slot}" />
+        <module name="org.hibernate.hql" slot="${hibernate.hql.module.slot}" />
+
+        <module name="org.infinispan.client.hotrod" slot="${infinispan.module.slot}" />
+        <module name="org.infinispan.protostream" slot="${infinispan.module.slot}" />
+        <module name="org.infinispan.commons" slot="${infinispan.module.slot}" />
+        <module name="org.infinispan.query.dsl" slot="${infinispan.module.slot}" />
+        <module name="org.infinispan.query.remote.client" slot="${infinispan.module.slot}" />
+
+        <module name="javax.api" />
+        <module name="javax.persistence.api" />
+        <module name="javax.transaction.api" />
+        <module name="org.jboss.logging" />
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>core</module>
         <!-- <module>ehcache</module> Is only enabled when not running in Java 9: see the profiles section-->
         <!-- <module>infinispan</module> Is only enabled when not running in Java 9: see the profiles section-->
+        <!-- <module>infinispan-remote</module> Is only enabled when not running in Java 9: see the profiles section-->
         <module>mongodb</module>
         <!-- <module>neo4j</module> Is only enabled when not running in Java 9: see the profiles section-->
         <module>couchdb</module>
@@ -40,6 +41,7 @@
         <!-- JDK version required to build OGM; requiring 1.8 as WildFly 10 requires JDK 1.8; We still create
              1.7 byte code to run in other environments -->
         <minJdkVersion>1.8</minJdkVersion>
+        <jdkTargetForProcessor>1.7</jdkTargetForProcessor>
         <!-- test / build-only dependency versions, managed below -->
         <jbossNamingVersion>7.1.0.Final</jbossNamingVersion>
         <shrinkwrapVersion>1.2.2</shrinkwrapVersion>
@@ -450,7 +452,7 @@
                                 <processors>
                                     <processor>org.jboss.logging.processor.apt.LoggingToolsProcessor</processor>
                                 </processors>
-                                <compilerArguments>-AtranslationFilesPath=${project.basedir}/src/main/resources/ -source 1.7 -target 1.7</compilerArguments>
+                                <compilerArguments>-AtranslationFilesPath=${project.basedir}/src/main/resources/ -source ${jdkTargetForProcessor} -target ${jdkTargetForProcessor}</compilerArguments>
                             </configuration>
                         </execution>
                     </executions>
@@ -768,6 +770,7 @@
             <modules>
                 <module>ehcache</module>
                 <module>infinispan</module>
+                <module>infinispan-remote</module>
                 <module>neo4j</module>
                 <!-- The WildFly modules require the other modules to be enabled too -->
                 <module>modules</module>


### PR DESCRIPTION
Some pending tasks are documented as sub-tasks on JIRA:
 - https://hibernate.atlassian.net/browse/OGM-353

(Although, I've started including some of the sub-tasks already since opening this PR; next working on the missing Sequencer tests and then documentation)

WildFly modules included
  - https://hibernate.atlassian.net/browse/OGM-1160


# Launching / Exploring tests

As usual, there's a `org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteBackendTckHelper` to help you start a test from OGM/core on this new dialect.
It includes a `@ClassRule` which will start an Infinispan Server as needed, or you can launch it via the static `main()` method to keep the server running (manually).

The tests which are specific to this module will use the same JUnit Rule so the database is auto-started as needed.

When running it via Maven, the Surefire plugin is instructed to activate the testing listener `org.hibernate.ogm.datastore.infinispanremote.utils.HotrodServerLifecycle`, which will keep the Infinispan Server running for the duration of the tests, and rest its state as needed.

I like this new approach, as the test execution is very fast and the debugging / development sessions are more practical.. we might consider evolving other modules to use a similar approach.

For the Arquillian tests, the magic is handled by an Arquillian extension which invokes the same JUnit helpers as before, but in the right timing as it needs to happen before the deployment: `org.hibernate.ogm.test.integration.infinispanremote.HotRodServerLifecycleManager` 
 - https://github.com/Sanne/hibernate-ogm/blob/bed210d92f8a3cf3b4033b8971b5206bef0665d0/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodServerLifecycleManager.java

# Schema & Encoders

This dialect needs a full schema to be deployed to the Server before any I/O can happen.

We already discussed the shape and strategy of the schema, but to remind you it's 1:1 of how ORM would map it to RDBMs Tables, I'll highlight the exceptions to this rule in the following sections.

The schema build process is driven by `org.hibernate.ogm.datastore.infinispanremote.impl.ProtobufSchemaInitializer`.

The core element representing a "Table" mapping is
`org.hibernate.ogm.datastore.infinispanremote.impl.schema.TableDefinition`
 - https://github.com/Sanne/hibernate-ogm/blob/bed210d92f8a3cf3b4033b8971b5206bef0665d0/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/schema/TableDefinition.java

These "TableDefinitions" are generated upfront during boot time, and are immutable after that.
They use "ProtofieldWriterSet" which encapsulates an ordered set of field definitions, each with its:
 - ORM column name
 - Protobuf field name
 - Encoder/Decoder references

So a single _TableDefinition_ is able to both export itself in string format to generate the schema DDL fragment, but is also containing the function to decode / encode the payload to the underlying buffers.

The actual driver for encoding / decoding is `org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtoDataMapper` , so the main dialect will interact with the _ProtoDataMapper_

## Capturing the generated Schema

There's a pluggable SPI `org.hibernate.ogm.datastore.infinispanremote.spi.schema.SchemaCapture` to intercept / capture the generated protobuf schema. This is controlled by a configuration option, and the default is to log the generated schema but in some tests I make use of it to validate the schema generation.
The user could also make use of this to override the schema generation and deploy a custom one (not that I'd suggest doing that as our encoders wouldn't be affected).

## Sequences and Table based generators

A sequence is mapped to a key / value, where the key is the sequence name, and stored in a Cache having the sequence name.

When using a table generator, ORM can store multiple "lines" called segments; in this case we consider the Table name as Cache name and each combination segment name part of the ID for the key/value store.

What's interesting is that, no matter if ORM ops for Sequences or Table strategy, we're actually storing in the same way.

The actual sequences are implemented via versioned CAS operations:
 - https://github.com/Sanne/hibernate-ogm/blob/bed210d92f8a3cf3b4033b8971b5206bef0665d0/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/sequences/HotRodSequencer.java

## Bags & unordered collections

Where a collection is of a "bag" type, ORM would map this to a table lacking a primary key, I guess primarily to support duplicate entries.
In a Key/Value store, the key is hardly optional so I have found no way to map this, and noticed the Cassandra dialect doesn't support it either.
The good news is that we detect this early on (at bootstrap, during schema generation) and throw a helpful exception.

# Versioning and Optimistic locking

Optimistic locking is used as an implementation detail by the Sequence generator, but it's not used as a general storage feature by the dialect.

There is some commented-out code in the `InfinispanRemoteDialect` which I believe should make it easy to implement proper optimistic locking in the near future, but I suspect this requires the fix on number of operations by @gsmet first.

# InfinispanRemoteDialect

The main Dialect driver is org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect<EK, AK, ISK>.

Among the optional features, it supports `MultigetGridDialect`.

The Dialect interacts with the usual Tuples from OGM but internally uses the pairs 
-  `ProtostreamPayload` to represent a ready-to-be-encoded Value
- `ProtostreamId` to represent a ready-to-be-encoded Key

These are the only types recognized by the two-way encoders so actual storage operations need to be handled using these payload objects.
Finally, all actual Cache IO operations have to be executed within the context of a "mapper.withinCacheEncodingContext( lambda )" so that the DataMapper can setup the right encoding scheme for the specific Cache. This is to workaround limitation in how the Protostream encoders are configured, as normally they have to be setup 1:1 to class types.. more on this on JIRA s to follow up so we can cleanup the ThreadLocal I'm using for this workaround.
