### PR TITLE
OGM-1064 Operation grouping

### DIFF
--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -46,6 +46,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -443,7 +444,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		Select select = QueryBuilder.select().all().from( quote( entityKeyMetadata.getTable() ) );
 
 		ResultSet resultSet;

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -44,9 +44,11 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -146,7 +148,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 
 		Select select = QueryBuilder.select().all().from( quote( key.getTable() ) );
 		Select.Where selectWhere = select.where( eq( quote( key.getColumnNames()[0] ), QueryBuilder.bindMarker() ) );
@@ -167,15 +169,16 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		Map<String, Object> toSave = new HashMap<String, Object>();
 		toSave.put( key.getColumnNames()[0], key.getColumnValues()[0] );
 		return new Tuple( new MapTupleSnapshot( toSave ) );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext)
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext)
 			throws TupleAlreadyExistsException {
+		Tuple tuple = tuplePointer.getTuple();
 
 		List<TupleOperation> updateOps = new ArrayList<TupleOperation>( tuple.getOperations().size() );
 		List<TupleOperation> deleteOps = new ArrayList<TupleOperation>( tuple.getOperations().size() );

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -31,6 +31,7 @@ import org.hibernate.ogm.datastore.cassandra.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.cassandra.model.impl.ResultSetTupleIterator;
 import org.hibernate.ogm.datastore.cassandra.query.impl.CassandraParameterMetadataBuilder;
 import org.hibernate.ogm.datastore.map.impl.MapAssociationSnapshot;
+import org.hibernate.ogm.datastore.map.impl.MapHelpers;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.dialect.query.spi.BackendQuery;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
@@ -259,7 +260,6 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	@Override
 	public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
 		Table tableMetadata = provider.getMetaDataCache().get( key.getTable() );
-		@SuppressWarnings("unchecked")
 		List<Column> tablePKCols = tableMetadata.getPrimaryKey().getColumns();
 
 		Select select = QueryBuilder.select().all().from( quote( key.getTable() ) );
@@ -401,6 +401,8 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 
 			bindAndExecute( columnValues.toArray(), delete );
 		}
+
+		MapHelpers.updateAssociation( association );
 	}
 
 	@Override

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -539,4 +539,10 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 		// the db server supplied metadata or parsing assistance we can't do much meaningful validation.
 		return nativeQuery;
 	}
+
+	@Override
+	public boolean usesNavigationalInformationForInverseSideOfAssociations() {
+		return false;
+	}
+
 }

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/CassandraDialect.java
@@ -57,6 +57,7 @@ import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.AssociationOperation;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.model.spi.TupleOperation;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.persister.entity.Lockable;
@@ -164,7 +165,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 		}
 
 		Row row = resultSet.one();
-		Tuple tuple = new Tuple( new MapTupleSnapshot( tupleFromRow( row ) ) );
+		Tuple tuple = new Tuple( new MapTupleSnapshot( tupleFromRow( row ) ), SnapshotType.UPDATE );
 		return tuple;
 	}
 
@@ -172,7 +173,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		Map<String, Object> toSave = new HashMap<String, Object>();
 		toSave.put( key.getColumnNames()[0], key.getColumnValues()[0] );
-		return new Tuple( new MapTupleSnapshot( toSave ) );
+		return new Tuple( new MapTupleSnapshot( toSave ), SnapshotType.INSERT );
 	}
 
 	@Override
@@ -460,7 +461,7 @@ public class CassandraDialect extends BaseGridDialect implements GridDialect, Qu
 		Iterator<Row> iter = resultSet.iterator();
 		while ( iter.hasNext() ) {
 			Row row = iter.next();
-			consumer.consume( new Tuple( new MapTupleSnapshot( tupleFromRow( row ) ) ) );
+			consumer.consume( new Tuple( new MapTupleSnapshot( tupleFromRow( row ) ), SnapshotType.UPDATE ) );
 		}
 	}
 

--- a/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/model/impl/ResultSetTupleIterator.java
+++ b/cassandra/src/main/java/org/hibernate/ogm/datastore/cassandra/model/impl/ResultSetTupleIterator.java
@@ -12,6 +12,7 @@ import org.hibernate.ogm.datastore.cassandra.CassandraDialect;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * Wraps Cassandra java-driver ResultSet.
@@ -49,7 +50,7 @@ public class ResultSetTupleIterator implements ClosableIterator<Tuple> {
 	@Override
 	public Tuple next() {
 		count++;
-		return new Tuple( new MapTupleSnapshot( CassandraDialect.tupleFromRow( resultSet.one() ) ) );
+		return new Tuple( new MapTupleSnapshot( CassandraDialect.tupleFromRow( resultSet.one() ) ), SnapshotType.UPDATE );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/compensation/impl/InvocationCollectingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/impl/InvocationCollectingGridDialect.java
@@ -123,6 +123,24 @@ public class InvocationCollectingGridDialect extends ForwardingGridDialect<Seria
 		handleAppliedOperation( executeBatch );
 	}
 
+	@Override
+	public void executeGroupedChangesToEntity(GroupedChangesToEntityOperation operation) {
+		List<GridDialectOperation> operations = new ArrayList<>();
+		for ( Operation groupedOperation : operation.getOperations() ) {
+			operations.add( getSimpleGridDialectOperations( groupedOperation ) );
+		}
+
+		ExecuteBatch executeBatch = new ExecuteBatchImpl( operations );
+		try {
+			super.executeGroupedChangesToEntity( operation );
+		}
+		catch (Exception e) {
+			handleException( executeBatch, e );
+		}
+
+		handleAppliedOperation( executeBatch );
+	}
+
 	private GridDialectOperation getSimpleGridDialectOperations(Operation operation) {
 		GridDialectOperation gridDialectOperation;
 		if ( operation instanceof InsertOrUpdateTupleOperation ) {

--- a/core/src/main/java/org/hibernate/ogm/compensation/impl/InvocationCollectingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/impl/InvocationCollectingGridDialect.java
@@ -44,8 +44,10 @@ import org.hibernate.ogm.dialect.eventstate.impl.EventContextManager;
 import org.hibernate.ogm.dialect.impl.ForwardingGridDialect;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.exception.impl.Exceptions;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -69,11 +71,11 @@ public class InvocationCollectingGridDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		InsertOrUpdateTupleImpl insertOrUpdateTuple = new InsertOrUpdateTupleImpl( key, tuple );
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		InsertOrUpdateTupleImpl insertOrUpdateTuple = new InsertOrUpdateTupleImpl( key, tuplePointer.getTuple() );
 
 		try {
-			super.insertOrUpdateTuple( key, tuple, tupleContext );
+			super.insertOrUpdateTuple( key, tuplePointer, tupleContext );
 		}
 		catch (Exception e) {
 			handleException( insertOrUpdateTuple, e );
@@ -145,7 +147,7 @@ public class InvocationCollectingGridDialect extends ForwardingGridDialect<Seria
 		GridDialectOperation gridDialectOperation;
 		if ( operation instanceof InsertOrUpdateTupleOperation ) {
 			InsertOrUpdateTupleOperation insertOrUpdateTuple = (InsertOrUpdateTupleOperation) operation;
-			gridDialectOperation = new InsertOrUpdateTupleImpl( insertOrUpdateTuple.getEntityKey(), insertOrUpdateTuple.getTuple() );
+			gridDialectOperation = new InsertOrUpdateTupleImpl( insertOrUpdateTuple.getEntityKey(), insertOrUpdateTuple.getTuplePointer().getTuple() );
 		}
 		else if ( operation instanceof RemoveTupleOperation ) {
 			RemoveTupleOperation removeTuple = (RemoveTupleOperation) operation;
@@ -168,12 +170,12 @@ public class InvocationCollectingGridDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		Tuple tuple = null;
 		CreateTupleWithKey createTupleWithKey = new CreateTupleWithKeyImpl( key );
 
 		try {
-			tuple = super.createTuple( key, tupleContext );
+			tuple = super.createTuple( key, operationContext );
 		}
 		catch (Exception e) {
 			handleException( createTupleWithKey, e );
@@ -244,12 +246,12 @@ public class InvocationCollectingGridDialect extends ForwardingGridDialect<Seria
 	// IdentityColumnAwareGridDialect
 
 	@Override
-	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, OperationContext operationContext) {
 		Tuple tuple = null;
 		CreateTuple createTuple = new CreateTupleImpl( entityKeyMetadata );
 
 		try {
-			tuple = super.createTuple( entityKeyMetadata, tupleContext );
+			tuple = super.createTuple( entityKeyMetadata, operationContext );
 		}
 		catch (Exception e) {
 			handleException( createTuple, e );

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/CreateTuple.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/CreateTuple.java
@@ -11,7 +11,7 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 
 /**
  * Represents one execution of
- * {@link IdentityColumnAwareGridDialect#createTuple(EntityKeyMetadata, org.hibernate.ogm.dialect.spi.TupleContext)}.
+ * {@link IdentityColumnAwareGridDialect#createTuple(EntityKeyMetadata, org.hibernate.ogm.dialect.spi.OperationContext)}.
  *
  * @author Gunnar Morling
  */

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/CreateTupleWithKey.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/CreateTupleWithKey.java
@@ -11,7 +11,7 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 
 /**
  * Represents one execution of
- * {@link GridDialect#createTuple(EntityKey, org.hibernate.ogm.dialect.spi.TupleContext)}.
+ * {@link GridDialect#createTuple(EntityKey, org.hibernate.ogm.dialect.spi.OperationContext)}.
  *
  * @author Gunnar Morling
  */

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/FlushPendingOperations.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/FlushPendingOperations.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.compensation.operation;
+
+import java.util.List;
+
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
+
+/**
+ * Represents one execution of
+ * {@link GroupingByEntityDialect#flushPendingOperations(org.hibernate.ogm.model.key.spi.EntityKey, org.hibernate.ogm.dialect.spi.TupleContext)}.
+ *
+ * @author Guillaume Smet
+ *
+ */
+public interface FlushPendingOperations extends GridDialectOperation {
+
+	/**
+	 * Returns the list of batched operations.
+	 */
+	List<GridDialectOperation> getOperations();
+}

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/InsertOrUpdateTuple.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/InsertOrUpdateTuple.java
@@ -12,7 +12,7 @@ import org.hibernate.ogm.model.spi.Tuple;
 
 /**
  * Represents one execution of
- * {@link GridDialect#insertOrUpdateTuple(EntityKey, Tuple, org.hibernate.ogm.dialect.spi.TupleContext)}.
+ * {@link GridDialect#insertOrUpdateTuple(EntityKey, TuplePointer, org.hibernate.ogm.dialect.spi.TupleContext)}.
  *
  * @author Gunnar Morling
  */

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/OperationType.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/OperationType.java
@@ -21,6 +21,7 @@ public enum OperationType {
 	INSERT_OR_UPDATE_ASSOCIATION,
 	REMOVE_ASSOCIATION,
 	EXECUTE_BATCH,
+	FLUSH_PENDING_OPERATIONS,
 
 	// IdentityColumnAwareGridDialect
 

--- a/core/src/main/java/org/hibernate/ogm/compensation/operation/impl/FlushPendingOperationsImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/compensation/operation/impl/FlushPendingOperationsImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.compensation.operation.impl;
+
+import java.util.List;
+
+import org.hibernate.ogm.compensation.operation.ExecuteBatch;
+import org.hibernate.ogm.compensation.operation.FlushPendingOperations;
+import org.hibernate.ogm.compensation.operation.GridDialectOperation;
+import org.hibernate.ogm.compensation.operation.OperationType;
+
+/**
+ * @author Guillaume Smet
+ *
+ */
+public class FlushPendingOperationsImpl implements FlushPendingOperations {
+
+	private final List<GridDialectOperation> operations;
+
+	public FlushPendingOperationsImpl(List<GridDialectOperation> operations) {
+		this.operations = operations;
+	}
+
+	@Override
+	public <T extends GridDialectOperation> T as(Class<T> type) {
+		if ( ExecuteBatch.class.isAssignableFrom( type ) ) {
+			return type.cast( this );
+		}
+
+		throw new IllegalArgumentException( "Unexpected type: " + type );
+	}
+
+	@Override
+	public OperationType getType() {
+		return OperationType.FLUSH_PENDING_OPERATIONS;
+	}
+
+	@Override
+	public List<GridDialectOperation> getOperations() {
+		return operations;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRow.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRow.java
@@ -51,8 +51,6 @@ public class AssociationRow<R> implements TupleSnapshot {
 	private final Set<String> columnNames;
 	private final RowKey rowKey;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public AssociationRow(AssociationKey associationKey, AssociationRowAccessor<R> accessor, R row) {
 		this.associationKey = associationKey;
 		this.accessor = accessor;
@@ -98,16 +96,6 @@ public class AssociationRow<R> implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return columnNames;
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRow.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRow.java
@@ -51,6 +51,8 @@ public class AssociationRow<R> implements TupleSnapshot {
 	private final Set<String> columnNames;
 	private final RowKey rowKey;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public AssociationRow(AssociationKey associationKey, AssociationRowAccessor<R> accessor, R row) {
 		this.associationKey = associationKey;
 		this.accessor = accessor;
@@ -96,6 +98,16 @@ public class AssociationRow<R> implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return columnNames;
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRows.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRows.java
@@ -16,6 +16,7 @@ import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.AssociationSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * Represents the rows of an association in form of {@link AssociationRow}s.
@@ -38,7 +39,7 @@ public class AssociationRows implements AssociationSnapshot {
 	@Override
 	public Tuple get(RowKey rowKey) {
 		AssociationRow<?> row = rows.get( rowKey );
-		return row != null ? new Tuple( row ) : null;
+		return row != null ? new Tuple( row, SnapshotType.UPDATE ) : null;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/datastore/document/impl/EmbeddableStateFinder.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/impl/EmbeddableStateFinder.java
@@ -31,7 +31,7 @@ public class EmbeddableStateFinder {
 
 	public EmbeddableStateFinder(Tuple tuple, TupleContext tupleContext) {
 		this.tuple = tuple;
-		this.columns = tupleContext.getSelectableColumns();
+		this.columns = tupleContext.getTupleTypeContext().getSelectableColumns();
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/EmptyTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/EmptyTupleSnapshot.java
@@ -18,8 +18,6 @@ public final class EmptyTupleSnapshot implements TupleSnapshot {
 
 	public static final TupleSnapshot INSTANCE = new EmptyTupleSnapshot();
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	private EmptyTupleSnapshot() {
 	}
 
@@ -36,15 +34,5 @@ public final class EmptyTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return Collections.emptySet();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/EmptyTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/EmptyTupleSnapshot.java
@@ -18,6 +18,8 @@ public final class EmptyTupleSnapshot implements TupleSnapshot {
 
 	public static final TupleSnapshot INSTANCE = new EmptyTupleSnapshot();
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	private EmptyTupleSnapshot() {
 	}
 
@@ -34,5 +36,15 @@ public final class EmptyTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return Collections.emptySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapAssociationSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapAssociationSnapshot.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.AssociationSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
@@ -28,7 +29,7 @@ public final class MapAssociationSnapshot implements AssociationSnapshot {
 	@Override
 	public Tuple get(RowKey column) {
 		Map<String, Object> rawResult = associationMap.get( column );
-		return rawResult != null ? new Tuple( new MapTupleSnapshot( rawResult ) ) : null;
+		return rawResult != null ? new Tuple( new MapTupleSnapshot( rawResult ), SnapshotType.UPDATE ) : null;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -142,7 +143,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata metadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata metadata) {
 		Map<EntityKey, Map<String, Object>> entityMap = provider.getEntityMap();
 		for ( EntityKey key : entityMap.keySet() ) {
 			if ( key.getTable().equals( metadata.getTable() ) ) {

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
@@ -33,6 +33,7 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.persister.entity.Lockable;
 
 /**
@@ -76,7 +77,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 			return null;
 		}
 		else {
-			return new Tuple( new MapTupleSnapshot( entityMap ) );
+			return new Tuple( new MapTupleSnapshot( entityMap ), SnapshotType.UPDATE );
 		}
 	}
 
@@ -86,7 +87,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 		List<Tuple> results = new ArrayList<>( mapResults.size() );
 		// should be done with a lambda for the tuple creation but that's for demo purposes
 		for ( Map<String, Object> entry : mapResults ) {
-			results.add( entry != null ? new Tuple( new MapTupleSnapshot( entry ) ) : null );
+			results.add( entry != null ? new Tuple( new MapTupleSnapshot( entry ), SnapshotType.UPDATE ) : null );
 		}
 		return results;
 	}
@@ -95,7 +96,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		HashMap<String,Object> tuple = new HashMap<String, Object>();
 		provider.putEntity( key, tuple );
-		return new Tuple( new MapTupleSnapshot( tuple ) );
+		return new Tuple( new MapTupleSnapshot( tuple ), SnapshotType.INSERT );
 	}
 
 	@Override
@@ -149,7 +150,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 		Map<EntityKey, Map<String, Object>> entityMap = provider.getEntityMap();
 		for ( EntityKey key : entityMap.keySet() ) {
 			if ( key.getTable().equals( metadata.getTable() ) ) {
-				consumer.consume( new Tuple( new MapTupleSnapshot( entityMap.get( key ) ) ) );
+				consumer.consume( new Tuple( new MapTupleSnapshot( entityMap.get( key ) ), SnapshotType.UPDATE ) );
 			}
 		}
 	}

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
@@ -122,6 +122,8 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 	@Override
 	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
 		MapHelpers.updateAssociation( association );
+		// the association might have been removed prior to the update so we need to be sure it is present in the Map
+		provider.putAssociation( key, ( (MapAssociationSnapshot) association.getSnapshot() ).getUnderlyingMap() );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
@@ -22,8 +22,10 @@ import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -68,7 +70,7 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 		Map<String, Object> entityMap = provider.getEntityTuple( key );
 		if ( entityMap == null ) {
 			return null;
@@ -90,16 +92,16 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
-		HashMap<String,Object> tuple = new HashMap<String,Object>();
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
+		HashMap<String,Object> tuple = new HashMap<String, Object>();
 		provider.putEntity( key, tuple );
 		return new Tuple( new MapTupleSnapshot( tuple ) );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		Map<String,Object> entityRecord = ( (MapTupleSnapshot) tuple.getSnapshot() ).getMap();
-		MapHelpers.applyTupleOpsOnMap( tuple, entityRecord );
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		Map<String,Object> entityRecord = ( (MapTupleSnapshot) tuplePointer.getTuple().getSnapshot() ).getMap();
+		MapHelpers.applyTupleOpsOnMap( tuplePointer.getTuple(), entityRecord );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapHelpers.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapHelpers.java
@@ -74,6 +74,8 @@ public final class MapHelpers {
 					break;
 			}
 		}
+		// the snapshot has been updated so we have to clear the various operations added to the Association
+		association.reset();
 	}
 
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
@@ -17,8 +17,6 @@ import org.hibernate.ogm.model.spi.TupleSnapshot;
 public final class MapTupleSnapshot implements TupleSnapshot {
 	private final Map<String, Object> map;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public MapTupleSnapshot(Map<String, Object> map) {
 		this.map = map;
 	}
@@ -39,15 +37,5 @@ public final class MapTupleSnapshot implements TupleSnapshot {
 
 	public Map<String, Object> getMap() {
 		return map;
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.ogm.model.spi.TupleSnapshot;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapTupleSnapshot.java
@@ -10,12 +10,15 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.ogm.model.spi.TupleSnapshot;
+import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 public final class MapTupleSnapshot implements TupleSnapshot {
 	private final Map<String, Object> map;
+
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
 
 	public MapTupleSnapshot(Map<String, Object> map) {
 		this.map = map;
@@ -37,5 +40,15 @@ public final class MapTupleSnapshot implements TupleSnapshot {
 
 	public Map<String, Object> getMap() {
 		return map;
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupableEntityOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupableEntityOperation.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.batch.spi;
+
+import org.hibernate.ogm.model.key.spi.EntityKey;
+
+/**
+ * Represents an {@link Operation} we can group by entity
+ *
+ * @author Guillaume Smet
+ */
+public interface GroupableEntityOperation extends Operation {
+
+	EntityKey getEntityKey();
+
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupedChangesToEntityAwareDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupedChangesToEntityAwareDialect.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.batch.spi;
+
+import org.hibernate.ogm.dialect.spi.GridDialect;
+
+/**
+ * @author Guillaume Smet
+ *
+ * XXX GSM: to be removed
+ */
+public interface GroupedChangesToEntityAwareDialect extends GridDialect {
+
+	void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation);
+
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupedChangesToEntityOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupedChangesToEntityOperation.java
@@ -6,38 +6,40 @@
  */
 package org.hibernate.ogm.dialect.batch.spi;
 
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import java.util.LinkedList;
+import java.util.Queue;
+
 import org.hibernate.ogm.model.key.spi.EntityKey;
-import org.hibernate.ogm.model.spi.Tuple;
 
 /**
- * Contains the data required to update a tuple
+ * Wrapper grouping all the update operations for a given entity.
  *
- * @author Davide D'Alto &lt;davide@hibernate.org&gt;
+ * @author Guillaume Smet
  */
-public class InsertOrUpdateTupleOperation implements GroupableEntityOperation {
+public class GroupedChangesToEntityOperation implements Operation {
 
-	private final Tuple tuple;
 	private final EntityKey entityKey;
-	private final TupleContext tupleContext;
 
-	public InsertOrUpdateTupleOperation(Tuple tuple, EntityKey entityKey, TupleContext tupleContext) {
-		this.tuple = tuple;
+	private final Queue<Operation> operations = new LinkedList<>();
+
+	public GroupedChangesToEntityOperation(EntityKey entityKey) {
 		this.entityKey = entityKey;
-		this.tupleContext = tupleContext;
 	}
 
-	public Tuple getTuple() {
-		return tuple;
-	}
-
-	@Override
 	public EntityKey getEntityKey() {
 		return entityKey;
 	}
 
-	public TupleContext getTupleContext() {
-		return tupleContext;
+	public void addOperation(Operation operation) {
+		operations.add( operation );
+	}
+
+	public Queue<Operation> getOperations() {
+		return operations;
+	}
+
+	public void clear() {
+		operations.clear();
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupingByEntityDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupingByEntityDialect.java
@@ -7,6 +7,8 @@
 package org.hibernate.ogm.dialect.batch.spi;
 
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 
 /**
  * A {@link GridDialect} that can group operations for a given entity.
@@ -16,10 +18,18 @@ import org.hibernate.ogm.dialect.spi.GridDialect;
 public interface GroupingByEntityDialect extends GridDialect {
 
 	/**
-	 * Execute all the changes collected for a given entity.
+	 * Execute all the changes collected in the {@link OperationsQueue}.
 	 *
-	 * @param groupedOperation the grouped operation
+	 * @param operationsQueue the operations queue
 	 */
-	void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation);
+	void executeBatch(OperationsQueue operationsQueue);
+
+	/**
+	 * Flush all the pending operations.
+	 *
+	 * @param entityKey the {@link EntityKey} of the entity which is the origin of this operation
+	 * @param tupleContext the {@link TupleContext}
+	 */
+	void flushPendingOperations(EntityKey entityKey, TupleContext tupleContext);
 
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupingByEntityDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/GroupingByEntityDialect.java
@@ -9,12 +9,17 @@ package org.hibernate.ogm.dialect.batch.spi;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 
 /**
- * @author Guillaume Smet
+ * A {@link GridDialect} that can group operations for a given entity.
  *
- * XXX GSM: to be removed
+ * @author Guillaume Smet
  */
-public interface GroupedChangesToEntityAwareDialect extends GridDialect {
+public interface GroupingByEntityDialect extends GridDialect {
 
+	/**
+	 * Execute all the changes collected for a given entity.
+	 *
+	 * @param groupedOperation the grouped operation
+	 */
 	void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation);
 
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/InsertOrUpdateAssociationOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/InsertOrUpdateAssociationOperation.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.dialect.batch.spi;
 
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.spi.Association;
 
 /**
@@ -15,7 +16,7 @@ import org.hibernate.ogm.model.spi.Association;
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class InsertOrUpdateAssociationOperation implements Operation {
+public class InsertOrUpdateAssociationOperation implements GroupableEntityOperation {
 
 	private final Association association;
 	private final AssociationKey associationKey;
@@ -37,6 +38,23 @@ public class InsertOrUpdateAssociationOperation implements Operation {
 
 	public AssociationContext getContext() {
 		return context;
+	}
+
+	@Override
+	public EntityKey getEntityKey() {
+		return getAssociationKey().getEntityKey();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( getClass().getSimpleName() );
+		sb.append( "[" );
+		sb.append( getEntityKey() );
+		sb.append( ", collectionRole=" );
+		sb.append( getAssociationKey().getMetadata().getCollectionRole() );
+		sb.append( "]" );
+		return sb.toString();
 	}
 
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/InsertOrUpdateTupleOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/InsertOrUpdateTupleOperation.java
@@ -7,8 +7,8 @@
 package org.hibernate.ogm.dialect.batch.spi;
 
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.EntityKey;
-import org.hibernate.ogm.model.spi.Tuple;
 
 /**
  * Contains the data required to update a tuple
@@ -17,18 +17,18 @@ import org.hibernate.ogm.model.spi.Tuple;
  */
 public class InsertOrUpdateTupleOperation implements GroupableEntityOperation {
 
-	private final Tuple tuple;
+	private final TuplePointer tuplePointer;
 	private final EntityKey entityKey;
 	private final TupleContext tupleContext;
 
-	public InsertOrUpdateTupleOperation(Tuple tuple, EntityKey entityKey, TupleContext tupleContext) {
-		this.tuple = tuple;
+	public InsertOrUpdateTupleOperation(TuplePointer tuplePointer, EntityKey entityKey, TupleContext tupleContext) {
+		this.tuplePointer = tuplePointer;
 		this.entityKey = entityKey;
 		this.tupleContext = tupleContext;
 	}
 
-	public Tuple getTuple() {
-		return tuple;
+	public TuplePointer getTuplePointer() {
+		return tuplePointer;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/RemoveAssociationOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/RemoveAssociationOperation.java
@@ -8,13 +8,14 @@ package org.hibernate.ogm.dialect.batch.spi;
 
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 
 /**
  * An operation representing the removal of an association
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class RemoveAssociationOperation implements Operation {
+public class RemoveAssociationOperation implements GroupableEntityOperation {
 
 	private final AssociationKey associationKey;
 	private final AssociationContext context;
@@ -30,6 +31,23 @@ public class RemoveAssociationOperation implements Operation {
 
 	public AssociationContext getContext() {
 		return context;
+	}
+
+	@Override
+	public EntityKey getEntityKey() {
+		return getAssociationKey().getEntityKey();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( getClass().getSimpleName() );
+		sb.append( "[" );
+		sb.append( getEntityKey() );
+		sb.append( ", collectionRole=" );
+		sb.append( getAssociationKey().getMetadata().getCollectionRole() );
+		sb.append( "]" );
+		return sb.toString();
 	}
 
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/RemoveTupleOperation.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/batch/spi/RemoveTupleOperation.java
@@ -31,4 +31,14 @@ public class RemoveTupleOperation implements Operation {
 	public TupleContext getTupleContext() {
 		return tupleContext;
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( getClass().getSimpleName() );
+		sb.append( "[" );
+		sb.append( entityKey );
+		sb.append( "]" );
+		return sb.toString();
+	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/identity/spi/IdentityColumnAwareGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/identity/spi/IdentityColumnAwareGridDialect.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.dialect.identity.spi;
 
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
@@ -24,10 +25,10 @@ public interface IdentityColumnAwareGridDialect extends GridDialect {
 	 * to the datastore should be performed.
 	 *
 	 * @param entityKeyMetadata Represents the entity type for which the tuple should be created
-	 * @param tupleContext Provides additional meta-data useful for tuple creation
+	 * @param operationContext Provides additional meta-data useful for tuple creation
 	 * @return the newly created tuple
 	 */
-	Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext);
+	Tuple createTuple(EntityKeyMetadata entityKeyMetadata, OperationContext operationContext);
 
 	/**
 	 * Inserts the given tuple into the datastore, generating an id while doing so. The generated id is to be added to

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AbstractGroupingByEntityDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AbstractGroupingByEntityDialect.java
@@ -11,9 +11,12 @@ import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
 import org.hibernate.ogm.dialect.batch.spi.Operation;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.batch.spi.RemoveTupleOperation;
+import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
+import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 
 
@@ -53,6 +56,23 @@ public abstract class AbstractGroupingByEntityDialect extends BaseGridDialect im
 	@Override
 	public void flushPendingOperations(EntityKey entityKey, TupleContext tupleContext) {
 		executeBatch( tupleContext.getOperationsQueue() );
+	}
+
+	@Override
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		throw new UnsupportedOperationException( "Method not supported by GroupingByEntityDialect implementations" );
+	}
+
+	@Override
+	public void insertOrUpdateAssociation(
+			AssociationKey associationKey, org.hibernate.ogm.model.spi.Association association,
+			AssociationContext associationContext) {
+		throw new UnsupportedOperationException( "Method not supported by GroupingByEntityDialect implementations" );
+	}
+
+	@Override
+	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
+		throw new UnsupportedOperationException( "Method not supported by GroupingByEntityDialect implementations" );
 	}
 
 	protected abstract void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation);

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AbstractGroupingByEntityDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AbstractGroupingByEntityDialect.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.ogm.dialect.batch.spi.GroupedChangesToEntityOperation;
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
+import org.hibernate.ogm.dialect.batch.spi.Operation;
+import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+import org.hibernate.ogm.dialect.batch.spi.RemoveTupleOperation;
+import org.hibernate.ogm.dialect.spi.BaseGridDialect;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+
+
+/**
+ * Base class of all {@link GridDialect}s implementing the grouping of operations per entity.
+ * <p>
+ * The idea is to group all the insert/update operations regarding the same entity in one datastore operation.
+ *
+ * @author Guillaume Smet
+ */
+public abstract class AbstractGroupingByEntityDialect extends BaseGridDialect implements GroupingByEntityDialect {
+
+	@Override
+	public void executeBatch(OperationsQueue queue) {
+		if ( !queue.isClosed() ) {
+			Operation operation = queue.poll();
+
+			while ( operation != null ) {
+				if ( operation instanceof GroupedChangesToEntityOperation ) {
+					GroupedChangesToEntityOperation entityOperation = (GroupedChangesToEntityOperation) operation;
+					executeGroupedChangesToEntity( entityOperation );
+				}
+				else if ( operation instanceof RemoveTupleOperation ) {
+					RemoveTupleOperation removeTupleOperation = (RemoveTupleOperation) operation;
+					removeTuple( removeTupleOperation.getEntityKey(), removeTupleOperation.getTupleContext() );
+				}
+				else {
+					throw new UnsupportedOperationException( "Operation not supported: " + operation.getClass().getSimpleName() );
+				}
+				operation = queue.poll();
+			}
+
+			queue.clear();
+		}
+	}
+
+	@Override
+	public void flushPendingOperations(EntityKey entityKey, TupleContext tupleContext) {
+		executeBatch( tupleContext.getOperationsQueue() );
+	}
+
+	protected abstract void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation);
+
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
@@ -12,8 +12,8 @@ import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.spi.Association;
-import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.util.impl.Contracts;
 
 /**
@@ -26,25 +26,25 @@ public class AssociationContextImpl implements AssociationContext {
 
 	private final AssociationTypeContext associationTypeContext;
 	private final OperationsQueue operationsQueue;
-	private final Tuple entityTuple;
+	private final TuplePointer entityTuplePointer;
 	private final TransactionContext transactionContext;
 
-	public AssociationContextImpl(AssociationTypeContext associationTypeContext, Tuple entityTuple, TransactionContext transactionContext) {
-		this( associationTypeContext, entityTuple, null, transactionContext );
+	public AssociationContextImpl(AssociationTypeContext associationTypeContext, TuplePointer entityTuplePointer, TransactionContext transactionContext) {
+		this( associationTypeContext, entityTuplePointer, null, transactionContext );
 	}
 
 	public AssociationContextImpl(AssociationContextImpl original, OperationsQueue operationsQueue) {
-		this( original.associationTypeContext, original.entityTuple, operationsQueue, original.transactionContext );
+		this( original.associationTypeContext, original.entityTuplePointer, operationsQueue, original.transactionContext );
 	}
 
 	private AssociationContextImpl(AssociationTypeContext associationTypeContext,
-			Tuple entityTuple,
+			TuplePointer entityTuplePointer,
 			OperationsQueue operationsQueue,
 			TransactionContext transactionContext) {
 		Contracts.assertParameterNotNull( associationTypeContext, "associationTypeContext" );
 
 		this.associationTypeContext = associationTypeContext;
-		this.entityTuple = entityTuple;
+		this.entityTuplePointer = entityTuplePointer;
 		this.operationsQueue = operationsQueue;
 		this.transactionContext = transactionContext;
 	}
@@ -65,8 +65,8 @@ public class AssociationContextImpl implements AssociationContext {
 	}
 
 	@Override
-	public Tuple getEntityTuple() {
-		return entityTuple;
+	public TuplePointer getEntityTuplePointer() {
+		return entityTuplePointer;
 	}
 
 	@Override
@@ -77,6 +77,6 @@ public class AssociationContextImpl implements AssociationContext {
 	@Override
 	public String toString() {
 		return "AssociationContextImpl [associationTypeContext=" + associationTypeContext + ", operationsQueue=" + operationsQueue + ", entityTuple="
-				+ entityTuple + "]";
+				+ entityTuplePointer + "]";
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationContextImpl.java
@@ -11,6 +11,7 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.util.impl.Contracts;
@@ -66,6 +67,11 @@ public class AssociationContextImpl implements AssociationContext {
 	@Override
 	public Tuple getEntityTuple() {
 		return entityTuple;
+	}
+
+	@Override
+	public TupleTypeContext getTupleTypeContext() {
+		return associationTypeContext.getOwnerEntityTupleTypeContext();
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationTypeContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/AssociationTypeContextImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.dialect.impl;
 
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.options.spi.OptionsContext;
@@ -22,13 +23,16 @@ public class AssociationTypeContextImpl implements AssociationTypeContext {
 
 	private final OptionsContext optionsContext;
 	private final OptionsContext ownerEntityOptionsContext;
+	private final TupleTypeContext ownerEntityTupleTypeContext;
 	private final AssociatedEntityKeyMetadata associatedEntityKeyMetadata;
 	private final String roleOnMainSide;
 
 	public AssociationTypeContextImpl(OptionsContext optionsContext, OptionsContext ownerEntityOptionsContext,
+			TupleTypeContext ownerEntityTupleTypeContext,
 			AssociatedEntityKeyMetadata associatedEntityKeyMetadata, String roleOnMainSide) {
 		this.optionsContext = optionsContext;
 		this.ownerEntityOptionsContext = ownerEntityOptionsContext;
+		this.ownerEntityTupleTypeContext = ownerEntityTupleTypeContext;
 		this.associatedEntityKeyMetadata = associatedEntityKeyMetadata;
 		this.roleOnMainSide = roleOnMainSide;
 	}
@@ -41,6 +45,11 @@ public class AssociationTypeContextImpl implements AssociationTypeContext {
 	@Override
 	public OptionsContext getOwnerEntityOptionsContext() {
 		return ownerEntityOptionsContext;
+	}
+
+	@Override
+	public TupleTypeContext getOwnerEntityTupleTypeContext() {
+		return ownerEntityTupleTypeContext;
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/BatchOperationsDelegator.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/BatchOperationsDelegator.java
@@ -71,11 +71,10 @@ public class BatchOperationsDelegator extends ForwardingGridDialect<Serializable
 
 	@Override
 	public void executeBatch(OperationsQueue operationsQueue) {
-		log.tracef( "Executing batch" );
-
 		try {
 			if ( GridDialects.hasFacet( getGridDialect(), BatchableGridDialect.class )
 					|| GridDialects.hasFacet( getGridDialect(), GroupingByEntityDialect.class ) ) {
+				log.tracef( "Executing batch" );
 				super.executeBatch( operationsQueue );
 			}
 		}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -14,6 +14,8 @@ import org.hibernate.LockMode;
 import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.dialect.batch.spi.BatchableGridDialect;
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
+import org.hibernate.ogm.dialect.batch.spi.GroupedChangesToEntityOperation;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.identity.spi.IdentityColumnAwareGridDialect;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
@@ -56,7 +58,7 @@ import org.hibernate.type.Type;
  *
  * @author Gunnar Morling
  */
-public class ForwardingGridDialect<T extends Serializable> implements GridDialect, BatchableGridDialect, SessionFactoryLifecycleAwareDialect, IdentityColumnAwareGridDialect, QueryableGridDialect<T>, OptimisticLockingAwareGridDialect, Configurable, ServiceRegistryAwareService, MultigetGridDialect {
+public class ForwardingGridDialect<T extends Serializable> implements GridDialect, BatchableGridDialect, SessionFactoryLifecycleAwareDialect, IdentityColumnAwareGridDialect, QueryableGridDialect<T>, OptimisticLockingAwareGridDialect, Configurable, ServiceRegistryAwareService, MultigetGridDialect, GroupingByEntityDialect {
 
 	private final GridDialect gridDialect;
 	private final BatchableGridDialect batchableGridDialect;
@@ -284,5 +286,12 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 		sb.append( "]" );
 
 		return sb.toString();
+	}
+
+	@Override
+	public void executeGroupedChangesToEntity(GroupedChangesToEntityOperation operation) {
+		if ( gridDialect instanceof GroupingByEntityDialect ) {
+			( (GroupingByEntityDialect) gridDialect ).executeGroupedChangesToEntity( operation );
+		}
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -14,8 +14,8 @@ import org.hibernate.LockMode;
 import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.dialect.batch.spi.BatchableGridDialect;
-import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
 import org.hibernate.ogm.dialect.batch.spi.GroupedChangesToEntityOperation;
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.identity.spi.IdentityColumnAwareGridDialect;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
@@ -31,9 +31,11 @@ import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -101,18 +103,18 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
-		return gridDialect.getTuple( key, tupleContext );
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
+		return gridDialect.getTuple( key, operationContext );
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
-		return gridDialect.createTuple( key, tupleContext );
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
+		return gridDialect.createTuple( key, operationContext );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		gridDialect.insertOrUpdateTuple( key, tuple, tupleContext );
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		gridDialect.insertOrUpdateTuple( key, tuplePointer, tupleContext );
 	}
 
 	@Override
@@ -231,8 +233,8 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	 */
 
 	@Override
-	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		return identityColumnAwareGridDialect.createTuple( entityKeyMetadata, tupleContext );
+	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, OperationContext operationContext) {
+		return identityColumnAwareGridDialect.createTuple( entityKeyMetadata, operationContext );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -33,6 +33,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -160,8 +161,8 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
-		gridDialect.forEachTuple( consumer, tupleContext, entityKeyMetadata );
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
+		gridDialect.forEachTuple( consumer, tupleTypeContext, entityKeyMetadata );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -302,4 +302,10 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	public void flushPendingOperations(EntityKey entityKey, TupleContext tupleContext) {
 		groupingByEntityGridDialect.flushPendingOperations( entityKey, tupleContext );
 	}
+
+	@Override
+	public boolean usesNavigationalInformationForInverseSideOfAssociations() {
+		return gridDialect.usesNavigationalInformationForInverseSideOfAssociations();
+	}
+
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectInitiator.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectInitiator.java
@@ -15,6 +15,7 @@ import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.compensation.impl.InvocationCollectingGridDialect;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.batch.spi.BatchableGridDialect;
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
 import org.hibernate.ogm.dialect.eventstate.impl.EventContextManager;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.util.configurationreader.impl.DefaultClassPropertyReaderContext;
@@ -96,9 +97,9 @@ public class GridDialectInitiator implements StandardServiceInitiator<GridDialec
 					gridDialect = new InvocationCollectingGridDialect( gridDialect, eventContext );
 				}
 
-				if ( GridDialects.hasFacet( gridDialect, BatchableGridDialect.class ) ) {
-					BatchableGridDialect batchable = (BatchableGridDialect) gridDialect;
-					gridDialect = new BatchOperationsDelegator( batchable, eventContext );
+				if ( GridDialects.hasFacet( gridDialect, BatchableGridDialect.class ) ||
+						GridDialects.hasFacet( gridDialect, GroupingByEntityDialect.class ) ) {
+					gridDialect = new BatchOperationsDelegator( gridDialect, eventContext );
 				}
 
 				log.useGridDialect( gridDialect.getClass() );

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/GridDialectLogger.java
@@ -18,7 +18,9 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -55,9 +57,9 @@ public class GridDialectLogger extends ForwardingGridDialect<Serializable> {
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
-		log.tracef( "Reading tuple with key %1$s and context %2$s", key, tupleContext );
-		return super.getTuple( key, tupleContext );
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
+		log.tracef( "Reading tuple with key %1$s and context %2$s", key, operationContext );
+		return super.getTuple( key, operationContext );
 	}
 
 	@Override
@@ -69,20 +71,20 @@ public class GridDialectLogger extends ForwardingGridDialect<Serializable> {
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		log.tracef( "Creating tuple with key %1$s", key );
-		return super.createTuple( key, tupleContext );
+		return super.createTuple( key, operationContext );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		if ( tuple.getSnapshot().isEmpty() ) {
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		if ( tuplePointer.getTuple().getSnapshot().isEmpty() ) {
 			log.tracef( "Inserting tuple with key %1$s into datastore", key );
 		}
 		else {
 			log.tracef( "Updating tuple with key %1$s in datastore", key );
 		}
-		super.insertOrUpdateTuple( key, tuple, tupleContext );
+		super.insertOrUpdateTuple( key, tuplePointer, tupleContext );
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleContextImpl.java
@@ -6,16 +6,10 @@
  */
 package org.hibernate.ogm.dialect.impl;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
-import org.hibernate.ogm.options.spi.OptionsContext;
-import org.hibernate.ogm.util.impl.StringHelper;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 
 /**
  * Represents all information used to load an entity with some specific characteristics like a projection
@@ -25,53 +19,30 @@ import org.hibernate.ogm.util.impl.StringHelper;
  */
 public class TupleContextImpl implements TupleContext {
 
-	private final List<String> selectableColumns;
-	private final OptionsContext optionsContext;
+	private final TupleTypeContext tupleTypeContext;
 	private final OperationsQueue operationsQueue;
 	private final TransactionContext transactionContext;
 
-	/**
-	 * Information of the associated entity stored per foreign key column names
-	 */
-	private final Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata;
-
-	private final Map<String, String> roles;
-
 	public TupleContextImpl(TupleContextImpl original, OperationsQueue operationsQueue) {
-		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, operationsQueue, original.transactionContext );
+		this( original.tupleTypeContext, operationsQueue, original.transactionContext );
 	}
 
 	public TupleContextImpl(TupleContextImpl original, TransactionContext transactionContext) {
-		this( original.selectableColumns, original.associatedEntityMetadata, original.roles, original.optionsContext, original.operationsQueue, transactionContext );
+		this( original.tupleTypeContext, original.operationsQueue, transactionContext );
 	}
 
-	public TupleContextImpl(List<String> selectableColumns, Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata, Map<String, String> roles, OptionsContext optionsContext, TransactionContext transactionContext) {
-		this( selectableColumns, associatedEntityMetadata, roles, optionsContext, null, transactionContext );
+	public TupleContextImpl(TupleTypeContext tupleTypeContext, TransactionContext transactionContext) {
+		this( tupleTypeContext, null, transactionContext );
 	}
 
-	private TupleContextImpl(List<String> selectableColumns,
-			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
-			Map<String, String> roles,
-			OptionsContext optionsContext,
-			OperationsQueue operationsQueue,
-			TransactionContext transactionContext) {
+	public TupleContextImpl(TupleTypeContext tupleTypeContext) {
+		this( tupleTypeContext, null, null );
+	}
 
-		this.selectableColumns = selectableColumns;
-		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
-		this.roles = Collections.unmodifiableMap( roles );
-		this.optionsContext = optionsContext;
+	private TupleContextImpl(TupleTypeContext tupleTypeContext, OperationsQueue operationsQueue, TransactionContext transactionContext) {
+		this.tupleTypeContext = tupleTypeContext;
 		this.operationsQueue = operationsQueue;
 		this.transactionContext = transactionContext;
-	}
-
-	@Override
-	public List<String> getSelectableColumns() {
-		return selectableColumns;
-	}
-
-	@Override
-	public OptionsContext getOptionsContext() {
-		return optionsContext;
 	}
 
 	@Override
@@ -80,43 +51,13 @@ public class TupleContextImpl implements TupleContext {
 	}
 
 	@Override
-	public boolean isPartOfAssociation(String column) {
-		return associatedEntityMetadata.containsKey( column );
-	}
-
-	@Override
-	public AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column) {
-		return associatedEntityMetadata.get( column );
-	}
-
-	@Override
-	public Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata() {
-		return associatedEntityMetadata;
-	}
-
-	@Override
-	public String getRole(String column) {
-		return roles.get( column );
-	}
-
-	@Override
-	public Map<String, String> getAllRoles() {
-		return roles;
-	}
-
-	@Override
 	public OperationsQueue getOperationsQueue() {
 		return operationsQueue;
 	}
 
 	@Override
-	public String toString() {
-		final StringBuilder builder = new StringBuilder( "Tuple Context {" );
-
-		builder.append( "selectableColumns: [" );
-		builder.append( StringHelper.join( selectableColumns, ", " ) );
-		builder.append( "] }" );
-
-		return builder.toString();
+	public TupleTypeContext getTupleTypeContext() {
+		return tupleTypeContext;
 	}
+
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
+import org.hibernate.ogm.options.spi.OptionsContext;
+import org.hibernate.ogm.util.impl.StringHelper;
+
+/**
+ * Represents all information used to load an entity with some specific characteristics like a projection
+ *
+ * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
+ * @author Gunnar Morling
+ */
+public class TupleTypeContextImpl implements TupleTypeContext {
+
+	private final List<String> selectableColumns;
+	private final OptionsContext optionsContext;
+
+	/**
+	 * Information of the associated entity stored per foreign key column names
+	 */
+	private final Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata;
+
+	private final Map<String, String> roles;
+
+	public TupleTypeContextImpl(List<String> selectableColumns,
+			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
+			Map<String, String> roles,
+			OptionsContext optionsContext) {
+
+		this.selectableColumns = Collections.unmodifiableList( selectableColumns );
+		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
+		this.roles = Collections.unmodifiableMap( roles );
+		this.optionsContext = optionsContext;
+	}
+
+	@Override
+	public List<String> getSelectableColumns() {
+		return selectableColumns;
+	}
+
+	@Override
+	public OptionsContext getOptionsContext() {
+		return optionsContext;
+	}
+
+	@Override
+	public boolean isPartOfAssociation(String column) {
+		return associatedEntityMetadata.containsKey( column );
+	}
+
+	@Override
+	public AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column) {
+		return associatedEntityMetadata.get( column );
+	}
+
+	@Override
+	public Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata() {
+		return associatedEntityMetadata;
+	}
+
+	@Override
+	public String getRole(String column) {
+		return roles.get( column );
+	}
+
+	@Override
+	public Map<String, String> getAllRoles() {
+		return roles;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder builder = new StringBuilder( "Tuple Context {" );
+
+		builder.append( "selectableColumns: [" );
+		builder.append( StringHelper.join( selectableColumns, ", " ) );
+		builder.append( "] }" );
+
+		return builder.toString();
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.ogm.dialect.spi;
 
-import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 
@@ -16,16 +15,7 @@ import org.hibernate.ogm.model.spi.Tuple;
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  * @author Gunnar Morling
  */
-public interface AssociationContext {
-
-	/**
-	 * Provides access to the operations queue of the current flush cycle if the active dialect supports the batched
-	 * execution of operations.
-	 *
-	 * @return the operations queue of the current flush or {@code null} if the active dialect does the batched
-	 * execution of operations
-	 */
-	OperationsQueue getOperationsQueue();
+public interface AssociationContext extends OperationContext {
 
 	/**
 	 * Provides context information related to the given association's type.
@@ -41,10 +31,4 @@ public interface AssociationContext {
 	 */
 	Tuple getEntityTuple();
 
-	/**
-	 * Provides the information related to the transactional boundaries the query can be executed
-	 *
-	 * @return a transaction context containing information about the current running transaction, or null
-	 */
-	TransactionContext getTransactionContext();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationContext.java
@@ -6,8 +6,8 @@
  */
 package org.hibernate.ogm.dialect.spi;
 
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.spi.Association;
-import org.hibernate.ogm.model.spi.Tuple;
 
 /**
  * Provides context information to {@link GridDialect}s when accessing {@link Association}s.
@@ -29,6 +29,6 @@ public interface AssociationContext extends OperationContext {
 	 *
 	 * @return A tuple representing the entity on the current side of the association
 	 */
-	Tuple getEntityTuple();
+	TuplePointer getEntityTuplePointer();
 
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationTypeContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/AssociationTypeContext.java
@@ -34,6 +34,13 @@ public interface AssociationTypeContext {
 	OptionsContext getOwnerEntityOptionsContext();
 
 	/**
+	 * Provide access to the {@link TupleTypeContext} of the entity owner of the association.
+	 *
+	 * @return a context object providing access to the {code TupleTypeContext} of the owner entity.
+	 */
+	TupleTypeContext getOwnerEntityTupleTypeContext();
+
+	/**
 	 * Provides meta-data about the entity key on the other side of this association.
 	 *
 	 * @return A meta-data object providing information about the entity key on the other side of this information.
@@ -49,4 +56,5 @@ public interface AssociationTypeContext {
 	 * association.
 	 */
 	String getRoleOnMainSide();
+
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
@@ -8,7 +8,9 @@ package org.hibernate.ogm.dialect.spi;
 
 import org.hibernate.LockMode;
 import org.hibernate.dialect.lock.LockingStrategy;
+import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.impl.ExceptionThrowingLockingStrategy;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.persister.entity.Lockable;
@@ -43,5 +45,10 @@ public abstract class BaseGridDialect implements GridDialect {
 	@Override
 	public DuplicateInsertPreventionStrategy getDuplicateInsertPreventionStrategy(EntityKeyMetadata entityKeyMetadata) {
 		return DuplicateInsertPreventionStrategy.LOOK_UP;
+	}
+
+	protected static boolean isInTheInsertionQueue(EntityKey key, TupleContext tupleContext) {
+		OperationsQueue queue = tupleContext.getOperationsQueue();
+		return queue != null && queue.isInTheInsertionQueue( key );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
@@ -43,6 +43,11 @@ public abstract class BaseGridDialect implements GridDialect {
 	}
 
 	@Override
+	public boolean usesNavigationalInformationForInverseSideOfAssociations() {
+		return true;
+	}
+
+	@Override
 	public DuplicateInsertPreventionStrategy getDuplicateInsertPreventionStrategy(EntityKeyMetadata entityKeyMetadata) {
 		return DuplicateInsertPreventionStrategy.LOOK_UP;
 	}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/BaseGridDialect.java
@@ -47,7 +47,7 @@ public abstract class BaseGridDialect implements GridDialect {
 		return DuplicateInsertPreventionStrategy.LOOK_UP;
 	}
 
-	protected static boolean isInTheInsertionQueue(EntityKey key, TupleContext tupleContext) {
+	protected static boolean isInTheInsertionQueue(EntityKey key, OperationContext tupleContext) {
 		OperationsQueue queue = tupleContext.getOperationsQueue();
 		return queue != null && queue.isInTheInsertionQueue( key );
 	}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
@@ -187,4 +187,11 @@ public interface GridDialect extends Service {
 	 * same primary key
 	 */
 	DuplicateInsertPreventionStrategy getDuplicateInsertPreventionStrategy(EntityKeyMetadata entityKeyMetadata);
+
+	/**
+	 * Whether this dialect uses navigational information to deal with the inverse side of an association.
+	 *
+	 * @return {@code true} is this dialect uses navigational information.
+	 */
+	boolean usesNavigationalInformationForInverseSideOfAssociations();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.dialect.spi;
 
 import org.hibernate.LockMode;
 import org.hibernate.dialect.lock.LockingStrategy;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -46,17 +47,17 @@ public interface GridDialect extends Service {
 	 * Return the tuple with the given column for a given key
 	 *
 	 * @param key The tuple identifier
-	 * @param tupleContext Contains additional information that might be used to create the tuple
+	 * @param operationContext Contains additional information that might be used to create the tuple
 	 * @return the tuple identified by the key
 	 */
-	Tuple getTuple(EntityKey key, TupleContext tupleContext);
+	Tuple getTuple(EntityKey key, OperationContext operationContext);
 
 	/**
 	 * Creates a new tuple for the given entity key.
 	 * <p>
 	 * Only invoked if no tuple is present yet for the given key. Implementations should not perform a round-trip to the
 	 * datastore but rather return a transient instance. The OGM engine will invoke
-	 * {@link #insertOrUpdateTuple(EntityKey, Tuple, TupleContext)} subsequently.
+	 * {@link #insertOrUpdateTuple(EntityKey, TuplePointer, TupleContext)} subsequently.
 	 * <p>
 	 * Columns in the tuple may represent properties of the corresponding entity as well as *-to-one associations to
 	 * other entities. Implementations may choose to persist the latter e.g. in form of fields or as actual
@@ -64,20 +65,20 @@ public interface GridDialect extends Service {
 	 * corresponding association role for a given column can be obtained from the passed tuple context.
 	 *
 	 * @param key The tuple identifier
-	 * @param tupleContext Contains additional information that might be used to create the tuple
+	 * @param operationContext Contains additional information that might be used to create the tuple
 	 * @return the created tuple
 	 */
-	Tuple createTuple(EntityKey key, TupleContext tupleContext);
+	Tuple createTuple(EntityKey key, OperationContext operationContext);
 
 	/**
 	 * Inserts or updates the tuple corresponding to the given entity key.
 	 *
 	 * @param key The tuple identifier
-	 * @param tuple The list of operations to execute
+	 * @param tuplePointer A pointer to the list of operations to execute
 	 * @param tupleContext Contains additional information that might be used to create or update the tuple
 	 * @throws TupleAlreadyExistsException upon insertion of a tuple with an already existing unique identifier
 	 */
-	void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) throws TupleAlreadyExistsException;
+	void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) throws TupleAlreadyExistsException;
 
 	/**
 	 * Remove the tuple for a given key

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/GridDialect.java
@@ -170,12 +170,12 @@ public interface GridDialect extends Service {
 	 *
 	 * @param consumer
 	 *            the instance that is going to be called for every {@link Tuple}
-	 * @param tupleContext
+	 * @param tupleTypeContext
 	 *            contains additional information that might be used to build the tuple
 	 * @param entityKeyMetadata
 	 *            the key metadata of the table for which we want to apply the consumer
 	 */
-	void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata);
+	void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata);
 
 	/**
 	 * Returns this dialect's strategy for detecting the insertion of several entity tuples of the given type with the

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/OperationContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/OperationContext.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.spi;
+
+import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
+
+/**
+ * Provides context information to {@link GridDialect}s about an operation performed on an entity.
+ *
+ * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ */
+public interface OperationContext {
+
+	/**
+	 * Provides access to the operations queue of the current flush cycle if the active dialect supports the batched
+	 * execution of operations.
+	 *
+	 * @return the operations queue of the current flush or {@code null} if the active dialect does the batched
+	 * execution of operations
+	 */
+	OperationsQueue getOperationsQueue();
+
+	/**
+	 * Provides the information related to the transactional boundaries the query can be executed
+	 *
+	 * @return a transaction context containing information about the current running transaction, or null
+	 */
+	TransactionContext getTransactionContext();
+
+	/**
+	 * Provides context information related to the given entity's type.
+	 * @return Context information related to the given entity's type
+	 */
+	TupleTypeContext getTupleTypeContext();
+
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleAlreadyExistsException.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleAlreadyExistsException.java
@@ -7,8 +7,8 @@
 package org.hibernate.ogm.dialect.spi;
 
 import org.hibernate.HibernateException;
+import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
-import org.hibernate.ogm.model.spi.Tuple;
 
 /**
  * Raised by {@link GridDialect} implementations using {@link DuplicateInsertPreventionStrategy#NATIVE} upon insertion
@@ -18,55 +18,99 @@ import org.hibernate.ogm.model.spi.Tuple;
  */
 public class TupleAlreadyExistsException extends HibernateException {
 
+	/**
+	 * The {@link EntityKeyMetadata} of the tuple.
+	 */
 	private final EntityKeyMetadata entityKeyMetadata;
-	private final Tuple id;
+
+	/**
+	 * The {@link EntityKey} of the tuple.
+	 *
+	 * Might be null if the exception is thrown during a batched operation.
+	 */
+	private final EntityKey entityKey;
 
 	/**
 	 * Creates a new {@code TupleAlreadyExistsException}.
 	 *
-	 * @param entityKeyMetadata Key metadata for the affected entity
-	 * @param id A {@link Tuple} containing the id column(s) of the affected entity
+	 * @param entityKey An {@link EntityKey} containing the id of the affected entity
 	 */
-	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata, Tuple id) {
+	public TupleAlreadyExistsException(EntityKey entityKey) {
 		super( (Throwable) null );
 
-		this.entityKeyMetadata = entityKeyMetadata;
-		this.id = id;
+		this.entityKey = entityKey;
+		this.entityKeyMetadata = entityKey.getMetadata();
 	}
 
 	/**
 	 * Creates a new {@code TupleAlreadyExistsException}.
 	 *
-	 * @param entityKeyMetadata Key metadata for the affected entity
-	 * @param id A {@link Tuple} containing the id column(s) of the affected entity
+	 * @param entityKey An {@link EntityKey} containing the id of the affected entity
 	 * @param message a message explaining the cause of the error
 	 */
-	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata, Tuple id, String message) {
+	public TupleAlreadyExistsException(EntityKey entityKey, String message) {
 		super( message );
 
-		this.entityKeyMetadata = entityKeyMetadata;
-		this.id = id;
+		this.entityKey = entityKey;
+		this.entityKeyMetadata = entityKey.getMetadata();
+	}
+
+	/**
+	 * Creates a new {@code TupleAlreadyExistsException}.
+	 *
+	 * @param entityKey An {@link EntityKey} containing the id of the affected entity
+	 * @param cause An exception raised by the underlying datastore indicating the insertion of a duplicate primary key
+	 */
+	public TupleAlreadyExistsException(EntityKey entityKey, Throwable cause) {
+		super( cause );
+
+		this.entityKey = entityKey;
+		this.entityKeyMetadata = entityKey.getMetadata();
 	}
 
 	/**
 	 * Creates a new {@code TupleAlreadyExistsException}.
 	 *
 	 * @param entityKeyMetadata Key metadata for the affected entity
-	 * @param id A {@link Tuple} containing the id column(s) of the affected entity
+	 */
+	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata) {
+		super( (Throwable) null );
+
+		this.entityKey = null;
+		this.entityKeyMetadata = entityKey.getMetadata();
+	}
+
+	/**
+	 * Creates a new {@code TupleAlreadyExistsException}.
+	 *
+	 * @param entityKeyMetadata Key metadata for the affected entity
+	 * @param message a message explaining the cause of the error
+	 */
+	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata, String message) {
+		super( message );
+
+		this.entityKey = null;
+		this.entityKeyMetadata = entityKey.getMetadata();
+	}
+
+	/**
+	 * Creates a new {@code TupleAlreadyExistsException}.
+	 *
+	 * @param entityKeyMetadata Key metadata for the affected entity
 	 * @param cause An exception raised by the underlying datastore indicating the insertion of a duplicate primary key
 	 */
-	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata, Tuple id, Throwable cause) {
+	public TupleAlreadyExistsException(EntityKeyMetadata entityKeyMetadata, Throwable cause) {
 		super( cause );
 
+		this.entityKey = null;
 		this.entityKeyMetadata = entityKeyMetadata;
-		this.id = id;
 	}
 
 	public EntityKeyMetadata getEntityKeyMetadata() {
 		return entityKeyMetadata;
 	}
 
-	public Tuple getId() {
-		return id;
+	public EntityKey getEntityKey() {
+		return entityKey;
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleContext.java
@@ -6,92 +6,12 @@
  */
 package org.hibernate.ogm.dialect.spi;
 
-import java.util.List;
-import java.util.Map;
-
-import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
-import org.hibernate.ogm.options.spi.OptionsContext;
-
 /**
  * Represents all information used to load an entity with some specific characteristics like a projection
  *
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  * @author Gunnar Morling
  */
-public interface TupleContext {
+public interface TupleContext extends OperationContext {
 
-	/**
-	 * Get the option context.
-	 *
-	 * @return a context object providing access to the options effectively applying for a given entity or property.
-	 */
-	OptionsContext getOptionsContext();
-
-	/**
-	 * Provides the information related to the transactional boundaries the query can be executed
-	 *
-	 * @return a transaction context containing information about the current running transaction, or null
-	 */
-	TransactionContext getTransactionContext();
-
-	/**
-	 * Returns the mapped columns of the given entity. May be used by a dialect to only load those columns instead of
-	 * the complete document/record. If the dialect supports the embedded storage of element collections and
-	 * associations, the respective columns will be part of the returned list as well.
-	 *
-	 * @return the columns that can be selected on the given entity
-	 */
-	List<String> getSelectableColumns();
-
-	/**
-	 * Whether the given column is part of a *-to-one association or not. If so, a dialect may choose to not persist the
-	 * column value in the corresponding tuple data structure itself but e.g. as a native relationship (in the case of
-	 * graph stores).
-	 *
-	 * @param column the name of the column
-	 * @return {@code true} if the given column is part of a *-to-one association, {@code false} otherwise.
-	 */
-	boolean isPartOfAssociation(String column);
-
-	/**
-	 * Provides meta-data about the *-to-one associations represented in a given tuple. Note that the same meta-data
-	 * object will be returned for different columns, if those columns are part of a compound key.
-	 *
-	 * @param column The column name to return the *-to-one association meta-data for.
-	 * @return meta-data about the *-to-one association of which the given column is part of or {@code null} if the
-	 * given column is not part of such an association
-	 */
-	AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column);
-
-	/**
-	 * Get the meta-data of all the associated entities keys
-	 *
-	 * @return the meta-data about all the *-to-one associations represented in a given tuple, keyed by column name.
-	 */
-	Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata();
-
-	/**
-	 * Get the role of a column
-	 *
-	 * @param column the column name
-	 * @return the role of the given column
-	 */
-	String getRole(String column);
-
-	/**
-	 * Get all the roles
-	 *
-	 * @return the roles, keyed by column name.
-	 */
-	Map<String, String> getAllRoles();
-
-	/**
-	 * Provides access to the operations queue of the current flush cycle if the active dialect supports the batched
-	 * execution of operations.
-	 *
-	 * @return the operations queue of the current flush or {@code null} if the active dialect does the batched
-	 * execution of operations
-	 */
-	OperationsQueue getOperationsQueue();
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.spi;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.options.spi.OptionsContext;
+
+/**
+ * Provides context information related to the tuple type to {@link GridDialect}s when accessing
+ * {@link Tuple}s.
+ *
+ * @author Guillaume Smet
+ */
+public interface TupleTypeContext {
+
+	/**
+	 * Get the option context.
+	 *
+	 * @return a context object providing access to the options effectively applying for a given entity or property.
+	 */
+	OptionsContext getOptionsContext();
+
+	/**
+	 * Returns the mapped columns of the given entity. May be used by a dialect to only load those columns instead of
+	 * the complete document/record. If the dialect supports the embedded storage of element collections and
+	 * associations, the respective columns will be part of the returned list as well.
+	 *
+	 * @return the columns that can be selected on the given entity
+	 */
+	List<String> getSelectableColumns();
+
+	/**
+	 * Whether the given column is part of a *-to-one association or not. If so, a dialect may choose to not persist the
+	 * column value in the corresponding tuple data structure itself but e.g. as a native relationship (in the case of
+	 * graph stores).
+	 *
+	 * @param column the name of the column
+	 * @return {@code true} if the given column is part of a *-to-one association, {@code false} otherwise.
+	 */
+	boolean isPartOfAssociation(String column);
+
+	/**
+	 * Provides meta-data about the *-to-one associations represented in a given tuple. Note that the same meta-data
+	 * object will be returned for different columns, if those columns are part of a compound key.
+	 *
+	 * @param column The column name to return the *-to-one association meta-data for.
+	 * @return meta-data about the *-to-one association of which the given column is part of or {@code null} if the
+	 * given column is not part of such an association
+	 */
+	AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column);
+
+	/**
+	 * Get the meta-data of all the associated entities keys
+	 *
+	 * @return the meta-data about all the *-to-one associations represented in a given tuple, keyed by column name.
+	 */
+	Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata();
+
+	/**
+	 * Get the role of a column
+	 *
+	 * @param column the column name
+	 * @return the role of the given column
+	 */
+	String getRole(String column);
+
+	/**
+	 * Get all the roles
+	 *
+	 * @return the roles, keyed by column name.
+	 */
+	Map<String, String> getAllRoles();
+
+}

--- a/core/src/main/java/org/hibernate/ogm/entityentry/impl/OgmEntityEntryState.java
+++ b/core/src/main/java/org/hibernate/ogm/entityentry/impl/OgmEntityEntryState.java
@@ -21,27 +21,23 @@ import org.hibernate.ogm.util.impl.LoggerFactory;
  * Entity-dependent state specific to Hibernate OGM.
  *
  * @author Gunnar Morling
+ * @author Guillaume Smet
  */
 public class OgmEntityEntryState implements EntityEntryExtraState {
 
 	private static final Log log = LoggerFactory.make();
 
 	private EntityEntryExtraState next;
-	private Tuple tuple;
+	private final TuplePointer tuplePointer = new TuplePointer();
 	private Map<String, Association> associations;
 
 	/**
-	 * The {@link Tuple} representing the given entity, as loaded from the datastore. May be {@code null} in case the
-	 * loading code failed to set it.
+	 * Return the stable pointer to the {@link Tuple} representing the given entity, as loaded from the datastore.
 	 *
-	 * @return the tuple representing the given entity
+	 * @return the pointer to the tuple representing the given entity
 	 */
-	public Tuple getTuple() {
-		return tuple;
-	}
-
-	public void setTuple(Tuple tuple) {
-		this.tuple = tuple;
+	public TuplePointer getTuplePointer() {
+		return tuplePointer;
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/entityentry/impl/OgmEntityEntryState.java
+++ b/core/src/main/java/org/hibernate/ogm/entityentry/impl/OgmEntityEntryState.java
@@ -6,9 +6,13 @@
  */
 package org.hibernate.ogm.entityentry.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityEntryExtraState;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
@@ -24,6 +28,7 @@ public class OgmEntityEntryState implements EntityEntryExtraState {
 
 	private EntityEntryExtraState next;
 	private Tuple tuple;
+	private Map<String, Association> associations;
 
 	/**
 	 * The {@link Tuple} representing the given entity, as loaded from the datastore. May be {@code null} in case the
@@ -37,6 +42,45 @@ public class OgmEntityEntryState implements EntityEntryExtraState {
 
 	public void setTuple(Tuple tuple) {
 		this.tuple = tuple;
+	}
+
+	/**
+	 * Return the association as cached in the entry state.
+	 *
+	 * @param collectionRole the role of the association
+	 * @return the cached association
+	 */
+	public Association getAssociation(String collectionRole) {
+		if ( associations == null ) {
+			return null;
+		}
+		return associations.get( collectionRole );
+	}
+
+	/**
+	 * Indicates if the entry state contains information about the given association.
+	 *
+	 * @param collectionRole the role of the association
+	 * @return true if the entry state contains information about the given association
+	 */
+	public boolean hasAssociation(String collectionRole) {
+		if ( associations == null ) {
+			return false;
+		}
+		return associations.containsKey( collectionRole );
+	}
+
+	/**
+	 * Set the association in the entry state.
+	 *
+	 * @param collectionRole the role of the association
+	 * @param association the association
+	 */
+	public void setAssociation(String collectionRole, Association association) {
+		if ( associations == null ) {
+			associations = new HashMap<>();
+		}
+		associations.put( collectionRole, association );
 	}
 
 	public static OgmEntityEntryState getStateFor(SessionImplementor session, Object object) {

--- a/core/src/main/java/org/hibernate/ogm/entityentry/impl/TuplePointer.java
+++ b/core/src/main/java/org/hibernate/ogm/entityentry/impl/TuplePointer.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.entityentry.impl;
+
+import org.hibernate.ogm.model.spi.Tuple;
+
+/**
+ * A pointer to a {@link Tuple}.
+ *
+ * @author Guillaume Smet
+ */
+public class TuplePointer {
+
+	private Tuple tuple;
+
+	public TuplePointer() {
+	}
+
+	public TuplePointer(Tuple tuple) {
+		this.tuple = tuple;
+	}
+
+	public void setTuple(Tuple tuple) {
+		this.tuple = tuple;
+	}
+
+	public Tuple getTuple() {
+		return tuple;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( getClass().getSimpleName() );
+		sb.append( "[" );
+		sb.append( tuple );
+		sb.append( "]" );
+		return sb.toString();
+	}
+
+}

--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -1203,7 +1203,7 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 				session
 			);
 
-		OgmEntityEntryState.getStateFor( session, object ).setTuple( resultset );
+		OgmEntityEntryState.getStateFor( session, object ).getTuplePointer().setTuple( resultset );
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchIndexingWorkspace.java
+++ b/core/src/main/java/org/hibernate/ogm/massindex/impl/BatchIndexingWorkspace.java
@@ -74,7 +74,7 @@ public class BatchIndexingWorkspace implements Runnable {
 			final EntityKeyMetadata keyMetadata = new DefaultEntityKeyMetadata( persister.getTableName(), persister.getRootTableIdentifierColumnNames() );
 
 			final SessionAwareRunnable consumer = new TupleIndexer( indexedType, monitor, sessionFactory, searchIntegrator, cacheMode, batchBackend, errorHandler, tenantId );
-			gridDialect.forEachTuple( new OptionallyWrapInJTATransaction( sessionFactory, errorHandler, consumer ), persister.getTupleContext( null ), keyMetadata );
+			gridDialect.forEachTuple( new OptionallyWrapInJTATransaction( sessionFactory, errorHandler, consumer ), persister.getTupleTypeContext(), keyMetadata );
 		}
 		catch ( RuntimeException re ) {
 			// being this an async thread we want to make sure everything is somehow reported

--- a/core/src/main/java/org/hibernate/ogm/model/spi/Association.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/Association.java
@@ -216,6 +216,14 @@ public class Association {
 		currentState.clear();
 	}
 
+	/**
+	 * Reset the association to the datastore state.
+	 */
+	public void reset() {
+		cleared = false;
+		currentState.clear();
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder( "Association[" ).append( StringHelper.lineSeparator() );

--- a/core/src/main/java/org/hibernate/ogm/model/spi/Tuple.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/Tuple.java
@@ -22,7 +22,7 @@ import org.hibernate.ogm.datastore.impl.SetFromCollection;
 /**
  * Represents a Tuple (think of it as a row)
  *
- * A tuple accepts a TupleShapshot which is a read-only state
+ * A tuple accepts a TupleSnapshot which is a read-only state
  * of the tuple at creation time.
  *
  * A tuple collects changes applied to it. These changes are represented by a
@@ -34,15 +34,30 @@ import org.hibernate.ogm.datastore.impl.SetFromCollection;
  */
 public class Tuple {
 
+	/**
+	 * Identifies the purpose of a {@link TupleSnapshot}.
+	 */
+	public enum SnapshotType {
+		INSERT,
+		UPDATE,
+		/**
+		 * This one is used by dialects not implementing completely the snapshot paradigm.
+		 */
+		UNKNOWN
+	}
+
 	private final TupleSnapshot snapshot;
 	private Map<String, TupleOperation> currentState = null; //lazy initialize the Map as it costs quite some memory
+	private SnapshotType snapshotType;
 
 	public Tuple() {
 		this.snapshot = EmptyTupleSnapshot.INSTANCE;
+		this.snapshotType = SnapshotType.INSERT;
 	}
 
-	public Tuple(TupleSnapshot snapshot) {
+	public Tuple(TupleSnapshot snapshot, SnapshotType snapshotType) {
 		this.snapshot = snapshot;
+		this.snapshotType = snapshotType;
 	}
 
 	public Object get(String column) {
@@ -97,6 +112,14 @@ public class Tuple {
 
 	public TupleSnapshot getSnapshot() {
 		return snapshot;
+	}
+
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	public Set<String> getColumnNames() {

--- a/core/src/main/java/org/hibernate/ogm/model/spi/TupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/TupleSnapshot.java
@@ -27,18 +27,6 @@ import java.util.Set;
 public interface TupleSnapshot {
 
 	/**
-	 * Identifies the purpose of a {@link TupleSnapshot}.
-	 */
-	public enum SnapshotType {
-		INSERT,
-		UPDATE,
-		/**
-		 * This one is used by dialects not implementing completely the snapshot paradigm.
-		 */
-		UNKNOWN
-	}
-
-	/**
 	 * Get the value of a column in the tuple
 	 *
 	 * @param column the name of the column
@@ -59,19 +47,5 @@ public interface TupleSnapshot {
 	 * @return the columns names
 	 */
 	Set<String> getColumnNames();
-
-	/**
-	 * Get the type of this snapshot
-	 *
-	 * @return the type of the snapshot
-	 */
-	SnapshotType getSnapshotType();
-
-	/**
-	 * Set the type of this snapshot
-	 *
-	 * @param snapshotType the new {@link SnapshotType}
-	 */
-	void setSnapshotType(SnapshotType snapshotType);
 
 }

--- a/core/src/main/java/org/hibernate/ogm/model/spi/TupleSnapshot.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/TupleSnapshot.java
@@ -18,13 +18,26 @@ import java.util.Set;
  * "id.countryCode" or "address.city.zipCode". The column names of the physical JPA model will be used, as e.g. given
  * via {@code @Column} .
  * <p>
- * In some special cases implementations may chose to persist different names than mandated by this model, e.g. always
+ * In some special cases implementations may choose to persist different names than mandated by this model, e.g. always
  * {@code _id} will be used as id column name by MongoDB. It is the responsibility of such implementation in this case
  * to do the required translation of column names internally.
  *
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
 public interface TupleSnapshot {
+
+	/**
+	 * Identifies the purpose of a {@link TupleSnapshot}.
+	 */
+	public enum SnapshotType {
+		INSERT,
+		UPDATE,
+		/**
+		 * This one is used by dialects not implementing completely the snapshot paradigm.
+		 */
+		UNKNOWN
+	}
+
 	/**
 	 * Get the value of a column in the tuple
 	 *
@@ -46,4 +59,19 @@ public interface TupleSnapshot {
 	 * @return the columns names
 	 */
 	Set<String> getColumnNames();
+
+	/**
+	 * Get the type of this snapshot
+	 *
+	 * @return the type of the snapshot
+	 */
+	SnapshotType getSnapshotType();
+
+	/**
+	 * Set the type of this snapshot
+	 *
+	 * @param snapshotType the new {@link SnapshotType}
+	 */
+	void setSnapshotType(SnapshotType snapshotType);
+
 }

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
@@ -159,7 +159,7 @@ class EntityAssociationUpdater {
 		}
 		associationPersister.getAssociation().put( rowKey, associationRow );
 
-		if ( associationPersister.getAssociationContext().getEntityTuple() == null ) {
+		if ( associationPersister.getAssociationContext().getEntityTuplePointer().getTuple() == null ) {
 			throw log.entityTupleNotFound( associationKeyMetadata.getCollectionRole(), associationPersister.getAssociationKey().getEntityKey() );
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
@@ -128,6 +128,8 @@ class EntityAssociationUpdater {
 
 		for ( int propertyIndex = 0; propertyIndex < persister.getEntityMetamodel().getPropertySpan(); propertyIndex++ ) {
 			if ( persister.isPropertyOfTable( propertyIndex, tableIndex ) ) {
+
+
 				AssociationKeyMetadata associationKeyMetadata = getInverseAssociationKeyMetadata( propertyIndex );
 
 				// there is no inverse association for the given property
@@ -171,7 +173,11 @@ class EntityAssociationUpdater {
 
 		Association association = associationPersister.getAssociationOrNull();
 
-		if ( association != null ) {
+		// The association might be empty if the navigation information have already been removed.
+		// This typically happens when the entity owning the inverse association has already been deleted prior to
+		// deleting the entity owning the association and a {@code @NotFound(action = NotFoundAction.IGNORE)} is
+		// involved.
+		if ( association != null && !association.isEmpty() ) {
 			RowKey rowKey = getInverseRowKey( associationKeyMetadata, oldColumnValue );
 			association.remove( rowKey );
 			associationPersister.flushToDatastore();

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/EntityAssociationUpdater.java
@@ -189,6 +189,7 @@ class EntityAssociationUpdater {
 		AssociationTypeContext associationTypeContext = new AssociationTypeContextImpl(
 				serviceContext.getPropertyOptions( entityType, associationKeyMetadata.getCollectionRole() ),
 				serviceContext.getEntityOptions( entityType ),
+				persister.getTupleTypeContext(),
 				associationKeyMetadata.getAssociatedEntityKeyMetadata(),
 				persister.getPropertyNames()[propertyIndex]
 		);

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -618,7 +618,6 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private void updateInverseSideOfAssociationNavigation(SessionImplementor session, Object entity, AssociationKey associationKey, Tuple associationRow, Action action, RowKey rowKey) {
 		if ( associationType == AssociationType.EMBEDDED_FK_TO_ENTITY ) {
 			// update the associated object

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.Session;
 import org.hibernate.annotations.common.AssertionFailure;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
@@ -725,12 +726,17 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 				// shortcut to avoid loop if we can
 				if ( associationType != AssociationType.OTHER ) {
 					for ( RowKey assocEntryKey : association.getKeys() ) {
+						Tuple associationRow = association.get( assocEntryKey );
+						Serializable entityId = (Serializable) gridTypeOfAssociatedId.nullSafeGet( associationRow, getElementColumnNames(), session, null );
+						@SuppressWarnings("unchecked")
+						Object entity = ( (Session) session ).get( getElementPersister().getMappedClass(), entityId );
+
 						// we unfortunately cannot mass change the update of the associated entity
 						updateInverseSideOfAssociationNavigation(
 								session,
-								null,
+								entity,
 								associationPersister.getAssociationKey(),
-								association.get( assocEntryKey ),
+								associationRow,
 								Action.REMOVE,
 								assocEntryKey
 								);

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -854,6 +854,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 		AssociationTypeContext associationTypeContext = new AssociationTypeContextImpl(
 				serviceContext.getPropertyOptions( getOwnerEntityPersister().getMappedClass(), associationKeyMetadata.getCollectionRole() ),
 				serviceContext.getEntityOptions( getOwnerEntityPersister().getMappedClass() ),
+				getOwnerEntityPersister().getTupleTypeContext(),
 				associationKeyMetadata.getAssociatedEntityKeyMetadata(),
 				mainSidePropertyName
 		);
@@ -884,4 +885,10 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			.associationTypeContext( associationTypeContext )
 			.session( session );
 	}
+
+	@Override
+	public OgmEntityPersister getOwnerEntityPersister() {
+		return (OgmEntityPersister) super.getOwnerEntityPersister();
+	}
+
 }

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -618,6 +618,7 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private void updateInverseSideOfAssociationNavigation(SessionImplementor session, Object entity, AssociationKey associationKey, Tuple associationRow, Action action, RowKey rowKey) {
 		if ( associationType == AssociationType.EMBEDDED_FK_TO_ENTITY ) {
 			// update the associated object
@@ -645,12 +646,12 @@ public class OgmCollectionPersister extends AbstractCollectionPersister implemen
 			else {
 				throw new AssertionFailure( "Unknown action type: " + action );
 			}
-			gridDialect.insertOrUpdateTuple( entityKey, entityTuplePointer, persister.getTupleContext( session ) );
+			persister.insertOrUpdateTuple( entityKey, entityTuplePointer, persister.hasUpdateGeneratedProperties() || persister.hasInsertGeneratedProperties(), session );
 		}
 		else if ( associationType == AssociationType.ASSOCIATION_TABLE_TO_ENTITY ) {
 			String[] elementColumnNames = getElementColumnNames();
 			Object[] elementColumnValues = LogicalPhysicalConverterHelper.getColumnValuesFromResultset( associationRow, elementColumnNames );
-			Serializable entityId = (Serializable) gridTypeOfAssociatedId.nullSafeGet( associationRow, getElementColumnNames(), session, null );
+			Serializable entityId = (Serializable) gridTypeOfAssociatedId.nullSafeGet( associationRow, elementColumnNames, session, null );
 
 			if ( inverseCollectionPersister == null ) {
 				return;

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -1229,6 +1229,12 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 	}
 
 	public void checkVersionAndRaiseSOSE(Serializable id, Object oldVersion, SessionImplementor session, Tuple resultset) {
+		// The tuple has been deleted
+		if ( resultset == null ) {
+			raiseStaleObjectStateException( id );
+			return;
+		}
+
 		final Object resultSetVersion = gridVersionType.nullSafeGet( resultset, getVersionColumnName(), session, null );
 
 		if ( !gridVersionType.isEqual( oldVersion, resultSetVersion, getFactory() ) ) {

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -1754,6 +1754,11 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		return spaces;
 	}
 
+	/**
+	 * Returns the TupleTypeContext associated with this entity type.
+	 *
+	 * @return the tupleTypeContext
+	 */
 	public TupleTypeContext getTupleTypeContext() {
 		return tupleTypeContext;
 	}
@@ -1761,13 +1766,10 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 	/**
 	 * Returns the {@link TupleContext}.
 	 *
-	 * @param session the current session, if null the {@link TupleContext#getTransactionContext()} will be null.
+	 * @param session the current session, cannot be null. If you don't have a session, you probably want to use {@code getTupleTypeContext()}.
 	 * @return the tupleContext for the session
 	 */
 	public TupleContext getTupleContext(SessionImplementor session) {
-		if ( session == null ) {
-			return new TupleContextImpl( tupleTypeContext, null );
-		}
 		return new TupleContextImpl( tupleTypeContext, TransactionContextHelper.transactionContext( session ) );
 	}
 

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -712,6 +712,9 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		checkVersionAndRaiseSOSE( id, currentVersion, session, resultset );
 		gridVersionType.nullSafeSet( resultset, nextVersion, new String[] { getVersionColumnName() }, session );
 		gridDialect.insertOrUpdateTuple( key, resultset, getTupleContext( session ) );
+
+		OgmEntityEntryState.getStateFor( session, nextVersion ).setTuple( resultset );
+
 		return nextVersion;
 	}
 
@@ -1228,6 +1231,8 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				if ( mightRequireInverseAssociationManagement ) {
 					addToInverseAssociations( resultset, j, id, session );
 				}
+
+				OgmEntityEntryState.getStateFor( session, object ).setTuple( resultset );
 			}
 		}
 	}
@@ -1810,6 +1815,8 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				setPropertyValue( entity, propertyIndex, state[propertyIndex] );
 			}
 		}
+
+		OgmEntityEntryState.getStateFor( session, entity ).setTuple( tuple );
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -1766,7 +1766,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 	@Override
 	public void processInsertGeneratedProperties(Serializable id, Object entity, Object[] state, SessionImplementor session) {
-		if ( !hasUpdateGeneratedProperties() ) {
+		if ( !hasInsertGeneratedProperties() ) {
 			throw new AssertionFailure("no insert-generated properties");
 		}
 		processGeneratedProperties( id, entity, state, session, GenerationTiming.INSERT );

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -1386,7 +1386,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 					}
 					else {
 						try {
-							invocationCollectingGridDialect.onInsertOrUpdateTupleFailure( key, resultset, new TupleAlreadyExistsException( entityKeyMetadata, resultset ) );
+							invocationCollectingGridDialect.onInsertOrUpdateTupleFailure( key, resultset, new TupleAlreadyExistsException( key ) );
 						}
 						catch ( TupleAlreadyExistsException taee ) {
 							throw log.mustNotInsertSameEntityTwice( MessageHelper.infoString( this, id, getFactory() ), taee );

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -153,6 +153,8 @@ public class AssociationPersister {
 				}
 				else {
 					association = gridDialect.getAssociation( key, getAssociationContext() );
+					OgmEntityEntryState.getStateFor( session, hostingEntity )
+							.setAssociation( associationKeyMetadata.getCollectionRole(), association );
 				}
 			}
 			else {
@@ -161,10 +163,10 @@ public class AssociationPersister {
 
 			if ( association == null ) {
 				association = gridDialect.createAssociation( key, getAssociationContext() );
-			}
-			if ( hostingEntity != null ) {
-				OgmEntityEntryState.getStateFor( session, hostingEntity )
-						.setAssociation( associationKeyMetadata.getCollectionRole(), association );
+				if ( hostingEntity != null ) {
+					OgmEntityEntryState.getStateFor( session, hostingEntity )
+							.setAssociation( associationKeyMetadata.getCollectionRole(), association );
+				}
 			}
 		}
 		return association;

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -258,7 +258,7 @@ public class AssociationPersister {
 		if ( associationContext == null ) {
 			associationContext = new AssociationContextImpl(
 					associationTypeContext,
-					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuple() : null,
+					hostingEntity != null ? OgmEntityEntryState.getStateFor( session, hostingEntity ).getTuplePointer() : null,
 					transactionContext( session )
 			);
 		}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/AssociationPersister.java
@@ -200,7 +200,7 @@ public class AssociationPersister {
 			association = null;
 			OgmEntityEntryState.getStateFor( session, hostingEntity ).setAssociation( associationKeyMetadata.getCollectionRole(), null );
 		}
-		else {
+		else if ( !getAssociation().getOperations().isEmpty() ) {
 			gridDialect.insertOrUpdateAssociation( getAssociationKey(), getAssociation(), getAssociationContext() );
 		}
 

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
@@ -70,6 +70,5 @@ public class TupleContextHelper {
 		public OperationsQueue getOperationsQueue() {
 			throw LOG.tupleContextNotAvailable();
 		}
-
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/TupleContextHelper.java
@@ -6,16 +6,12 @@
  */
 package org.hibernate.ogm.util.impl;
 
-import java.util.List;
-import java.util.Map;
-
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.spi.EntityMetadataInformation;
-import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.persister.impl.OgmEntityPersister;
 
 /**
@@ -66,22 +62,7 @@ public class TupleContextHelper {
 		}
 
 		@Override
-		public boolean isPartOfAssociation(String column) {
-			throw LOG.tupleContextNotAvailable();
-		}
-
-		@Override
-		public List<String> getSelectableColumns() {
-			throw LOG.tupleContextNotAvailable();
-		}
-
-		@Override
-		public String getRole(String column) {
-			throw LOG.tupleContextNotAvailable();
-		}
-
-		@Override
-		public OptionsContext getOptionsContext() {
+		public TupleTypeContext getTupleTypeContext() {
 			throw LOG.tupleContextNotAvailable();
 		}
 
@@ -90,19 +71,5 @@ public class TupleContextHelper {
 			throw LOG.tupleContextNotAvailable();
 		}
 
-		@Override
-		public AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column) {
-			throw LOG.tupleContextNotAvailable();
-		}
-
-		@Override
-		public Map<String, String> getAllRoles() {
-			throw LOG.tupleContextNotAvailable();
-		}
-
-		@Override
-		public Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata() {
-			throw LOG.tupleContextNotAvailable();
-		}
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
@@ -263,51 +263,52 @@ public class ManyToOneTest extends OgmTestCase {
 		checkCleanCache();
 	}
 
-	@Test
-	public void testRemovalOfTransientEntityWithAssociation() throws Exception {
-		final Session session = openSession();
-		Transaction transaction = session.beginTransaction();
-
-		SalesForce force = new SalesForce( "red_hat" );
-		force.setCorporation( "Red Hat" );
-		session.save( force );
-
-		SalesGuy eric = new SalesGuy( "eric" );
-		eric.setName( "Eric" );
-		eric.setSalesForce( force );
-		force.getSalesGuys().add( eric );
-		session.save( eric );
-
-		SalesGuy simon = new SalesGuy( "simon" );
-		simon.setName( "Simon" );
-		simon.setSalesForce( force );
-		force.getSalesGuys().add( simon );
-		session.save( simon );
-
-		transaction.commit();
-		session.clear();
-
-		transaction = session.beginTransaction();
-
-		// The classic API allows to delete transient instances;
-		// Intentionally not deleting the referencing sales guys
-		session.delete( force );
-		transaction.commit();
-
-		transaction = session.beginTransaction();
-
-		SalesGuy salesGuy = session.get( SalesGuy.class, "eric" );
-		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
-		session.delete( salesGuy );
-
-		salesGuy = session.get( SalesGuy.class, "simon" );
-		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
-		session.delete( salesGuy );
-
-		transaction.commit();
-		session.close();
-		checkCleanCache();
-	}
+// XXX GSM: reenable once fixed.
+//	@Test
+//	public void testRemovalOfTransientEntityWithAssociation() throws Exception {
+//		final Session session = openSession();
+//		Transaction transaction = session.beginTransaction();
+//
+//		SalesForce force = new SalesForce( "red_hat" );
+//		force.setCorporation( "Red Hat" );
+//		session.save( force );
+//
+//		SalesGuy eric = new SalesGuy( "eric" );
+//		eric.setName( "Eric" );
+//		eric.setSalesForce( force );
+//		force.getSalesGuys().add( eric );
+//		session.save( eric );
+//
+//		SalesGuy simon = new SalesGuy( "simon" );
+//		simon.setName( "Simon" );
+//		simon.setSalesForce( force );
+//		force.getSalesGuys().add( simon );
+//		session.save( simon );
+//
+//		transaction.commit();
+//		session.clear();
+//
+//		transaction = session.beginTransaction();
+//
+//		// The classic API allows to delete transient instances;
+//		// Intentionally not deleting the referencing sales guys
+//		session.delete( force );
+//		transaction.commit();
+//
+//		transaction = session.beginTransaction();
+//
+//		SalesGuy salesGuy = session.get( SalesGuy.class, "eric" );
+//		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
+//		session.delete( salesGuy );
+//
+//		salesGuy = session.get( SalesGuy.class, "simon" );
+//		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
+//		session.delete( salesGuy );
+//
+//		transaction.commit();
+//		session.close();
+//		checkCleanCache();
+//	}
 
 	@Test
 	public void testDefaultBiDirManyToOneCompositeKeyTest() throws Exception {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/manytoone/ManyToOneTest.java
@@ -263,52 +263,51 @@ public class ManyToOneTest extends OgmTestCase {
 		checkCleanCache();
 	}
 
-// XXX GSM: reenable once fixed.
-//	@Test
-//	public void testRemovalOfTransientEntityWithAssociation() throws Exception {
-//		final Session session = openSession();
-//		Transaction transaction = session.beginTransaction();
-//
-//		SalesForce force = new SalesForce( "red_hat" );
-//		force.setCorporation( "Red Hat" );
-//		session.save( force );
-//
-//		SalesGuy eric = new SalesGuy( "eric" );
-//		eric.setName( "Eric" );
-//		eric.setSalesForce( force );
-//		force.getSalesGuys().add( eric );
-//		session.save( eric );
-//
-//		SalesGuy simon = new SalesGuy( "simon" );
-//		simon.setName( "Simon" );
-//		simon.setSalesForce( force );
-//		force.getSalesGuys().add( simon );
-//		session.save( simon );
-//
-//		transaction.commit();
-//		session.clear();
-//
-//		transaction = session.beginTransaction();
-//
-//		// The classic API allows to delete transient instances;
-//		// Intentionally not deleting the referencing sales guys
-//		session.delete( force );
-//		transaction.commit();
-//
-//		transaction = session.beginTransaction();
-//
-//		SalesGuy salesGuy = session.get( SalesGuy.class, "eric" );
-//		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
-//		session.delete( salesGuy );
-//
-//		salesGuy = session.get( SalesGuy.class, "simon" );
-//		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
-//		session.delete( salesGuy );
-//
-//		transaction.commit();
-//		session.close();
-//		checkCleanCache();
-//	}
+	@Test
+	public void testRemovalOfTransientEntityWithAssociation() throws Exception {
+		final Session session = openSession();
+		Transaction transaction = session.beginTransaction();
+
+		SalesForce force = new SalesForce( "red_hat" );
+		force.setCorporation( "Red Hat" );
+		session.save( force );
+
+		SalesGuy eric = new SalesGuy( "eric" );
+		eric.setName( "Eric" );
+		eric.setSalesForce( force );
+		force.getSalesGuys().add( eric );
+		session.save( eric );
+
+		SalesGuy simon = new SalesGuy( "simon" );
+		simon.setName( "Simon" );
+		simon.setSalesForce( force );
+		force.getSalesGuys().add( simon );
+		session.save( simon );
+
+		transaction.commit();
+		session.clear();
+
+		transaction = session.beginTransaction();
+
+		// The classic API allows to delete transient instances;
+		// Intentionally not deleting the referencing sales guys
+		session.delete( force );
+		transaction.commit();
+
+		transaction = session.beginTransaction();
+
+		SalesGuy salesGuy = session.get( SalesGuy.class, "eric" );
+		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
+		session.delete( salesGuy );
+
+		salesGuy = session.get( SalesGuy.class, "simon" );
+		assertThat( salesGuy.getSalesForce() ).describedAs( "Stale association should be exposed as null" ).isNull();
+		session.delete( salesGuy );
+
+		transaction.commit();
+		session.close();
+		checkCleanCache();
+	}
 
 	@Test
 	public void testDefaultBiDirManyToOneCompositeKeyTest() throws Exception {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetEmbeddedIdTest.java
@@ -164,7 +164,10 @@ public class MultiGetEmbeddedIdTest extends OgmTestCase {
 
 	private TupleContext tupleContext(Session session) {
 		return new GridDialectOperationContexts.TupleContextBuilder()
-				.selectableColumns( METADATA.getColumnNames() )
+				.tupleTypeContext(
+						new GridDialectOperationContexts.TupleTypeContextBuilder()
+								.selectableColumns( METADATA.getColumnNames() )
+								.buildTupleTypeContext() )
 				.transactionContext( session )
 				.buildTupleContext();
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetMultiColumnsIdTest.java
@@ -124,7 +124,10 @@ public class MultiGetMultiColumnsIdTest extends OgmTestCase {
 
 	private TupleContext tupleContext(Session session) {
 		return new GridDialectOperationContexts.TupleContextBuilder()
-				.selectableColumns( METADATA.getColumnNames() )
+				.tupleTypeContext(
+						new GridDialectOperationContexts.TupleTypeContextBuilder()
+								.selectableColumns( METADATA.getColumnNames() )
+								.buildTupleTypeContext() )
 				.transactionContext( session )
 				.buildTupleContext();
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/batchfetching/MultiGetSingleColumnIdTest.java
@@ -127,7 +127,10 @@ public class MultiGetSingleColumnIdTest extends OgmTestCase {
 
 	private TupleContext tupleContext(Session session) {
 		return new GridDialectOperationContexts.TupleContextBuilder()
-				.selectableColumns( "name", "publisher" )
+				.tupleTypeContext(
+						new GridDialectOperationContexts.TupleTypeContextBuilder()
+								.selectableColumns( "name", "publisher" )
+								.buildTupleTypeContext() )
 				.transactionContext( session )
 				.buildTupleContext();
 	}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
@@ -93,7 +93,7 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 		Iterator<GridDialectOperation> appliedOperations = onRollbackInvocations.next().getAppliedGridDialectOperations().iterator();
 		assertThat( onRollbackInvocations.hasNext() ).isFalse();
 
-		if ( currentDialectHasFacet( BatchableGridDialect.class ) ) {
+		if ( currentDialectHasFacet( BatchableGridDialect.class ) || currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			GridDialectOperation operation = appliedOperations.next();
@@ -102,24 +102,6 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 			ExecuteBatch batch = operation.as( ExecuteBatch.class );
 			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-		}
-		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-
-			GridDialectOperation operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			ExecuteBatch batch = operation.as( ExecuteBatch.class );
-			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-
-			operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			batch = operation.as( ExecuteBatch.class );
-			batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
 			assertThat( batchedOperations.hasNext() ).isFalse();
 		}
@@ -184,12 +166,7 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 		Iterator<GridDialectOperation> appliedOperations = onRollbackInvocations.next().getAppliedGridDialectOperations().iterator();
 		assertThat( onRollbackInvocations.hasNext() ).isFalse();
 
-		if ( currentDialectHasFacet( BatchableGridDialect.class ) ) {
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( ExecuteBatch.class );
-		}
-		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
+		if ( currentDialectHasFacet( BatchableGridDialect.class ) || currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 
@@ -198,12 +175,6 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 			ExecuteBatch batch = operation.as( ExecuteBatch.class );
 			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-
-			operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			batch = operation.as( ExecuteBatch.class );
-			batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
 			assertThat( batchedOperations.hasNext() ).isFalse();
 		}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiJpaTest.java
@@ -27,6 +27,7 @@ import org.hibernate.ogm.compensation.operation.ExecuteBatch;
 import org.hibernate.ogm.compensation.operation.GridDialectOperation;
 import org.hibernate.ogm.compensation.operation.InsertOrUpdateTuple;
 import org.hibernate.ogm.dialect.batch.spi.BatchableGridDialect;
+import org.hibernate.ogm.dialect.batch.spi.GroupingByEntityDialect;
 import org.hibernate.ogm.dialect.impl.GridDialects;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.GridDialect;
@@ -104,6 +105,24 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
 			assertThat( batchedOperations.hasNext() ).isFalse();
 		}
+		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
+			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
+			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
+
+			GridDialectOperation operation = appliedOperations.next();
+			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
+			ExecuteBatch batch = operation.as( ExecuteBatch.class );
+			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
+			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
+			assertThat( batchedOperations.hasNext() ).isFalse();
+
+			operation = appliedOperations.next();
+			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
+			batch = operation.as( ExecuteBatch.class );
+			batchedOperations = batch.getOperations().iterator();
+			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
+			assertThat( batchedOperations.hasNext() ).isFalse();
+		}
 		else {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
@@ -169,6 +188,24 @@ public class CompensationSpiJpaTest  extends OgmJpaTestCase {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( ExecuteBatch.class );
+		}
+		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
+			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
+			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
+
+			GridDialectOperation operation = appliedOperations.next();
+			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
+			ExecuteBatch batch = operation.as( ExecuteBatch.class );
+			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
+			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
+			assertThat( batchedOperations.hasNext() ).isFalse();
+
+			operation = appliedOperations.next();
+			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
+			batch = operation.as( ExecuteBatch.class );
+			batchedOperations = batch.getOperations().iterator();
+			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
+			assertThat( batchedOperations.hasNext() ).isFalse();
 		}
 		else {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/compensation/CompensationSpiTest.java
@@ -93,7 +93,8 @@ public class CompensationSpiTest extends OgmTestCase {
 		Iterator<GridDialectOperation> appliedOperations = onRollbackInvocations.next().getAppliedGridDialectOperations().iterator();
 		assertThat( onRollbackInvocations.hasNext() ).isFalse();
 
-		if ( currentDialectHasFacet( BatchableGridDialect.class ) ) {
+		if ( currentDialectHasFacet( BatchableGridDialect.class ) ||
+				currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			GridDialectOperation operation = appliedOperations.next();
@@ -102,24 +103,6 @@ public class CompensationSpiTest extends OgmTestCase {
 			ExecuteBatch batch = operation.as( ExecuteBatch.class );
 			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-		}
-		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-
-			GridDialectOperation operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			ExecuteBatch batch = operation.as( ExecuteBatch.class );
-			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-
-			operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			batch = operation.as( ExecuteBatch.class );
-			batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
 			assertThat( batchedOperations.hasNext() ).isFalse();
 		}
@@ -167,15 +150,10 @@ public class CompensationSpiTest extends OgmTestCase {
 		Iterator<GridDialectOperation> appliedOperations = onRollbackInvocations.next().getAppliedGridDialectOperations().iterator();
 		assertThat( onRollbackInvocations.hasNext() ).isFalse();
 
-		if ( currentDialectHasFacet( BatchableGridDialect.class ) ) {
+		if ( currentDialectHasFacet( BatchableGridDialect.class )
+				|| currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( ExecuteBatch.class );
-		}
-		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( ExecuteBatch.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( ExecuteBatch.class );
 		}
 		else {
@@ -393,7 +371,8 @@ public class CompensationSpiTest extends OgmTestCase {
 		// and the applied ops
 		Iterator<GridDialectOperation> appliedOperations = invocation.getAppliedGridDialectOperations().iterator();
 
-		if ( currentDialectHasFacet( BatchableGridDialect.class ) ) {
+		if ( currentDialectHasFacet( BatchableGridDialect.class ) ||
+				currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
 			GridDialectOperation operation = appliedOperations.next();
@@ -402,24 +381,6 @@ public class CompensationSpiTest extends OgmTestCase {
 			ExecuteBatch batch = operation.as( ExecuteBatch.class );
 			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-		}
-		else if ( currentDialectHasFacet( GroupingByEntityDialect.class ) ) {
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-			assertThat( appliedOperations.next() ).isInstanceOf( CreateTupleWithKey.class );
-
-			GridDialectOperation operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			ExecuteBatch batch = operation.as( ExecuteBatch.class );
-			Iterator<GridDialectOperation> batchedOperations = batch.getOperations().iterator();
-			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
-			assertThat( batchedOperations.hasNext() ).isFalse();
-
-			operation = appliedOperations.next();
-			assertThat( operation ).isInstanceOf( ExecuteBatch.class );
-			batch = operation.as( ExecuteBatch.class );
-			batchedOperations = batch.getOperations().iterator();
 			assertThat( batchedOperations.next() ).isInstanceOf( InsertOrUpdateTuple.class );
 			assertThat( batchedOperations.hasNext() ).isFalse();
 		}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/AbstractGridDialectOperationInvocationsTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/AbstractGridDialectOperationInvocationsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.dialectinvocations;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.dialect.impl.GridDialects;
+import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
+import org.hibernate.ogm.utils.InvokedOperationsLoggingDialect;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Before;
+
+/**
+ * Base class for all the tests checking the operation invoked.
+ *
+ * @author Guillaume Smet
+ */
+public abstract class AbstractGridDialectOperationInvocationsTest extends OgmTestCase {
+
+	@Before
+	public void resetOperationsLog() {
+		getOperationsLogger().reset();
+	}
+
+	@Override
+	protected void configure(Map<String, Object> settings) {
+		settings.put( OgmProperties.GRID_DIALECT, InvokedOperationsLoggingDialect.class );
+	}
+
+	private InvokedOperationsLoggingDialect getOperationsLogger() {
+		InvokedOperationsLoggingDialect invocationLogger = GridDialects.getDelegateOrNull(
+				getGridDialect(),
+				InvokedOperationsLoggingDialect.class
+		);
+
+		return invocationLogger;
+	}
+
+	protected GridDialect getGridDialect() {
+		return getSessionFactory().getServiceRegistry().getService( GridDialect.class );
+	}
+
+	protected List<String> getOperations() {
+		return getOperationsLogger().getOperations();
+	}
+
+	protected boolean isDuplicateInsertPreventionStrategyNative(GridDialect gridDialect) {
+		return DuplicateInsertPreventionStrategy.NATIVE
+				.equals( gridDialect.getDuplicateInsertPreventionStrategy( new DefaultEntityKeyMetadata( "TableName", new String[]{ "id" } ) ) );
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/loader/LoaderFromTupleTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/loader/LoaderFromTupleTest.java
@@ -24,6 +24,7 @@ import org.hibernate.ogm.loader.impl.OgmLoadingContext;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.persister.impl.OgmEntityPersister;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.persister.entity.EntityPersister;
@@ -48,7 +49,7 @@ public class LoaderFromTupleTest extends OgmTestCase {
 		transaction = session.beginTransaction();
 		EntityKey key = new EntityKey( new DefaultEntityKeyMetadata( "Feeling", new String[] { "UUID" } ), new Object[] { feeling.getUUID() } );
 		Map<String, Object> entityTuple = extractEntityTuple( session, key );
-		final Tuple tuple = new Tuple( new MapTupleSnapshot( entityTuple ) );
+		final Tuple tuple = new Tuple( new MapTupleSnapshot( entityTuple ), SnapshotType.UPDATE );
 
 		EntityPersister persister = ( (SessionFactoryImplementor) session.getSessionFactory() )
 				.getEntityPersister( Feeling.class.getName() );

--- a/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
@@ -22,6 +22,7 @@ import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -146,7 +147,7 @@ public class BatchExecutionTest extends OgmTestCase {
 		}
 
 		@Override
-		public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+		public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/batch/BatchExecutionTest.java
@@ -21,8 +21,10 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -106,17 +108,17 @@ public class BatchExecutionTest extends OgmTestCase {
 		}
 
 		@Override
-		public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple getTuple(EntityKey key, OperationContext tupleContext) {
 			return null;
 		}
 
 		@Override
-		public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple createTuple(EntityKey key, OperationContext tupleContext) {
 			return new Tuple();
 		}
 
 		@Override
-		public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+		public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
@@ -21,6 +21,7 @@ import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -123,7 +124,7 @@ public class DatastoreProviderGeneratingSchema extends BaseDatastoreProvider {
 		}
 
 		@Override
-		public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+		public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		}
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/DatastoreProviderGeneratingSchema.java
@@ -20,8 +20,10 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -78,17 +80,17 @@ public class DatastoreProviderGeneratingSchema extends BaseDatastoreProvider {
 		}
 
 		@Override
-		public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple getTuple(EntityKey key, OperationContext tupleContext) {
 			return null;
 		}
 
 		@Override
-		public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple createTuple(EntityKey key, OperationContext tupleContext) {
 			return null;
 		}
 
 		@Override
-		public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+		public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
@@ -21,6 +21,7 @@ import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.utils.GridDialectOperationContexts;
 import org.junit.Test;
 
@@ -50,7 +51,7 @@ public class EmbeddableStateFinderTest {
 		tupleData.put( "nested3.null1.b2", null );
 		tupleData.put( "nested3.null2", null );
 
-		Tuple tuple = new Tuple( new MapTupleSnapshot( tupleData ) );
+		Tuple tuple = new Tuple( new MapTupleSnapshot( tupleData ), SnapshotType.UPDATE );
 
 		TupleContext context = new TupleContext() {
 			@Override

--- a/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/datastore/document/EmbeddableStateFinderTest.java
@@ -7,23 +7,22 @@
 
 package org.hibernate.ogm.test.datastore.document;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.datastore.document.impl.EmbeddableStateFinder;
+import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.dialect.batch.spi.OperationsQueue;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
-import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.options.spi.OptionsContext;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.hibernate.ogm.utils.GridDialectOperationContexts;
+import org.junit.Test;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
@@ -55,43 +54,6 @@ public class EmbeddableStateFinderTest {
 
 		TupleContext context = new TupleContext() {
 			@Override
-			public OptionsContext getOptionsContext() {
-				return null;
-			}
-
-			@Override
-			public List<String> getSelectableColumns() {
-				List<String> results = new ArrayList<String>();
-				results.addAll( tupleData.keySet() );
-				return results;
-			}
-
-			@Override
-			public boolean isPartOfAssociation(String column) {
-				return false;
-			}
-
-			@Override
-			public AssociatedEntityKeyMetadata getAssociatedEntityKeyMetadata(String column) {
-				return null;
-			}
-
-			@Override
-			public Map<String, AssociatedEntityKeyMetadata> getAllAssociatedEntityKeyMetadata() {
-				return null;
-			}
-
-			@Override
-			public String getRole(String column) {
-				return null;
-			}
-
-			@Override
-			public Map<String, String> getAllRoles() {
-				return null;
-			}
-
-			@Override
 			public OperationsQueue getOperationsQueue() {
 				return null;
 			}
@@ -99,6 +61,13 @@ public class EmbeddableStateFinderTest {
 			@Override
 			public TransactionContext getTransactionContext() {
 				return null;
+			}
+
+			@Override
+			public TupleTypeContext getTupleTypeContext() {
+				List<String> results = new ArrayList<String>();
+				results.addAll( tupleData.keySet() );
+				return new GridDialectOperationContexts.TupleTypeContextBuilder().selectableColumns( results ).buildTupleTypeContext();
 			}
 		};
 

--- a/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
+++ b/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
@@ -14,6 +14,7 @@ import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -83,7 +84,7 @@ public class SampleDatastoreProvider extends BaseDatastoreProvider {
 		}
 
 		@Override
-		public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+		public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		}
 	}
 }

--- a/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
+++ b/core/src/test/java/org/hibernate/ogm/test/options/mapping/model/SampleDatastoreProvider.java
@@ -13,8 +13,10 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -38,17 +40,17 @@ public class SampleDatastoreProvider extends BaseDatastoreProvider {
 		}
 
 		@Override
-		public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple getTuple(EntityKey key, OperationContext tupleContext) {
 			return null;
 		}
 
 		@Override
-		public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+		public Tuple createTuple(EntityKey key, OperationContext tupleContext) {
 			return null;
 		}
 
 		@Override
-		public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+		public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
 		}
 
 		@Override

--- a/core/src/test/java/org/hibernate/ogm/test/util/impl/TupleContextHelperTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/util/impl/TupleContextHelperTest.java
@@ -51,7 +51,7 @@ public class TupleContextHelperTest extends OgmTestCase {
 		thrown.expectMessage( "OGM000087" );
 
 		TupleContext tupleContext = TupleContextHelper.tupleContext( (SessionImplementor) openSession(), null );
-		tupleContext.getAllRoles();
+		tupleContext.getTupleTypeContext().getAllRoles();
 	}
 
 	@Test

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -20,8 +20,8 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
-import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.util.impl.TransactionContextHelper;
 
@@ -93,7 +93,6 @@ public class GridDialectOperationContexts {
 		private AssociatedEntityKeyMetadata associatedEntityKeyMetadata = null;
 		private String roleOnMainSide = null;
 		private TransactionContext transactionContext = null;
-		private Tuple tuple = null;
 
 		public AssociationContextBuilder optionsContext(OptionsContext optionsContext) {
 			this.optionsContext = optionsContext;
@@ -117,7 +116,7 @@ public class GridDialectOperationContexts {
 
 		public AssociationContext buildAssociationContext() {
 			return new AssociationContextImpl( new AssociationTypeContextImpl( optionsContext, ownerEntityOptionsContext, ownerEntityTupleTypeContext,
-					associatedEntityKeyMetadata, roleOnMainSide ), tuple, transactionContext );
+					associatedEntityKeyMetadata, roleOnMainSide ), new TuplePointer(), transactionContext );
 		}
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -15,9 +15,11 @@ import org.hibernate.Session;
 import org.hibernate.ogm.dialect.impl.AssociationContextImpl;
 import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
 import org.hibernate.ogm.dialect.impl.TupleContextImpl;
+import org.hibernate.ogm.dialect.impl.TupleTypeContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.options.spi.OptionsContext;
@@ -32,35 +34,54 @@ public class GridDialectOperationContexts {
 
 	public static class TupleContextBuilder {
 
-		private List<String> selectableColumns = Collections.<String>emptyList();
-		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = Collections.<String, AssociatedEntityKeyMetadata>emptyMap();
-		private Map<String, String> roles = Collections.<String, String>emptyMap();
-		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
 		private TransactionContext transactionContext = null;
-
-		public TupleContextBuilder selectableColumns(String... columns) {
-			this.selectableColumns = Arrays.asList( columns );
-			return this;
-		}
-
-		public TupleContextBuilder selectableColumns(List<String> columns) {
-			this.selectableColumns = columns;
-			return this;
-		}
+		private TupleTypeContext tupleTypeContext;
 
 		public TupleContextBuilder transactionContext(Session session) {
 			this.transactionContext = TransactionContextHelper.transactionContext( session );
 			return this;
 		}
 
-		public TupleContextBuilder optionContext(OptionsContext optionsContext) {
-			this.optionsContext = optionsContext;
+		public TupleContextBuilder tupleTypeContext(TupleTypeContext tupleTypeContext) {
+			this.tupleTypeContext = tupleTypeContext;
 			return this;
 		}
 
 		public TupleContext buildTupleContext() {
-			return new TupleContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
-					Collections.unmodifiableMap( roles ), optionsContext, transactionContext );
+			return new TupleContextImpl( tupleTypeContext, transactionContext );
+		}
+	}
+
+	public static class TupleTypeContextBuilder {
+
+		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
+		private List<String> selectableColumns = Collections.<String>emptyList();
+		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = Collections.<String, AssociatedEntityKeyMetadata>emptyMap();
+		private Map<String, String> roles = Collections.<String, String>emptyMap();
+
+		public TupleTypeContextBuilder selectableColumns(String... columns) {
+			this.selectableColumns = Arrays.asList( columns );
+			return this;
+		}
+
+		public TupleTypeContextBuilder selectableColumns(List<String> columns) {
+			this.selectableColumns = columns;
+			return this;
+		}
+
+		public TupleTypeContextBuilder roles(Map<String, String> roles) {
+			this.roles = roles;
+			return this;
+		}
+
+		public TupleTypeContextBuilder optionContext(OptionsContext optionsContext) {
+			this.optionsContext = optionsContext;
+			return this;
+		}
+
+		public TupleTypeContext buildTupleTypeContext() {
+			return new TupleTypeContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
+					Collections.unmodifiableMap( roles ), optionsContext );
 		}
 	}
 
@@ -68,6 +89,7 @@ public class GridDialectOperationContexts {
 
 		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
 		private OptionsContext ownerEntityOptionsContext = EmptyOptionsContext.INSTANCE;
+		private TupleTypeContext ownerEntityTupleTypeContext;
 		private AssociatedEntityKeyMetadata associatedEntityKeyMetadata = null;
 		private String roleOnMainSide = null;
 		private TransactionContext transactionContext = null;
@@ -83,14 +105,19 @@ public class GridDialectOperationContexts {
 			return this;
 		}
 
+		public AssociationContextBuilder ownerEntityTupleTypeContext(TupleTypeContext ownerEntityTupleTypeContext) {
+			this.ownerEntityTupleTypeContext = ownerEntityTupleTypeContext;
+			return this;
+		}
+
 		public AssociationContextBuilder transactionContext(Session session) {
 			this.transactionContext = TransactionContextHelper.transactionContext( session );
 			return this;
 		}
 
 		public AssociationContext buildAssociationContext() {
-			return new AssociationContextImpl( new AssociationTypeContextImpl( optionsContext, ownerEntityOptionsContext, associatedEntityKeyMetadata, roleOnMainSide ), tuple,
-					transactionContext );
+			return new AssociationContextImpl( new AssociationTypeContextImpl( optionsContext, ownerEntityOptionsContext, ownerEntityTupleTypeContext,
+					associatedEntityKeyMetadata, roleOnMainSide ), tuple, transactionContext );
 		}
 	}
 
@@ -98,7 +125,11 @@ public class GridDialectOperationContexts {
 	}
 
 	public static TupleContext emptyTupleContext() {
-		return new TupleContextBuilder().buildTupleContext();
+		return new TupleContextBuilder().tupleTypeContext( emptyTupleTypeContext() ).buildTupleContext();
+	}
+
+	public static TupleTypeContext emptyTupleTypeContext() {
+		return new TupleTypeContextBuilder().buildTupleTypeContext();
 	}
 
 	public static AssociationContext emptyAssociationContext() {

--- a/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/InvokedOperationsLoggingDialect.java
@@ -31,7 +31,9 @@ import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
@@ -82,8 +84,8 @@ public class InvokedOperationsLoggingDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
-		Tuple tuple = super.getTuple( key, tupleContext );
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
+		Tuple tuple = super.getTuple( key, operationContext );
 		log( "getTuple", key.toString(), tuple != null ? tuple.toString() : "null" );
 		return tuple;
 	}
@@ -96,16 +98,16 @@ public class InvokedOperationsLoggingDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
-		Tuple tuple = super.createTuple( key, tupleContext );
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
+		Tuple tuple = super.createTuple( key, operationContext );
 		log( "createTuple", key.toString(), tuple != null ? tuple.toString() : "null" );
 		return tuple;
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		super.insertOrUpdateTuple( key, tuple, tupleContext );
-		log( "insertOrUpdateTuple", key.toString() + ", " + tuple.toString(), "VOID" );
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		super.insertOrUpdateTuple( key, tuplePointer, tupleContext );
+		log( "insertOrUpdateTuple", key.toString() + ", " + tuplePointer.toString(), "VOID" );
 	}
 
 	@Override
@@ -155,8 +157,8 @@ public class InvokedOperationsLoggingDialect extends ForwardingGridDialect<Seria
 	}
 
 	@Override
-	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		return super.createTuple( entityKeyMetadata, tupleContext );
+	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, OperationContext operationContext) {
+		return super.createTuple( entityKeyMetadata, operationContext );
 	}
 
 	@Override

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
@@ -140,6 +140,8 @@ public class OgmTestRunner extends SkippableTestRunner {
 		}
 		finally {
 			if ( testMethodScopedSessionFactory != null ) {
+				cleanUpPendingTransactionIfRequired();
+				TestHelper.dropSchemaAndDatabase( testScopedSessionFactory );
 				testMethodScopedSessionFactory.close();
 			}
 		}

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.ogm.datastore.couchdb;
 
 import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
-import static org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType.UPDATE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,8 +58,8 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.model.spi.TupleOperation;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.type.impl.Iso8601StringCalendarType;
 import org.hibernate.ogm.type.impl.Iso8601StringDateType;
@@ -94,7 +93,7 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 		EntityDocument entity = getDataStore().getEntity( Identifier.createEntityId( key ) );
 		if ( entity != null ) {
-			return new Tuple( new CouchDBTupleSnapshot( entity, SnapshotType.UPDATE ) );
+			return new Tuple( new CouchDBTupleSnapshot( entity ), SnapshotType.UPDATE );
 		}
 		else if ( isInTheInsertionQueue( key, operationContext ) ) {
 			return createTuple( key, operationContext );
@@ -106,7 +105,7 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 
 	@Override
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
-		return new Tuple( new CouchDBTupleSnapshot( new EntityDocument( key ), SnapshotType.INSERT ) );
+		return new Tuple( new CouchDBTupleSnapshot( new EntityDocument( key ) ), SnapshotType.INSERT );
 	}
 
 	@Override
@@ -124,7 +123,7 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 				Tuple tuple = insertOrUpdateTupleOperation.getTuplePointer().getTuple();
 				TupleContext tupleContext = insertOrUpdateTupleOperation.getTupleContext();
 
-				if ( SnapshotType.INSERT.equals( tuple.getSnapshot().getSnapshotType() ) ) {
+				if ( SnapshotType.INSERT.equals( tuple.getSnapshotType() ) ) {
 					snapshotType = SnapshotType.INSERT;
 				}
 
@@ -286,7 +285,7 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 			EntityDocument owningEntity = getEntityFromTuple( tuplePointer.getTuple() );
 			if ( owningEntity == null ) {
 				owningEntity = (EntityDocument) getDataStore().saveDocument( new EntityDocument( key.getEntityKey() ) );
-				tuplePointer.setTuple( new Tuple( new CouchDBTupleSnapshot( owningEntity, UPDATE ) ) );
+				tuplePointer.setTuple( new Tuple( new CouchDBTupleSnapshot( owningEntity ), SnapshotType.UPDATE ) );
 			}
 
 			couchDBAssociation = CouchDBAssociation.fromEmbeddedAssociation( tuplePointer, key.getMetadata() );

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -39,9 +39,9 @@ import org.hibernate.ogm.dialect.batch.spi.InsertOrUpdateAssociationOperation;
 import org.hibernate.ogm.dialect.batch.spi.InsertOrUpdateTupleOperation;
 import org.hibernate.ogm.dialect.batch.spi.Operation;
 import org.hibernate.ogm.dialect.batch.spi.RemoveAssociationOperation;
+import org.hibernate.ogm.dialect.impl.AbstractGroupingByEntityDialect;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
-import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
@@ -82,7 +82,7 @@ import org.hibernate.type.Type;
  * @author Gunnar Morling
  * @author Guillaume Smet
  */
-public class CouchDBDialect extends BaseGridDialect implements GroupingByEntityDialect {
+public class CouchDBDialect extends AbstractGroupingByEntityDialect implements GroupingByEntityDialect {
 
 	private final CouchDBDatastoreProvider provider;
 

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -37,6 +37,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -311,7 +312,7 @@ public class CouchDBDialect extends BaseGridDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		forTuple( consumer, entityKeyMetadata );
 	}
 

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.ogm.datastore.couchdb;
 
+import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,9 +37,11 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -57,8 +61,6 @@ import org.hibernate.type.SerializableToBlobType;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 
-import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
-
 /**
  * Stores tuples and associations as JSON documents inside CouchDB.
  * <p>
@@ -77,7 +79,7 @@ public class CouchDBDialect extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 		EntityDocument entity = getDataStore().getEntity( Identifier.createEntityId( key ) );
 		if ( entity != null ) {
 			return new Tuple( new CouchDBTupleSnapshot( entity.getProperties() ) );
@@ -87,12 +89,13 @@ public class CouchDBDialect extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		return new Tuple( new CouchDBTupleSnapshot( key ) );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		Tuple tuple = tuplePointer.getTuple();
 		CouchDBTupleSnapshot snapshot = (CouchDBTupleSnapshot) tuple.getSnapshot();
 
 		String revision = (String) snapshot.get( Document.REVISION_FIELD_NAME );

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -112,7 +112,7 @@ public class CouchDBDialect extends BaseGridDialect {
 		}
 		catch (OptimisticLockException ole) {
 			if ( snapshot.isCreatedOnInsert() ) {
-				throw new TupleAlreadyExistsException( key.getMetadata(), tuple, ole );
+				throw new TupleAlreadyExistsException( key, ole );
 			}
 			else {
 				throw ole;

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/CouchDBDialect.java
@@ -237,11 +237,6 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
-	}
-
-	@Override
 	public void removeTuple(EntityKey key, TupleContext tupleContext) {
 		removeDocumentIfPresent( Identifier.createEntityId( key ) );
 	}
@@ -306,11 +301,6 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 		return association;
 	}
 
-	@Override
-	public void insertOrUpdateAssociation(AssociationKey associationKey, Association association, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Method not supported in GridDialect anymore" );
-	}
-
 	private Object getAssociationRows(Association association, AssociationKey associationKey, AssociationContext associationContext) {
 		boolean organizeByRowKey = DotPatternMapHelpers.organizeAssociationMapByRowKey(
 				association,
@@ -369,11 +359,6 @@ public class CouchDBDialect extends AbstractGroupingByEntityDialect implements G
 		}
 
 		return rowObject.getPropertiesAsHierarchy();
-	}
-
-	@Override
-	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
 	}
 
 	@Override

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/designdocument/impl/EntityTupleRows.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/designdocument/impl/EntityTupleRows.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
 import org.hibernate.ogm.datastore.couchdb.dialect.model.impl.CouchDBTupleSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -39,7 +40,7 @@ public class EntityTupleRows {
 		List<Tuple> tuples = new ArrayList<Tuple>( rows.size() );
 		if ( rows.size() > 0 ) {
 			for ( Row row : rows ) {
-				tuples.add( new Tuple( new CouchDBTupleSnapshot( row.getValue().getProperties() ) ) );
+				tuples.add( new Tuple( new CouchDBTupleSnapshot( row.getValue(), SnapshotType.UPDATE ) ) );
 			}
 		}
 		return tuples;

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/designdocument/impl/EntityTupleRows.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/designdocument/impl/EntityTupleRows.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
 import org.hibernate.ogm.datastore.couchdb.dialect.model.impl.CouchDBTupleSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -40,7 +40,7 @@ public class EntityTupleRows {
 		List<Tuple> tuples = new ArrayList<Tuple>( rows.size() );
 		if ( rows.size() > 0 ) {
 			for ( Row row : rows ) {
-				tuples.add( new Tuple( new CouchDBTupleSnapshot( row.getValue(), SnapshotType.UPDATE ) ) );
+				tuples.add( new Tuple( new CouchDBTupleSnapshot( row.getValue() ), SnapshotType.UPDATE ) );
 			}
 		}
 		return tuples;

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/impl/EntityDocument.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/backend/json/impl/EntityDocument.java
@@ -98,10 +98,13 @@ public class EntityDocument extends Document {
 		super( Identifier.createEntityId( key ), revision );
 		table = key.getTable();
 
+		for ( int i = 0; i < key.getColumnNames().length; i++ ) {
+			properties.put( key.getColumnNames()[i], key.getColumnValues()[i] );
+		}
+
 		if ( tuple != null ) {
 			for ( String columnName : tuple.getColumnNames() ) {
 				if ( columnName != Document.REVISION_FIELD_NAME ) {
-
 					Object value = tuple.get( columnName );
 					if ( value != null ) {
 						properties.put( columnName, value );
@@ -223,7 +226,7 @@ public class EntityDocument extends Document {
 	}
 
 	@JsonIgnore
-	public void removeAssociation(String name) {
+	public void unset(String name) {
 		if ( properties.containsKey( name ) ) {
 			properties.remove( name );
 		}
@@ -231,11 +234,27 @@ public class EntityDocument extends Document {
 			Set<String> keys = new HashSet<String>( properties.keySet() );
 			for ( String key : keys ) {
 				if ( key.startsWith( name + "." ) ) {
-					removeAssociation( key );
+					unset( key );
 				}
 			}
 
 			DotPatternMapHelpers.resetValue( properties, name );
 		}
 	}
+
+	@JsonIgnore
+	public boolean isEmpty() {
+		return getProperties().isEmpty();
+	}
+
+	@JsonIgnore
+	public Set<String> getKeys() {
+		return getProperties().keySet();
+	}
+
+	@JsonIgnore
+	public Object getProperty(String dotPath) {
+		return getProperties().get( dotPath );
+	}
+
 }

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociation.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBAssociation.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.AssociationDocument;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.Document;
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 
 /**
@@ -25,12 +26,12 @@ public abstract class CouchDBAssociation {
 	/**
 	 * Creates a {@link CouchDBAssociation} from the given {@link EntityDocument} and association name.
 	 *
-	 * @param entity the owner of the association
+	 * @param tuplePointer the owner of the association
 	 * @param associationKeyMetadata association key meta-data
 	 * @return a {@link CouchDBAssociation} representing the association
 	 */
-	public static CouchDBAssociation fromEmbeddedAssociation(EntityDocument entity, AssociationKeyMetadata associationKeyMetadata) {
-		return new EmbeddedAssociation( entity, associationKeyMetadata );
+	public static CouchDBAssociation fromEmbeddedAssociation(TuplePointer tuplePointer, AssociationKeyMetadata associationKeyMetadata) {
+		return new EmbeddedAssociation( tuplePointer, associationKeyMetadata );
 	}
 
 	/**

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
@@ -20,11 +20,9 @@ import org.hibernate.ogm.model.spi.TupleSnapshot;
 public class CouchDBTupleSnapshot implements TupleSnapshot {
 
 	private final EntityDocument entity;
-	private SnapshotType snapshotType;
 
-	public CouchDBTupleSnapshot(EntityDocument entity, SnapshotType snapshotType) {
+	public CouchDBTupleSnapshot(EntityDocument entity) {
 		this.entity = entity;
-		this.snapshotType = snapshotType;
 	}
 
 	@Override
@@ -40,16 +38,6 @@ public class CouchDBTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return entity.getKeys();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	public EntityDocument getEntity() {

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
@@ -6,57 +6,40 @@
  */
 package org.hibernate.ogm.datastore.couchdb.dialect.model.impl;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.couchdb.dialect.backend.json.impl.EntityDocument;
-import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
-import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
 
 /**
- * A {@link TupleSnapshot} based on the properties of a CouchDB {@link EntityDocument}.
- * <p>
- * Fundamentally a {@link MapTupleSnapshot} except that the {@link EntityKey} column names and values are copied.
+ * A {@link TupleSnapshot} based on a CouchDB {@link EntityDocument}.
  *
  * @author Andrea Boriero &lt;dreborier@gmail.com&gt;
  * @author Gunnar Morling
  */
 public class CouchDBTupleSnapshot implements TupleSnapshot {
 
-	private final Map<String, Object> properties;
-	private final boolean createdOnInsert;
+	private final EntityDocument entity;
+	private SnapshotType snapshotType;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
-	public CouchDBTupleSnapshot(EntityKey key) {
-		createdOnInsert = true;
-
-		properties = new HashMap<String, Object>();
-		for ( int i = 0; i < key.getColumnNames().length; i++ ) {
-			properties.put( key.getColumnNames()[i], key.getColumnValues()[i] );
-		}
-	}
-
-	public CouchDBTupleSnapshot(Map<String, Object> properties) {
-		createdOnInsert = false;
-		this.properties = properties;
+	public CouchDBTupleSnapshot(EntityDocument entity, SnapshotType snapshotType) {
+		this.entity = entity;
+		this.snapshotType = snapshotType;
 	}
 
 	@Override
 	public Object get(String column) {
-		return properties.get( column );
+		return entity.getProperty( column );
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return properties.isEmpty();
+		return entity.isEmpty();
 	}
 
 	@Override
 	public Set<String> getColumnNames() {
-		return properties.keySet();
+		return entity.getKeys();
 	}
 
 	@Override
@@ -69,13 +52,7 @@ public class CouchDBTupleSnapshot implements TupleSnapshot {
 		this.snapshotType = snapshotType;
 	}
 
-	/**
-	 * Whether this snapshot has been created during an insert or not.
-	 *
-	 * @return {@code true} if the snapshot has been created during an insert, {@code false} if it has been created
-	 * during an update.
-	 */
-	public boolean isCreatedOnInsert() {
-		return createdOnInsert;
+	public EntityDocument getEntity() {
+		return entity;
 	}
 }

--- a/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
+++ b/couchdb/src/main/java/org/hibernate/ogm/datastore/couchdb/dialect/model/impl/CouchDBTupleSnapshot.java
@@ -28,6 +28,8 @@ public class CouchDBTupleSnapshot implements TupleSnapshot {
 	private final Map<String, Object> properties;
 	private final boolean createdOnInsert;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public CouchDBTupleSnapshot(EntityKey key) {
 		createdOnInsert = true;
 
@@ -55,6 +57,16 @@ public class CouchDBTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return properties.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	/**

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/dialect/CouchDBDialectTest.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/dialect/CouchDBDialectTest.java
@@ -21,6 +21,7 @@ import org.hibernate.ogm.datastore.couchdb.CouchDBDialect;
 import org.hibernate.ogm.datastore.couchdb.dialect.model.impl.CouchDBTupleSnapshot;
 import org.hibernate.ogm.datastore.couchdb.impl.CouchDBDatastoreProvider;
 import org.hibernate.ogm.datastore.couchdb.utils.CouchDBTestHelper;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.impl.DefaultAssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
@@ -75,7 +76,7 @@ public class CouchDBDialectTest {
 		EntityKey key = createEntityKey( "user", new String[] { "id", "age" }, new Object[] { "17", 36 } );
 		Tuple createdTuple = dialect.createTuple( key, emptyTupleContext() );
 
-		dialect.insertOrUpdateTuple( key, createdTuple, emptyTupleContext() );
+		dialect.insertOrUpdateTuple( key, new TuplePointer( createdTuple ), emptyTupleContext() );
 
 		Tuple actualTuple = dialect.getTuple( key, emptyTupleContext() );
 
@@ -99,7 +100,7 @@ public class CouchDBDialectTest {
 		Tuple createdTuple = dialect.createTuple( key, emptyTupleContext() );
 		createdTuple.put( "name", "and" );
 
-		dialect.insertOrUpdateTuple( key, createdTuple, emptyTupleContext() );
+		dialect.insertOrUpdateTuple( key, new TuplePointer( createdTuple ), emptyTupleContext() );
 
 		Tuple tuple = dialect.getTuple( key, emptyTupleContext() );
 		assertThat( (String) tuple.get( "name" ) ).isEqualTo( "and" );
@@ -129,7 +130,7 @@ public class CouchDBDialectTest {
 		Object[] rowKeyColumnValues = new Object[] { "Emmanuel", 1 };
 		EntityKey entityKey = createEntityKey( "user", new String[] { "id", "age" }, new Object[] { "17", 36 } );
 		Tuple tuple = dialect.createTuple( entityKey, emptyTupleContext() );
-		dialect.insertOrUpdateTuple( entityKey, tuple, emptyTupleContext() );
+		dialect.insertOrUpdateTuple( entityKey, new TuplePointer( tuple ), emptyTupleContext() );
 
 		AssociationKey key = createAssociationKey(
 				entityKey, "addresses", "user_address", new String[] { "user_id" }, new Object[] { "Emmanuel" }, rowKeyColumnNames

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/dialect/optimisticlocking/User.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/test/dialect/optimisticlocking/User.java
@@ -74,7 +74,7 @@ public class User {
 			projectIds.add( project.getId() );
 		}
 
-		return "Contributor [id=" + id + ", name=" + name + ", revision=" + revision +
+		return "User [id=" + id + ", name=" + name + ", revision=" + revision +
 				", projects=[" + StringHelper.join( projectIds, ", " ) + "]]";
 	}
 }

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
@@ -45,7 +45,6 @@ import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.exception.impl.Exceptions;
 import org.hibernate.ogm.model.key.spi.EntityKey;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.utils.GridDialectTestHelper;
 import org.jboss.resteasy.client.exception.ResteasyClientException;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -187,7 +186,7 @@ public class CouchDBTestHelper implements GridDialectTestHelper {
 		Map<String, Object> tupleMap = new HashMap<String, Object>();
 		CouchDBDatastore dataStore = getDataStore( session.getSessionFactory() );
 		EntityDocument entity = dataStore.getEntity( Identifier.createEntityId( key ) );
-		CouchDBTupleSnapshot snapshot = new CouchDBTupleSnapshot( entity, SnapshotType.UPDATE );
+		CouchDBTupleSnapshot snapshot = new CouchDBTupleSnapshot( entity );
 		Set<String> columnNames = snapshot.getColumnNames();
 		for ( String columnName : columnNames ) {
 			tupleMap.put( columnName, snapshot.get( columnName ) );

--- a/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
+++ b/couchdb/src/test/java/org/hibernate/ogm/datastore/couchdb/utils/CouchDBTestHelper.java
@@ -45,6 +45,7 @@ import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.exception.impl.Exceptions;
 import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.utils.GridDialectTestHelper;
 import org.jboss.resteasy.client.exception.ResteasyClientException;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -186,7 +187,7 @@ public class CouchDBTestHelper implements GridDialectTestHelper {
 		Map<String, Object> tupleMap = new HashMap<String, Object>();
 		CouchDBDatastore dataStore = getDataStore( session.getSessionFactory() );
 		EntityDocument entity = dataStore.getEntity( Identifier.createEntityId( key ) );
-		CouchDBTupleSnapshot snapshot = new CouchDBTupleSnapshot( entity.getProperties() );
+		CouchDBTupleSnapshot snapshot = new CouchDBTupleSnapshot( entity, SnapshotType.UPDATE );
 		Set<String> columnNames = snapshot.getColumnNames();
 		for ( String columnName : columnNames ) {
 			tupleMap.put( columnName, snapshot.get( columnName ) );

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -41,6 +41,7 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.AssociationOperation;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.persister.entity.Lockable;
 
 import net.sf.ehcache.Element;
@@ -100,12 +101,12 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 
 	@SuppressWarnings("unchecked")
 	private Tuple createTuple(final Element element) {
-		return new Tuple( new MapTupleSnapshot( (Map<String, Object>) element.getObjectValue() ) );
+		return new Tuple( new MapTupleSnapshot( (Map<String, Object>) element.getObjectValue() ), SnapshotType.UPDATE );
 	}
 
 	@Override
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
-		return new Tuple( new MapTupleSnapshot( new HashMap<String, Object>() ) );
+		return new Tuple( new MapTupleSnapshot( new HashMap<String, Object>() ), SnapshotType.INSERT );
 	}
 
 	@Override

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -175,6 +175,8 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 			}
 		}
 
+		association.reset();
+
 		final Cache<AK> associationCache = getCacheManager().getAssociationCache( key.getMetadata() );
 		associationCache.put( new Element( getKeyProvider().getAssociationCacheKey( key ), associationRows ) );
 	}

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -33,6 +33,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -206,7 +207,7 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		getCacheManager().forEachTuple( new EntityKeyProcessor( consumer ), entityKeyMetadata );
 	}
 

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -9,8 +9,6 @@ package org.hibernate.ogm.datastore.ehcache;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.sf.ehcache.Element;
-
 import org.hibernate.LockMode;
 import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.dialect.lock.OptimisticForceIncrementLockingStrategy;
@@ -31,9 +29,11 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -42,6 +42,8 @@ import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.AssociationOperation;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.persister.entity.Lockable;
+
+import net.sf.ehcache.Element;
 
 /**
  * Persists domain models in the Ehcache key/value store.
@@ -85,7 +87,7 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 		final Cache<EK> entityCache = getCacheManager().getEntityCache( key.getMetadata() );
 		final Element element = entityCache.get( getKeyProvider().getEntityCacheKey( key ) );
 		if ( element != null ) {
@@ -102,12 +104,13 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		return new Tuple( new MapTupleSnapshot( new HashMap<String, Object>() ) );
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		Tuple tuple = tuplePointer.getTuple();
 		Cache<EK> entityCache = getCacheManager().getEntityCache( key.getMetadata() );
 
 		Map<String, Object> entityRecord = ( (MapTupleSnapshot) tuple.getSnapshot() ).getMap();

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/EhcacheDialect.java
@@ -119,7 +119,7 @@ public class EhcacheDialect<EK, AK, ISK> extends BaseGridDialect {
 			MapHelpers.applyTupleOpsOnMap( tuple, entityRecord );
 			Element previous = entityCache.putIfAbsent( new Element( getKeyProvider().getEntityCacheKey( key ), entityRecord ) );
 			if ( previous != null ) {
-				throw new TupleAlreadyExistsException( key.getMetadata(), tuple );
+				throw new TupleAlreadyExistsException( key );
 			}
 		}
 		else {

--- a/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/dialect/impl/SerializableMapAssociationSnapshot.java
+++ b/ehcache/src/main/java/org/hibernate/ogm/datastore/ehcache/dialect/impl/SerializableMapAssociationSnapshot.java
@@ -15,6 +15,7 @@ import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.AssociationSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * An {@link AssociationSnapshot} based on a serializable map.
@@ -34,7 +35,7 @@ public final class SerializableMapAssociationSnapshot implements AssociationSnap
 	@Override
 	public Tuple get(RowKey column) {
 		Map<String, Object> rawResult = associationMap.get( new SerializableRowKey( column ) );
-		return rawResult != null ? new Tuple( new MapTupleSnapshot( rawResult ) ) : null;
+		return rawResult != null ? new Tuple( new MapTupleSnapshot( rawResult ), SnapshotType.UPDATE ) : null;
 	}
 
 	@Override

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
@@ -29,8 +29,10 @@ import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -95,7 +97,7 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple getTuple(EntityKey key, OperationContext operationContext) {
 		EK cacheKey = getKeyProvider().getEntityCacheKey( key );
 		Cache<EK, Map<String, Object>> cache = getCacheManager().getEntityCache( key.getMetadata() );
 		return getTupleFromCacheKey( cacheKey, cache );
@@ -116,7 +118,7 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		//TODO we don't verify that it does not yet exist assuming that this has been done before by the calling code
 		//should we improve?
 		Cache<EK, Map<String, Object>> cache = getCacheManager().getEntityCache( key.getMetadata() );
@@ -126,7 +128,8 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		Tuple tuple = tuplePointer.getTuple();
 		Map<String,Object> atomicMap = ( (InfinispanTupleSnapshot) tuple.getSnapshot() ).getAtomicMap();
 		MapHelpers.applyTupleOpsOnMap( tuple, atomicMap );
 	}

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
@@ -40,6 +40,7 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.persister.entity.Lockable;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -113,7 +114,7 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 			return null;
 		}
 		else {
-			return new Tuple( new InfinispanTupleSnapshot( atomicMap ) );
+			return new Tuple( new InfinispanTupleSnapshot( atomicMap ), SnapshotType.UPDATE );
 		}
 	}
 
@@ -124,7 +125,7 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 		Cache<EK, Map<String, Object>> cache = getCacheManager().getEntityCache( key.getMetadata() );
 		EK cacheKey = getKeyProvider().getEntityCacheKey( key );
 		FineGrainedAtomicMap<String,Object> atomicMap =  AtomicMapLookup.getFineGrainedAtomicMap( cache, cacheKey, true );
-		return new Tuple( new InfinispanTupleSnapshot( atomicMap ) );
+		return new Tuple( new InfinispanTupleSnapshot( atomicMap ), SnapshotType.INSERT );
 	}
 
 	@Override

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
@@ -30,6 +30,7 @@ import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -209,7 +210,7 @@ public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		Set<Bucket<EK>> buckets = getCacheManager().getWorkBucketsFor(
 				entityKeyMetadata
 		);

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanTupleSnapshot.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanTupleSnapshot.java
@@ -17,6 +17,8 @@ import org.infinispan.atomic.FineGrainedAtomicMap;
 public final class InfinispanTupleSnapshot implements TupleSnapshot {
 	private final FineGrainedAtomicMap<String, Object> atomicMap;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public InfinispanTupleSnapshot(FineGrainedAtomicMap<String,Object> atomicMap) {
 		this.atomicMap = atomicMap;
 	}
@@ -33,6 +35,16 @@ public final class InfinispanTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return atomicMap.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	public FineGrainedAtomicMap<String, Object> getAtomicMap() {

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanTupleSnapshot.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanTupleSnapshot.java
@@ -17,8 +17,6 @@ import org.infinispan.atomic.FineGrainedAtomicMap;
 public final class InfinispanTupleSnapshot implements TupleSnapshot {
 	private final FineGrainedAtomicMap<String, Object> atomicMap;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public InfinispanTupleSnapshot(FineGrainedAtomicMap<String,Object> atomicMap) {
 		this.atomicMap = atomicMap;
 	}
@@ -35,16 +33,6 @@ public final class InfinispanTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return atomicMap.keySet();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	public FineGrainedAtomicMap<String, Object> getAtomicMap() {

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
@@ -27,6 +27,7 @@ import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.id.spi.PersistentNoSqlIdentifierGenerator;
 import org.hibernate.ogm.model.impl.DefaultAssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
@@ -99,7 +100,7 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 		// when
 		Tuple tuple = dialect1.createTuple( key, emptyTupleContext() );
 		tuple.put( "foo", "bar" );
-		dialect1.insertOrUpdateTuple( key, tuple, emptyTupleContext() );
+		dialect1.insertOrUpdateTuple( key, new TuplePointer( tuple ), emptyTupleContext() );
 
 		// then
 		Tuple readTuple = dialect2.getTuple( key, null );
@@ -159,7 +160,7 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 		// when
 		Tuple tuple = dialect1.createTuple( key, emptyTupleContext() );
 		tuple.put( "foo", "bar" );
-		dialect1.insertOrUpdateTuple( key, tuple, emptyTupleContext() );
+		dialect1.insertOrUpdateTuple( key, new TuplePointer( tuple ), emptyTupleContext() );
 
 		// then
 		MyConsumer consumer = new MyConsumer();

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.datastore.infinispan.test.dialect.impl;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.hibernate.ogm.utils.GridDialectOperationContexts.emptyTupleContext;
+import static org.hibernate.ogm.utils.GridDialectOperationContexts.emptyTupleTypeContext;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -162,7 +163,7 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 
 		// then
 		MyConsumer consumer = new MyConsumer();
-		dialect2.forEachTuple( consumer, emptyTupleContext(), keyMetadata );
+		dialect2.forEachTuple( consumer, emptyTupleTypeContext(), keyMetadata );
 		assertThat( consumer.consumedTuple.get( "foo" ) ).isEqualTo( "bar" );
 	}
 

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -56,6 +56,7 @@ import org.hibernate.ogm.datastore.mongodb.type.impl.ObjectIdGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.StringAsObjectIdGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.StringAsObjectIdType;
 import org.hibernate.ogm.dialect.batch.spi.BatchableGridDialect;
+import org.hibernate.ogm.dialect.batch.spi.GroupedChangesToEntityOperation;
 import org.hibernate.ogm.dialect.batch.spi.InsertOrUpdateAssociationOperation;
 import org.hibernate.ogm.dialect.batch.spi.InsertOrUpdateTupleOperation;
 import org.hibernate.ogm.dialect.batch.spi.Operation;
@@ -141,6 +142,7 @@ import com.mongodb.WriteResult;
  * @author Alan Fitton &lt;alan at eth0.org.uk&gt;
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  * @author Thorsten Möller &lt;thorsten.moeller@sbi.ch&gt;
+ * @author Guillaume Smet
  */
 public class MongoDBDialect extends BaseGridDialect implements QueryableGridDialect<MongoDBQueryDescriptor>, BatchableGridDialect, IdentityColumnAwareGridDialect, MultigetGridDialect, OptimisticLockingAwareGridDialect {
 
@@ -220,7 +222,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		if ( found != null ) {
 			return new Tuple( new MongoDBTupleSnapshot( found, key.getMetadata(), UPDATE ) );
 		}
-		else if ( isInTheQueue( key, tupleContext ) ) {
+		else if ( isInTheInsertionQueue( key, tupleContext ) ) {
 			// The key has not been inserted in the db but it is in the queue
 			return new Tuple( new MongoDBTupleSnapshot( prepareIdObject( key ), key.getMetadata(), INSERT ) );
 		}
@@ -229,9 +231,9 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 	}
 
-	private static boolean isInTheQueue(EntityKey key, TupleContext tupleContext) {
+	private static boolean isInTheInsertionQueue(EntityKey key, TupleContext tupleContext) {
 		OperationsQueue queue = tupleContext.getOperationsQueue();
-		return queue != null && queue.contains( key );
+		return queue != null && queue.isInTheInsertionQueue( key );
 	}
 
 	@Override
@@ -387,26 +389,27 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		query.append( operator, subQuery.append( column, value ) );
 	}
 
+	private static void addSetToQuery(BasicDBObject query, String column, Object value) {
+		removeSubQuery( "$unset", query, column );
+		addSubQuery( "$set", query, column, value );
+	}
+
+	private static void addUnsetToQuery(BasicDBObject query, String column) {
+		removeSubQuery( "$set", query, column );
+		addSubQuery( "$unset", query, column, Integer.valueOf( 1 ) );
+	}
+
+	private static void removeSubQuery(String operator, BasicDBObject query, String column) {
+		BasicDBObject subQuery = getSubQuery( operator, query );
+		subQuery.removeField( column );
+		if ( subQuery.isEmpty() ) {
+			query.removeField( operator );
+		}
+	}
+
 	@Override
 	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		BasicDBObject idObject = prepareIdObject( key );
-
-		DBObject updater = objectForUpdate( tuple, idObject, tupleContext );
-		WriteConcern writeConcern = getWriteConcern( tupleContext );
-
-		try {
-			getCollection( key ).update( idObject, updater, true, false, writeConcern );
-		}
-		catch ( DuplicateKeyException dke ) {
-			// This exception is used by MongoDB for all the unique indexes violation, not only the primary key
-			// so we determine if it concerns the primary key by matching on the message
-			if ( PRIMARY_KEY_CONSTRAINT_VIOLATION_MESSAGE.matcher( dke.getMessage() ).matches() ) {
-				throw new TupleAlreadyExistsException( key.getMetadata(), tuple, dke );
-			}
-			else {
-				throw log.constraintViolationForEntity( key, dke.getMessage(), dke );
-			}
-		}
+		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
 	}
 
 	@Override
@@ -418,7 +421,11 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 			idObject.put( versionColumn, oldLockState.get( versionColumn ) );
 		}
 
-		DBObject updater = objectForUpdate( tuple, idObject, tupleContext );
+		BasicDBObject updater = objectForUpdate( tuple, tupleContext );
+		if ( updater.isEmpty() ) {
+			return false;
+		}
+
 		DBObject doc = getCollection( entityKey ).findAndModify( idObject, updater );
 
 		return doc != null;
@@ -463,18 +470,21 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		return dbObject;
 	}
 
-	private static DBObject objectForUpdate(Tuple tuple, DBObject idObject, TupleContext tupleContext) {
+	private static BasicDBObject objectForUpdate(Tuple tuple, TupleContext tupleContext) {
+		return objectForUpdate( tuple, tupleContext, new BasicDBObject() );
+	}
+
+	private static BasicDBObject objectForUpdate(Tuple tuple, TupleContext tupleContext, BasicDBObject updateStatement) {
 		MongoDBTupleSnapshot snapshot = (MongoDBTupleSnapshot) tuple.getSnapshot();
 		EmbeddableStateFinder embeddableStateFinder = new EmbeddableStateFinder( tuple, tupleContext );
 		Set<String> nullEmbeddables = new HashSet<String>();
 
-		BasicDBObject updater = new BasicDBObject();
 		for ( TupleOperation operation : tuple.getOperations() ) {
 			String column = operation.getColumn();
 			if ( notInIdField( snapshot, column ) ) {
 				switch ( operation.getType() ) {
 				case PUT:
-					addSubQuery( "$set", updater, column, operation.getValue() );
+					addSetToQuery( updateStatement, column, operation.getValue() );
 					break;
 				case PUT_NULL:
 				case REMOVE:
@@ -485,30 +495,20 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 						// we have a null embeddable
 						if ( ! nullEmbeddables.contains( nullEmbeddable ) ) {
 							// we have not processed it yet
-							addSubQuery( "$unset", updater, nullEmbeddable, Integer.valueOf( 1 ) );
+							addUnsetToQuery( updateStatement, nullEmbeddable );
 							nullEmbeddables.add( nullEmbeddable );
 						}
 					}
 					else {
 						// simply unset the column
-						addSubQuery( "$unset", updater, column, Integer.valueOf( 1 ) );
+						addUnsetToQuery( updateStatement, column );
 					}
 					break;
 				}
 			}
 		}
-		/*
-		* Needed because in case of an object with only an ID field
-		* the "_id" won't be persisted properly.
-		* With this adjustment, it will work like this:
-		*	if the object (from snapshot) doesn't exist, create the one represented by updater
-		*	so if at this moment the "_id" is not enforced properly, an ObjectID will be created by the server instead
-		*	of the custom id
-		 */
-		if ( updater.size() == 0 ) {
-			return idObject;
-		}
-		return updater;
+
+		return updateStatement;
 	}
 
 	private static boolean notInIdField(MongoDBTupleSnapshot snapshot, String column) {
@@ -555,16 +555,16 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 	}
 
-	private static boolean isInTheQueue(EntityKey key, AssociationContext associationContext) {
+	private static boolean isInTheInsertionQueue(EntityKey key, AssociationContext associationContext) {
 		OperationsQueue queue = associationContext.getOperationsQueue();
-		return queue != null && queue.contains( key );
+		return queue != null && queue.isInTheInsertionQueue( key );
 	}
 
 	@Override
 	public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
 		AssociationStorageStrategy storageStrategy = getAssociationStorageStrategy( key, associationContext );
 
-		if ( isEmbeddedAssociation( key ) && isInTheQueue( key.getEntityKey(), associationContext ) ) {
+		if ( isEmbeddedAssociation( key ) && isInTheInsertionQueue( key.getEntityKey(), associationContext ) ) {
 			// The association is embedded and the owner of the association is in the insertion queue
 			DBObject idObject = prepareIdObject( key.getEntityKey() );
 			return new Association( new MongoDBAssociationSnapshot( idObject, key, storageStrategy ) );
@@ -687,60 +687,12 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 
 	@Override
 	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
-		DBCollection collection;
-		DBObject query;
-		MongoDBAssociationSnapshot assocSnapshot = (MongoDBAssociationSnapshot) association.getSnapshot();
-		String associationField;
-
-		AssociationStorageStrategy storageStrategy = getAssociationStorageStrategy( key, associationContext );
-		WriteConcern writeConcern = getWriteConcern( associationContext );
-
-		Object rows = getAssociationRows( association, key, associationContext );
-		Object toStore = key.getMetadata().getAssociationType() == AssociationType.ONE_TO_ONE ? ( (List<?>) rows ).get( 0 ) : rows;
-
-		if ( storageStrategy == AssociationStorageStrategy.IN_ENTITY ) {
-			collection = this.getCollection( key.getEntityKey() );
-			query = prepareIdObject( key.getEntityKey() );
-			associationField = key.getMetadata().getCollectionRole();
-
-			//TODO would that fail if getCollectionRole has dots?
-			( (MongoDBTupleSnapshot) associationContext.getEntityTuple().getSnapshot() ).getDbObject().put( key.getMetadata().getCollectionRole(), toStore );
-		}
-		else {
-			collection = getAssociationCollection( key, storageStrategy );
-			query = assocSnapshot.getQueryObject();
-			associationField = ROWS_FIELDNAME;
-		}
-
-		DBObject update = new BasicDBObject( "$set", new BasicDBObject( associationField, toStore ) );
-
-		collection.update( query, update, true, false, writeConcern );
+		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
 	}
 
 	@Override
 	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
-		AssociationStorageStrategy storageStrategy = getAssociationStorageStrategy( key, associationContext );
-		WriteConcern writeConcern = getWriteConcern( associationContext );
-
-		if ( storageStrategy == AssociationStorageStrategy.IN_ENTITY ) {
-			DBObject entity = prepareIdObject( key.getEntityKey() );
-			if ( entity != null ) {
-				BasicDBObject updater = new BasicDBObject();
-				addSubQuery( "$unset", updater, key.getMetadata().getCollectionRole(), Integer.valueOf( 1 ) );
-				DBObject dbObject = getEmbeddingEntity( key, associationContext );
-				if ( dbObject != null ) {
-					dbObject.removeField( key.getMetadata().getCollectionRole() );
-					getCollection( key.getEntityKey() ).update( entity, updater, true, false, writeConcern );
-				}
-			}
-		}
-		else {
-			DBCollection collection = getAssociationCollection( key, storageStrategy );
-			DBObject query = associationKeyToObject( key, storageStrategy );
-
-			int nAffected = collection.remove( query, writeConcern ).getN();
-			log.removedAssociation( nAffected );
-		}
+		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
 	}
 
 	@Override
@@ -1141,6 +1093,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	 * @param obj A JSON object representing a write concern.
 	 * @return The parsed write concern or <code>null</code> if <code>obj</code> is <code>null</code>.
 	 */
+	@SuppressWarnings("deprecation")
 	private static WriteConcern getWriteConcern(DBObject obj) {
 		WriteConcern wc = null;
 		if ( obj != null ) {
@@ -1237,36 +1190,25 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 			List<MongoDBTupleSnapshot> insertSnapshots = new ArrayList<MongoDBTupleSnapshot>();
 
 			while ( operation != null ) {
-				if ( operation instanceof InsertOrUpdateTupleOperation ) {
-					InsertOrUpdateTupleOperation update = (InsertOrUpdateTupleOperation) operation;
-					executeBatchUpdate( inserts, update );
-					MongoDBTupleSnapshot snapshot = (MongoDBTupleSnapshot) update.getTuple().getSnapshot();
-					if ( snapshot.getSnapshotType() == INSERT ) {
-						insertSnapshots.add( snapshot );
-					}
+				if ( operation instanceof GroupedChangesToEntityOperation ) {
+					GroupedChangesToEntityOperation entityOperation = (GroupedChangesToEntityOperation) operation;
+					executeBatchUpdate( inserts, insertSnapshots, entityOperation );
 				}
 				else if ( operation instanceof RemoveTupleOperation ) {
 					RemoveTupleOperation tupleOp = (RemoveTupleOperation) operation;
 					executeBatchRemove( inserts, tupleOp );
-				}
-				else if ( operation instanceof InsertOrUpdateAssociationOperation ) {
-					InsertOrUpdateAssociationOperation update = (InsertOrUpdateAssociationOperation) operation;
-					executeBatchUpdateAssociation( inserts, update );
-				}
-				else if ( operation instanceof RemoveAssociationOperation ) {
-					RemoveAssociationOperation remove = (RemoveAssociationOperation) operation;
-					removeAssociation( remove.getAssociationKey(), remove.getContext() );
 				}
 				else {
 					throw new UnsupportedOperationException( "Operation not supported on MongoDB: " + operation.getClass().getName() );
 				}
 				operation = queue.poll();
 			}
-			flushInserts( inserts );
 
+			flushInserts( inserts );
 			for ( MongoDBTupleSnapshot insertSnapshot : insertSnapshots ) {
 				insertSnapshot.setSnapshotType( UPDATE );
 			}
+
 			queue.clear();
 		}
 	}
@@ -1284,42 +1226,99 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 	}
 
-	private void executeBatchUpdate(Map<DBCollection, BatchInsertionTask> inserts, InsertOrUpdateTupleOperation tupleOperation) {
-		EntityKey entityKey = tupleOperation.getEntityKey();
-		Tuple tuple = tupleOperation.getTuple();
-		MongoDBTupleSnapshot snapshot = (MongoDBTupleSnapshot) tupleOperation.getTuple().getSnapshot();
-		WriteConcern writeConcern = getWriteConcern( tupleOperation.getTupleContext() );
+	private void executeBatchUpdate(Map<DBCollection, BatchInsertionTask> inserts, List<MongoDBTupleSnapshot> insertSnapshots,
+			GroupedChangesToEntityOperation groupedOperation) {
+		EntityKey entityKey = groupedOperation.getEntityKey();
+		DBCollection collection = getCollection( entityKey );
+		DBObject insertStatement = null;
+		BasicDBObject updateStatement = new BasicDBObject();
+		WriteConcern writeConcern = null;
 
-		if ( INSERT == snapshot.getSnapshotType() ) {
-			prepareForInsert( inserts, snapshot, entityKey, tuple, writeConcern );
-		}
-		else {
-			// Object already exists in the db or has invalid fields:
-			insertOrUpdateTuple( entityKey, tuple, tupleOperation.getTupleContext() );
-		}
-	}
+		for (Operation operation : groupedOperation.getOperations()) {
+			if ( operation instanceof InsertOrUpdateTupleOperation ) {
+				InsertOrUpdateTupleOperation tupleOperation = (InsertOrUpdateTupleOperation) operation;
+				Tuple tuple = tupleOperation.getTuple();
+				MongoDBTupleSnapshot snapshot = (MongoDBTupleSnapshot) tuple.getSnapshot();
+				writeConcern = mergeWriteConcern( writeConcern, getWriteConcern( tupleOperation.getTupleContext() ) );
 
-	private void executeBatchUpdateAssociation(Map<DBCollection, BatchInsertionTask> inserts, InsertOrUpdateAssociationOperation updateOp) {
-		AssociationKey associationKey = updateOp.getAssociationKey();
-		if ( isEmbeddedAssociation( associationKey ) ) {
-			DBCollection collection = getCollection( associationKey.getEntityKey() );
-			BatchInsertionTask batchInserts = inserts.get( collection );
-			if ( batchInserts != null && batchInserts.containsKey( associationKey.getEntityKey() ) ) {
-				// The owner of the association is in the insertion queue,
-				// we are going to update it with the collection of elements
-				WriteConcern writeConcern = getWriteConcern( updateOp.getContext() );
-				BatchInsertionTask insertTask = getOrCreateBatchInsertionTask( inserts, associationKey.getEntityKey().getMetadata(), collection, writeConcern );
-				DBObject documentForInsertion = insertTask.get( associationKey.getEntityKey() );
-				Object embeddedElements = getAssociationRows( updateOp.getAssociation(), updateOp.getAssociationKey(), updateOp.getContext() );
+				if ( INSERT == snapshot.getSnapshotType() ) {
+					DBObject document = getCurrentDocument( snapshot, insertStatement, entityKey );
+					insertStatement = objectForInsert( tuple, document );
+
+					getOrCreateBatchInsertionTask( inserts, entityKey.getMetadata(), collection, writeConcern )
+							.put( entityKey, insertStatement );
+					insertSnapshots.add( snapshot );
+				}
+				else {
+					updateStatement = objectForUpdate( tuple, tupleOperation.getTupleContext(), updateStatement );
+				}
+			}
+			else if ( operation instanceof InsertOrUpdateAssociationOperation) {
+				InsertOrUpdateAssociationOperation updateAssociationOperation = (InsertOrUpdateAssociationOperation) operation;
+				Association association = updateAssociationOperation.getAssociation();
+				AssociationKey associationKey = updateAssociationOperation.getAssociationKey();
+				AssociationContext associationContext = updateAssociationOperation.getContext();
+				AssociationStorageStrategy storageStrategy = getAssociationStorageStrategy( associationKey, associationContext );
 				String collectionRole = associationKey.getMetadata().getCollectionRole();
-				MongoHelpers.setValue( documentForInsertion, collectionRole, embeddedElements );
+
+				Object rows = getAssociationRows( association, associationKey, associationContext );
+				Object toStore = associationKey.getMetadata().getAssociationType() == AssociationType.ONE_TO_ONE ? ( (List<?>) rows ).get( 0 ) : rows;
+
+				if ( storageStrategy == AssociationStorageStrategy.IN_ENTITY ) {
+					writeConcern = mergeWriteConcern( writeConcern, getWriteConcern( associationContext ) );
+					if ( insertStatement != null ) {
+						MongoHelpers.setValue( insertStatement, collectionRole, rows );
+					}
+					else {
+						MongoHelpers.setValue( ( (MongoDBTupleSnapshot) associationContext.getEntityTuple().getSnapshot() ).getDbObject(),
+								associationKey.getMetadata().getCollectionRole(), toStore );
+						addSetToQuery( updateStatement, collectionRole, toStore );
+					}
+				}
+				else {
+					MongoDBAssociationSnapshot associationSnapshot = (MongoDBAssociationSnapshot) association.getSnapshot();
+					DBCollection associationCollection = getAssociationCollection( associationKey, storageStrategy );
+					DBObject query = associationSnapshot.getQueryObject();
+					DBObject update = new BasicDBObject( "$set", new BasicDBObject( ROWS_FIELDNAME, toStore ) );
+					associationCollection.update( query, update, true, false, getWriteConcern( associationContext ) );
+				}
+			}
+			else if ( operation instanceof RemoveAssociationOperation ) {
+				if ( insertStatement != null ) {
+					throw new IllegalStateException( "RemoveAssociationOperation not supported in the INSERT case" );
+				}
+
+				RemoveAssociationOperation removeAssociationOperation = (RemoveAssociationOperation) operation;
+				AssociationKey associationKey = removeAssociationOperation.getAssociationKey();
+				AssociationContext associationContext = removeAssociationOperation.getContext();
+
+				AssociationStorageStrategy storageStrategy = getAssociationStorageStrategy( associationKey, associationContext );
+
+				if ( storageStrategy == AssociationStorageStrategy.IN_ENTITY ) {
+					writeConcern = mergeWriteConcern( writeConcern, getWriteConcern( associationContext ) );
+					String collectionRole = associationKey.getMetadata().getCollectionRole();
+
+					if ( associationContext.getEntityTuple() != null ) {
+						MongoHelpers.resetValue( ( (MongoDBTupleSnapshot) associationContext.getEntityTuple().getSnapshot() ).getDbObject(),
+								collectionRole );
+					}
+					addUnsetToQuery( updateStatement, collectionRole );
+				}
+				else {
+					DBCollection associationCollection = getAssociationCollection( associationKey, storageStrategy );
+					DBObject query = associationKeyToObject( associationKey, storageStrategy );
+
+					int nAffected = associationCollection.remove( query, getWriteConcern( associationContext ) ).getN();
+					log.removedAssociation( nAffected );
+				}
 			}
 			else {
-				insertOrUpdateAssociation( updateOp.getAssociationKey(), updateOp.getAssociation(), updateOp.getContext() );
+				throw new IllegalStateException( operation.getClass().getSimpleName() + " not supported here" );
 			}
 		}
-		else {
-			insertOrUpdateAssociation( updateOp.getAssociationKey(), updateOp.getAssociation(), updateOp.getContext() );
+
+		if ( updateStatement != null && !updateStatement.isEmpty() ) {
+			collection.update( prepareIdObject( entityKey ), updateStatement, true, false, writeConcern );
 		}
 	}
 
@@ -1328,17 +1327,8 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		return NoOpParameterMetadataBuilder.INSTANCE;
 	}
 
-	private void prepareForInsert(Map<DBCollection, BatchInsertionTask> inserts, MongoDBTupleSnapshot snapshot, EntityKey entityKey, Tuple tuple, WriteConcern writeConcern) {
-		DBCollection collection = getCollection( entityKey );
-		BatchInsertionTask batchInsertion = getOrCreateBatchInsertionTask( inserts, entityKey.getMetadata(), collection, writeConcern );
-		DBObject document = getCurrentDocument( snapshot, batchInsertion, entityKey );
-		DBObject newDocument = objectForInsert( tuple, document );
-		inserts.get( collection ).put( entityKey, newDocument );
-	}
-
-	private static DBObject getCurrentDocument(MongoDBTupleSnapshot snapshot, BatchInsertionTask batchInsert, EntityKey entityKey) {
-		DBObject fromBatchInsertion = batchInsert.get( entityKey );
-		return fromBatchInsertion != null ? fromBatchInsertion : snapshot.getDbObject();
+	private static DBObject getCurrentDocument(MongoDBTupleSnapshot snapshot, DBObject insertStatement, EntityKey entityKey) {
+		return insertStatement != null ? insertStatement : snapshot.getDbObject();
 	}
 
 	private static BatchInsertionTask getOrCreateBatchInsertionTask(Map<DBCollection, BatchInsertionTask> inserts, EntityKeyMetadata entityKeyMetadata, DBCollection collection, WriteConcern writeConcern) {
@@ -1383,6 +1373,55 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 
 	private static WriteConcern getWriteConcern(AssociationContext associationContext) {
 		return associationContext.getAssociationTypeContext().getOptionsContext().getUnique( WriteConcernOption.class );
+	}
+
+	@SuppressWarnings("deprecation")
+	private static WriteConcern mergeWriteConcern(WriteConcern original, WriteConcern writeConcern) {
+		if ( original == null ) {
+			return writeConcern;
+		}
+		else if ( writeConcern == null ) {
+			return original;
+		}
+		else if ( original.equals( writeConcern ) ) {
+			return original;
+		}
+
+		Object wObject;
+		int wTimeoutMS;
+		boolean fsync;
+		Boolean journal;
+
+		if ( original.getWObject() instanceof String ) {
+			wObject = original.getWString();
+		}
+		else if ( writeConcern.getWObject() instanceof String ) {
+			wObject = writeConcern.getWString();
+		}
+		else {
+			wObject = Math.max( original.getW(), writeConcern.getW() );
+		}
+
+		wTimeoutMS = Math.min( original.getWtimeout(), writeConcern.getWtimeout() );
+
+		fsync = original.getFsync() || writeConcern.getFsync();
+
+		if ( original.getJournal() == null ) {
+			journal = writeConcern.getJournal();
+		}
+		else if ( writeConcern.getJournal() == null ) {
+			journal = original.getJournal();
+		}
+		else {
+			journal = original.getJournal() || writeConcern.getJournal();
+		}
+
+		if ( wObject instanceof String ) {
+			return new WriteConcern( (String) wObject, wTimeoutMS, fsync, journal );
+		}
+		else {
+			return new WriteConcern( (int) wObject, wTimeoutMS, fsync, journal );
+		}
 	}
 
 	private static ReadPreference getReadPreference(TupleContext tupleContext) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -1364,7 +1364,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 				// This exception is used by MongoDB for all the unique indexes violation, not only the primary key
 				// so we determine if it concerns the primary key by matching on the message
 				if ( PRIMARY_KEY_CONSTRAINT_VIOLATION_MESSAGE.matcher( dke.getMessage() ).matches() ) {
-					throw new TupleAlreadyExistsException( entry.getValue().getEntityKeyMetadata(), null, dke );
+					throw new TupleAlreadyExistsException( entry.getValue().getEntityKeyMetadata(), dke );
 				}
 				else {
 					throw log.constraintViolationOnFlush( dke.getMessage(), dke );

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -231,11 +231,6 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 	}
 
-	private static boolean isInTheInsertionQueue(EntityKey key, TupleContext tupleContext) {
-		OperationsQueue queue = tupleContext.getOperationsQueue();
-		return queue != null && queue.isInTheInsertionQueue( key );
-	}
-
 	@Override
 	public Tuple createTuple(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
 		return new Tuple( new MongoDBTupleSnapshot( new BasicDBObject(), entityKeyMetadata, SnapshotType.INSERT ) );

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -600,7 +600,15 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 				? getEmbeddingEntity( key, associationContext )
 				: associationKeyToObject( key, storageStrategy );
 
-		return new Association( new MongoDBAssociationSnapshot( document, key, storageStrategy ) );
+		Association association = new Association( new MongoDBAssociationSnapshot( document, key, storageStrategy ) );
+		// in the case of an association stored in the entity structure, we might end up with rows present in the
+		// current snapshot of the entity while we want an empty association here. So, in this case, we clear the
+		// snapshot to be sure the association created is empty.
+		if ( !association.isEmpty() ) {
+			association.clear();
+		}
+
+		return association;
 	}
 
 	/**

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -79,6 +79,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -753,7 +754,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		DB db = provider.getDatabase();
 		DBCollection collection = db.getCollection( entityKeyMetadata.getTable() );
 		for ( DBObject dbObject : collection.find() ) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -286,7 +286,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	private static BasicDBObject getProjection(TupleContext tupleContext) {
-		return getProjection( tupleContext.getSelectableColumns() );
+		return getProjection( tupleContext.getTupleTypeContext().getSelectableColumns() );
 	}
 
 	/**
@@ -1363,7 +1363,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	private static WriteConcern getWriteConcern(TupleContext tupleContext) {
-		return tupleContext.getOptionsContext().getUnique( WriteConcernOption.class );
+		return tupleContext.getTupleTypeContext().getOptionsContext().getUnique( WriteConcernOption.class );
 	}
 
 	private static WriteConcern getWriteConcern(AssociationContext associationContext) {
@@ -1420,7 +1420,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	}
 
 	private static ReadPreference getReadPreference(TupleContext tupleContext) {
-		return tupleContext.getOptionsContext().getUnique( ReadPreferenceOption.class );
+		return tupleContext.getTupleTypeContext().getOptionsContext().getUnique( ReadPreferenceOption.class );
 	}
 
 	private static ReadPreference getReadPreference(AssociationContext associationContext) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -8,9 +8,9 @@ package org.hibernate.ogm.datastore.mongodb;
 
 import static java.lang.Boolean.FALSE;
 import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
-import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot.SnapshotType.INSERT;
-import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot.SnapshotType.UPDATE;
 import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers.hasField;
+import static org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType.INSERT;
+import static org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType.UPDATE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,7 +40,6 @@ import org.hibernate.ogm.datastore.mongodb.configuration.impl.MongoDBConfigurati
 import org.hibernate.ogm.datastore.mongodb.dialect.impl.AssociationStorageStrategy;
 import org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBAssociationSnapshot;
 import org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot;
-import org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoDBTupleSnapshot.SnapshotType;
 import org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers;
 import org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
@@ -91,6 +90,7 @@ import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.TupleOperation;
+import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.type.impl.ByteStringType;
 import org.hibernate.ogm.type.impl.CharacterStringType;
 import org.hibernate.ogm.type.impl.StringCalendarDateType;

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -404,7 +404,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 
 	@Override
 	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
+		throw new UnsupportedOperationException( "Method not supported in GridDialect anymore" );
 	}
 
 	@Override
@@ -682,12 +682,12 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 
 	@Override
 	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
+		throw new UnsupportedOperationException( "Method not supported in GridDialect anymore" );
 	}
 
 	@Override
 	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
+		throw new UnsupportedOperationException( "Method not supported in GridDialect anymore" );
 	}
 
 	@Override
@@ -1190,11 +1190,11 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 					executeBatchUpdate( inserts, insertSnapshots, entityOperation );
 				}
 				else if ( operation instanceof RemoveTupleOperation ) {
-					RemoveTupleOperation tupleOp = (RemoveTupleOperation) operation;
-					executeBatchRemove( inserts, tupleOp );
+					RemoveTupleOperation removeTupleOperation = (RemoveTupleOperation) operation;
+					executeBatchRemove( inserts, removeTupleOperation );
 				}
 				else {
-					throw new UnsupportedOperationException( "Operation not supported on MongoDB: " + operation.getClass().getName() );
+					throw new UnsupportedOperationException( "Operation not supported: " + operation.getClass().getSimpleName() );
 				}
 				operation = queue.poll();
 			}
@@ -1229,7 +1229,7 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		BasicDBObject updateStatement = new BasicDBObject();
 		WriteConcern writeConcern = null;
 
-		for (Operation operation : groupedOperation.getOperations()) {
+		for ( Operation operation : groupedOperation.getOperations() ) {
 			if ( operation instanceof InsertOrUpdateTupleOperation ) {
 				InsertOrUpdateTupleOperation tupleOperation = (InsertOrUpdateTupleOperation) operation;
 				Tuple tuple = tupleOperation.getTuple();

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -1380,6 +1380,12 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		return associationContext.getAssociationTypeContext().getOptionsContext().getUnique( WriteConcernOption.class );
 	}
 
+	/**
+	 * As we merge several operations into one operation, we need to be sure the write concern applied to the aggregated
+	 * operation respects all the requirements expressed for each separate operation.
+	 *
+	 * Thus, for each parameter of the write concern, we keep the stricter one for the resulting merged write concern.
+	 */
 	@SuppressWarnings("deprecation")
 	private static WriteConcern mergeWriteConcern(WriteConcern original, WriteConcern writeConcern) {
 		if ( original == null ) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/dialect/impl/MongoDBTupleSnapshot.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/dialect/impl/MongoDBTupleSnapshot.java
@@ -28,12 +28,10 @@ public class MongoDBTupleSnapshot implements TupleSnapshot {
 
 	private final DBObject dbObject;
 	private final EntityKeyMetadata keyMetadata;
-	private SnapshotType snapshotType;
 
-	public MongoDBTupleSnapshot(DBObject dbObject, EntityKeyMetadata meta, SnapshotType snapshotType) {
+	public MongoDBTupleSnapshot(DBObject dbObject, EntityKeyMetadata meta) {
 		this.dbObject = dbObject;
 		this.keyMetadata = meta;
-		this.snapshotType = snapshotType;
 	}
 
 	public DBObject getDbObject() {
@@ -43,15 +41,6 @@ public class MongoDBTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return dbObject.keySet();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	@Override

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/dialect/impl/MongoDBTupleSnapshot.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/dialect/impl/MongoDBTupleSnapshot.java
@@ -20,19 +20,11 @@ import com.mongodb.DBObject;
  *
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  * @author Christopher Auston
+ * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
 public class MongoDBTupleSnapshot implements TupleSnapshot {
 
 	public static final Pattern EMBEDDED_FIELDNAME_SEPARATOR = Pattern.compile( "\\." );
-
-	/**
-	 * Identifies the purpose a {@link MongoDBTupleSnapshot}.
-	 *
-	 * @author Davide D'Alto &lt;davide@hibernate.org&gt;
-	 */
-	public enum SnapshotType {
-		INSERT, UPDATE
-	}
 
 	private final DBObject dbObject;
 	private final EntityKeyMetadata keyMetadata;
@@ -53,6 +45,7 @@ public class MongoDBTupleSnapshot implements TupleSnapshot {
 		return dbObject.keySet();
 	}
 
+	@Override
 	public SnapshotType getSnapshotType() {
 		return snapshotType;
 	}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/BatchInsertTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/BatchInsertTest.java
@@ -47,7 +47,6 @@ public class BatchInsertTest extends OgmTestCase {
 	@Test
 	public void testImplicitFlushWithUpdates() throws Exception {
 		int numInsert = 3;
-		int numUpdate = 1;
 
 		Session session = openSession();
 		session.beginTransaction();
@@ -60,7 +59,7 @@ public class BatchInsertTest extends OgmTestCase {
 		session.getTransaction().commit();
 		session.close();
 
-		Assertions.assertThat( LeakingMongoDBDialect.queueSize ).isEqualTo( numUpdate + ( numInsert + 1 ) );
+		Assertions.assertThat( LeakingMongoDBDialect.queueSize ).isEqualTo( numInsert + 1 );
 	}
 
 	@Test

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/dialectinvocations/GridDialectOperationInvocationsTest.java
@@ -70,9 +70,9 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 
 		assertThat( getOperations() ).containsExactly(
 				"createTuple",
-				"executeBatch[insertOrUpdateTuple]",
+				"executeBatch[group[insertOrUpdateTuple]]",
 				"getTuple",
-				"executeBatch[insertOrUpdateTuple]",
+				"executeBatch[group[insertOrUpdateTuple]]",
 				"getTuple",
 				"executeBatch[removeTuple]"
 		);
@@ -116,12 +116,12 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 		assertThat( getOperations() ).containsExactly(
 				"createTuple",
 				"getAssociation",
-				"executeBatch[insertOrUpdateTuple,insertOrUpdateAssociation]",
+				"executeBatch[group[insertOrUpdateTuple,insertOrUpdateAssociation]]",
 				"getTuple",
 				"getAssociation",
 				"getTuple",
 				"getAssociation",
-				"executeBatch[removeAssociation,removeTuple]"
+				"executeBatch[group[removeAssociation],removeTuple]"
 				);
 	}
 
@@ -155,8 +155,8 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 
 		assertThat( getOperations() ).containsExactly(
 				"createTuple",
-				"executeBatch[insertOrUpdateTuple]",
-				"executeBatch[insertOrUpdateTuple]",
+				"executeBatch[group[insertOrUpdateTuple]]",
+				"executeBatch[group[insertOrUpdateTuple]]",
 				"getTuple",
 				"executeBatch[removeTuple]"
 		);
@@ -196,9 +196,9 @@ public class GridDialectOperationInvocationsTest extends OgmTestCase {
 		session.close();
 		assertThat( getOperations() ).containsExactly(
 				"createTuple",
-				"executeBatch[insertOrUpdateTuple]",
+				"executeBatch[group[insertOrUpdateTuple]]",
 				"executeBackendQuery",
-				"executeBatch[insertOrUpdateTuple]",
+				"executeBatch[group[insertOrUpdateTuple]]",
 				"getTuple",
 				"executeBatch[removeTuple]"
 		);

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -155,6 +155,7 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 								"modules"
 						),
 						EmptyOptionsContext.INSTANCE,
+						GridDialectOperationContexts.emptyTupleTypeContext(),
 						new DefaultAssociatedEntityKeyMetadata( null, null ),
 						null
 				),
@@ -179,8 +180,11 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 				new Object[] { id }
 		);
 		TupleContext tupleContext = new GridDialectOperationContexts.TupleContextBuilder()
-				.selectableColumns( selectedColumns )
-				.optionContext( TestOptionContext.INSTANCE )
+				.tupleTypeContext(
+						new GridDialectOperationContexts.TupleTypeContextBuilder()
+								.selectableColumns( selectedColumns )
+								.optionContext( TestOptionContext.INSTANCE )
+								.buildTupleTypeContext() )
 				.buildTupleContext();
 
 		return getService( GridDialect.class ).getTuple( key, tupleContext );

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -36,6 +36,7 @@ import org.hibernate.ogm.dialect.impl.AssociationTypeContextImpl;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.impl.DefaultAssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
@@ -159,7 +160,7 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 						new DefaultAssociatedEntityKeyMetadata( null, null ),
 						null
 				),
-				new Tuple( new MongoDBTupleSnapshot( null, null, null ) ),
+				new TuplePointer( new Tuple( new MongoDBTupleSnapshot( null, null, null ) ) ),
 				transactionContext( session )
 		);
 

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/loading/LoadSelectedColumnsCollectionTest.java
@@ -47,6 +47,7 @@ import org.hibernate.ogm.model.key.spi.AssociationType;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.options.navigation.impl.OptionsContextImpl;
 import org.hibernate.ogm.options.navigation.source.impl.OptionValueSources;
 import org.hibernate.ogm.options.spi.Option;
@@ -160,7 +161,7 @@ public class LoadSelectedColumnsCollectionTest extends OgmTestCase {
 						new DefaultAssociatedEntityKeyMetadata( null, null ),
 						null
 				),
-				new TuplePointer( new Tuple( new MongoDBTupleSnapshot( null, null, null ) ) ),
+				new TuplePointer( new Tuple( new MongoDBTupleSnapshot( null, null ), SnapshotType.UPDATE ) ),
 				transactionContext( session )
 		);
 

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
@@ -218,7 +218,7 @@ public class WriteConcernPropagationTest {
 		session.close();
 
 		// then expect updates to the player document using the configured write concern
-		verify( mockClient.getCollection( "GolfPlayer" ), times( 2 ) ).update( any( DBObject.class ), any( DBObject.class ), anyBoolean(), anyBoolean(), eq( WriteConcern.MAJORITY ) );
+		verify( mockClient.getCollection( "GolfPlayer" ), times( 1 ) ).update( any( DBObject.class ), any( DBObject.class ), anyBoolean(), anyBoolean(), eq( WriteConcern.MAJORITY ) );
 	}
 
 	@Test

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/performance/MongoDBPerformanceTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/performance/MongoDBPerformanceTest.java
@@ -98,7 +98,7 @@ public class MongoDBPerformanceTest extends OgmTestCase {
 		loadInvocationCount = BytemanHelper.getAndResetInvocationCount( "load" );
 		updateInvocationCount = BytemanHelper.getAndResetInvocationCount( "update" );
 		assertThat( loadInvocationCount ).isEqualTo( 1 );
-		assertThat( updateInvocationCount ).isEqualTo( 3 );
+		assertThat( updateInvocationCount ).isEqualTo( 1 );
 
 		//assert removal has been propagated
 		tx = session.beginTransaction();

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
@@ -189,4 +189,9 @@ public abstract class BaseNeo4jDialect extends BaseGridDialect implements Querya
 		}
 		return parameters;
 	}
+
+	@Override
+	public boolean usesNavigationalInformationForInverseSideOfAssociations() {
+		return false;
+	}
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BaseNeo4jDialect.java
@@ -26,6 +26,7 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
@@ -68,7 +69,7 @@ public abstract class BaseNeo4jDialect extends BaseGridDialect implements Querya
 	}
 
 	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
 		return new Tuple();
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -248,7 +248,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			if ( CONSTRAINT_VIOLATION_CODE.equals( qee.getStatusCode() ) ) {
 				Throwable cause = findRecognizableCause( qee );
 				if ( cause instanceof UniquePropertyConstraintViolationKernelException ) {
-					throw new TupleAlreadyExistsException( key.getMetadata(), tuple, qee );
+					throw new TupleAlreadyExistsException( key, qee );
 				}
 			}
 			throw qee;

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -56,6 +56,7 @@ import org.hibernate.ogm.model.spi.AssociationOperation;
 import org.hibernate.ogm.model.spi.EntityMetadataInformation;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.TupleOperation;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.persister.impl.OgmCollectionPersister;
 import org.hibernate.ogm.persister.impl.OgmEntityPersister;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -158,7 +159,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 						context.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
 						context.getTupleTypeContext().getAllRoles(),
 						key.getMetadata()
-				)
+				), SnapshotType.UPDATE
 		);
 	}
 
@@ -194,7 +195,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 					tuples[i] = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( node,
 							tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
 							tupleContext.getTupleTypeContext().getAllRoles(),
-							keys[i].getMetadata() ) );
+							keys[i].getMetadata() ), SnapshotType.UPDATE );
 					// We assume there are no duplicated keys
 					break;
 				}
@@ -217,7 +218,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 
 	@Override
 	public Tuple createTuple(EntityKey key, OperationContext tupleContext) {
-		return new Tuple( EmbeddedNeo4jTupleSnapshot.emptySnapshot( key.getMetadata() ) );
+		return new Tuple( EmbeddedNeo4jTupleSnapshot.emptySnapshot( key.getMetadata() ), SnapshotType.INSERT );
 	}
 
 	@Override
@@ -345,7 +346,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 				AssociatedEntityKeyMetadata associatedEntityKeyMetadata = associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata();
 				EmbeddedNeo4jTupleAssociationSnapshot snapshot = new EmbeddedNeo4jTupleAssociationSnapshot( relationship, associationKey, associatedEntityKeyMetadata );
 				RowKey rowKey = convert( associationKey, snapshot );
-				tuples.put( rowKey, new Tuple( snapshot ) );
+				tuples.put( rowKey, new Tuple( snapshot, SnapshotType.UPDATE ) );
 			}
 			return tuples;
 		}
@@ -567,7 +568,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 				Node next = queryNodes.next();
 				Tuple tuple = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( next,
 						tupleTypeContext.getAllAssociatedEntityKeyMetadata(), tupleTypeContext.getAllRoles(),
-						entityKeyMetadata ) );
+						entityKeyMetadata ), SnapshotType.UPDATE );
 				consumer.consume( tuple );
 			}
 		}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -42,6 +42,7 @@ import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
@@ -554,13 +555,13 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		ResourceIterator<Node> queryNodes = entityQueries.get( entityKeyMetadata ).findEntities( dataBase );
 		try {
 			while ( queryNodes.hasNext() ) {
 				Node next = queryNodes.next();
 				Tuple tuple = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( next,
-						tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(), tupleContext.getTupleTypeContext().getAllRoles(),
+						tupleTypeContext.getAllAssociatedEntityKeyMetadata(), tupleTypeContext.getAllRoles(),
 						entityKeyMetadata ) );
 				consumer.consume( tuple );
 			}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -152,8 +152,8 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		return new Tuple(
 				EmbeddedNeo4jTupleSnapshot.fromNode(
 						entityNode,
-						context.getAllAssociatedEntityKeyMetadata(),
-						context.getAllRoles(),
+						context.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
+						context.getTupleTypeContext().getAllRoles(),
 						key.getMetadata()
 				)
 		);
@@ -188,8 +188,8 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			Node node = nodes.next();
 			for ( int i = 0; i < keys.length; i++ ) {
 				if ( matches( node, keys[i].getColumnNames(), keys[i].getColumnValues() ) ) {
-					tuples[i] = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( node, tupleContext.getAllAssociatedEntityKeyMetadata(), tupleContext.getAllRoles(),
-							keys[i].getMetadata() ) );
+					tuples[i] = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( node, tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
+							tupleContext.getTupleTypeContext().getAllRoles(), keys[i].getMetadata() ) );
 					// We assume there are no duplicated keys
 					break;
 				}
@@ -443,7 +443,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	private void removeTupleOperation(EntityKey entityKey, Node node, TupleOperation operation, TupleContext tupleContext, Set<String> processedAssociationRoles) {
-		if ( !tupleContext.isPartOfAssociation( operation.getColumn() ) ) {
+		if ( !tupleContext.getTupleTypeContext().isPartOfAssociation( operation.getColumn() ) ) {
 			if ( isPartOfRegularEmbedded( entityKey.getColumnNames(), operation.getColumn() ) ) {
 				// Embedded node
 				String[] split = split( operation.getColumn() );
@@ -455,7 +455,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		}
 		// if the column represents a to-one association, remove the relationship
 		else {
-			String associationRole = tupleContext.getRole( operation.getColumn() );
+			String associationRole = tupleContext.getTupleTypeContext().getRole( operation.getColumn() );
 			if ( !processedAssociationRoles.contains( associationRole ) ) {
 
 				Iterator<Relationship> relationships = node.getRelationships( withName( associationRole ) ).iterator();
@@ -505,7 +505,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	private void putTupleOperation(EntityKey entityKey, Tuple tuple, Node node, TupleOperation operation, TupleContext tupleContext, Set<String> processedAssociationRoles) {
-		if ( tupleContext.isPartOfAssociation( operation.getColumn() ) ) {
+		if ( tupleContext.getTupleTypeContext().isPartOfAssociation( operation.getColumn() ) ) {
 			// the column represents a to-one association, map it as relationship
 			putOneToOneAssociation( tuple, node, operation, tupleContext, processedAssociationRoles );
 		}
@@ -533,12 +533,12 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	private void putOneToOneAssociation(Tuple tuple, Node node, TupleOperation operation, TupleContext tupleContext, Set<String> processedAssociationRoles) {
-		String associationRole = tupleContext.getRole( operation.getColumn() );
+		String associationRole = tupleContext.getTupleTypeContext().getRole( operation.getColumn() );
 
 		if ( !processedAssociationRoles.contains( associationRole ) ) {
 			processedAssociationRoles.add( associationRole );
 
-			EntityKey targetKey = getEntityKey( tuple, tupleContext.getAssociatedEntityKeyMetadata( operation.getColumn() ) );
+			EntityKey targetKey = getEntityKey( tuple, tupleContext.getTupleTypeContext().getAssociatedEntityKeyMetadata( operation.getColumn() ) );
 
 			// delete the previous relationship if there is one; for a to-one association, the relationship won't have any
 			// properties, so the type is uniquely identifying it
@@ -560,7 +560,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			while ( queryNodes.hasNext() ) {
 				Node next = queryNodes.next();
 				Tuple tuple = new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( next,
-						tupleContext.getAllAssociatedEntityKeyMetadata(), tupleContext.getAllRoles(),
+						tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(), tupleContext.getTupleTypeContext().getAllRoles(),
 						entityKeyMetadata ) );
 				consumer.consume( tuple );
 			}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
@@ -265,7 +265,7 @@ public class RemoteNeo4jDialect extends BaseNeo4jDialect {
 	private HibernateException extractException(EntityKey key, Tuple tuple, ErrorResponse errorResponse) {
 		if ( errorResponse.getMessage().matches( ".*Node \\d+ already exists with label.*" ) ) {
 			// This is the exception we expect for this kind of error by the CompensationAPI and some unit tests
-			return new TupleAlreadyExistsException( key.getMetadata(), tuple, errorResponse.getMessage() );
+			return new TupleAlreadyExistsException( key, errorResponse.getMessage() );
 		}
 		else {
 			return log.constraintViolation( key, errorResponse.getMessage(), null );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
@@ -49,10 +49,12 @@ import org.hibernate.ogm.dialect.query.spi.QueryParameters;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
@@ -145,7 +147,7 @@ public class RemoteNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	@Override
-	public Tuple getTuple(EntityKey key, TupleContext context) {
+	public Tuple getTuple(EntityKey key, OperationContext context) {
 		RemoteNeo4jEntityQueries queries = entityQueries.get( key.getMetadata() );
 		Long txId = transactionId( context.getTransactionContext() );
 		NodeWithEmbeddedNodes node = queries.findEntity( dataBase, txId, key.getColumnValues() );
@@ -217,7 +219,8 @@ public class RemoteNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, Tuple tuple, TupleContext tupleContext) {
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+		Tuple tuple = tuplePointer.getTuple();
 		// insert
 		final Map<String, EntityKey> toOneAssociations = new HashMap<>();
 		Statements statements = new Statements();
@@ -538,7 +541,7 @@ public class RemoteNeo4jDialect extends BaseNeo4jDialect {
 				keys[i] = new EntityKey( entityKeyMetadata, values );
 			}
 			ClosableIterator<NodeWithEmbeddedNodes> entities = entityQueries.get( entityKeyMetadata ).findEntities( dataBase, keys, txId );
-			return new RemoteNeo4jNodesTupleIterator( dataBase, txId, queries, response, entityKeyMetadata, tupleContext, entities );
+			return new RemoteNeo4jNodesTupleIterator( dataBase, txId, queries, response, entityKeyMetadata, tupleContext.getTupleTypeContext(), entities );
 		}
 		else {
 			statement.setResultDataContents( Arrays.asList( Statement.AS_ROW ) );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/RemoteNeo4jDialect.java
@@ -52,6 +52,7 @@ import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
@@ -501,8 +502,11 @@ public class RemoteNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
-		Long txId = transactionId( tupleContext.getTransactionContext() );
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
+		// TODO OGM-1111 we don't have a transaction context here as we are not in a session yet.
+		// This is now clear thanks to the new TupleTypeContext contract.
+		//Long txId = transactionId( tupleContext.getTransactionContext() );
+		Long txId = null;
 		RemoteNeo4jEntityQueries queries = entityQueries.get( entityKeyMetadata );
 		ClosableIterator<NodeWithEmbeddedNodes> queryNodes = entityQueries.get( entityKeyMetadata ).findEntitiesWithEmbedded( dataBase, txId );
 		while ( queryNodes.hasNext() ) {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jEntityQueries.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.hibernate.internal.util.collections.BoundedConcurrentHashMap;
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
@@ -74,7 +74,7 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 
 	private final EntityKeyMetadata entityKeyMetadata;
 
-	public BaseNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext, boolean includeEmbedded) {
+	public BaseNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext, boolean includeEmbedded) {
 		this.entityKeyMetadata = entityKeyMetadata;
 		this.includeEmbedded = includeEmbedded;
 		this.updateEmbeddedPropertyQueryCache = new BoundedConcurrentHashMap<String, String>( CACHE_CAPACITY, CACHE_CONCURRENCY_LEVEL, BoundedConcurrentHashMap.Eviction.LIRS );
@@ -90,20 +90,20 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 		this.createEntityWithPropertiesQuery = initCreateEntityWithPropertiesQuery( entityKeyMetadata );
 		this.removeEntityQuery = initRemoveEntityQuery( entityKeyMetadata );
 		this.updateEmbeddedNodeQuery = initUpdateEmbeddedNodeQuery( entityKeyMetadata );
-		this.updateToOneQuery = initUpdateToOneQuery( entityKeyMetadata, tupleContext );
-		this.findAssociatedEntityQuery = initFindAssociatedEntityQuery( entityKeyMetadata, tupleContext );
-		this.findEmbeddedNodeQueries = initFindEmbeddedNodeQuery( entityKeyMetadata, tupleContext );
+		this.updateToOneQuery = initUpdateToOneQuery( entityKeyMetadata, tupleTypeContext );
+		this.findAssociatedEntityQuery = initFindAssociatedEntityQuery( entityKeyMetadata, tupleTypeContext );
+		this.findEmbeddedNodeQueries = initFindEmbeddedNodeQuery( entityKeyMetadata, tupleTypeContext );
 
 		this.multiGetQuery = initMultiGetEntitiesQuery( entityKeyMetadata, includeEmbedded );
 
-		this.removeEmbeddedPropertyQuery = initRemoveEmbeddedPropertyQuery( entityKeyMetadata, tupleContext );
-		this.removePropertyQueries = initRemovePropertyQueries( entityKeyMetadata, tupleContext );
-		this.removeToOneAssociation = initRemoveToOneAssociation( entityKeyMetadata, tupleContext );
+		this.removeEmbeddedPropertyQuery = initRemoveEmbeddedPropertyQuery( entityKeyMetadata, tupleTypeContext );
+		this.removePropertyQueries = initRemovePropertyQueries( entityKeyMetadata, tupleTypeContext );
+		this.removeToOneAssociation = initRemoveToOneAssociation( entityKeyMetadata, tupleTypeContext );
 		this.singlePropertyKey = entityKeyMetadata.getColumnNames().length == 1;
 		this.keyColumns = entityKeyMetadata.getColumnNames();
 	}
 
-	private String initRemoveToOneAssociation(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
+	private String initRemoveToOneAssociation(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
 		StringBuilder queryBuilder = new StringBuilder();
 		appendMatchOwnerEntityNode( queryBuilder, entityKeyMetadata );
 		queryBuilder.append( " -[r]-> (:" );
@@ -114,13 +114,13 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 		return queryBuilder.toString();
 	}
 
-	private Map<String, String> initRemovePropertyQueries(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		if ( tupleContext == null ) {
+	private Map<String, String> initRemovePropertyQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		if ( tupleTypeContext == null ) {
 			return Collections.emptyMap();
 		}
 
 		Map<String, String> removeColumn = new HashMap<>();
-		for ( String column : tupleContext.getSelectableColumns() ) {
+		for ( String column : tupleTypeContext.getSelectableColumns() ) {
 			if ( !column.contains( "." ) ) {
 				StringBuilder queryBuilder = new StringBuilder();
 				queryBuilder.append( "MATCH " );
@@ -174,12 +174,12 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 	 * MATCH (owner:ENTITY:Account {login: {0}}) -[:type]-> (e:EMBEDDED)
 	 * REMOVE e.property
 	 */
-	private Map<String, String> initRemoveEmbeddedPropertyQuery(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		if ( tupleContext == null ) {
+	private Map<String, String> initRemoveEmbeddedPropertyQuery(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		if ( tupleTypeContext == null ) {
 			return Collections.emptyMap();
 		}
 		Map<String, String> removeColumn = new HashMap<>();
-		for ( String column : tupleContext.getSelectableColumns() ) {
+		for ( String column : tupleTypeContext.getSelectableColumns() ) {
 			if ( EmbeddedHelper.isPartOfEmbedded( column ) ) {
 				if ( !removeColumn.containsKey( column ) ) {
 					StringBuilder queryBuilder = new StringBuilder();
@@ -219,12 +219,12 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 		return Collections.unmodifiableMap( removeColumn );
 	}
 
-	private Map<String, String> initUpdateToOneQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleContext tupleContext) {
-		if (tupleContext != null) {
-			Map<String, AssociatedEntityKeyMetadata> allAssociatedEntityKeyMetadata = tupleContext.getAllAssociatedEntityKeyMetadata();
+	private Map<String, String> initUpdateToOneQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		if ( tupleTypeContext != null ) {
+			Map<String, AssociatedEntityKeyMetadata> allAssociatedEntityKeyMetadata = tupleTypeContext.getAllAssociatedEntityKeyMetadata();
 			Map<String, String> queries = new HashMap<>( allAssociatedEntityKeyMetadata.size() );
 			for ( Entry<String, AssociatedEntityKeyMetadata> entry : allAssociatedEntityKeyMetadata.entrySet() ) {
-				String associationRole = tupleContext.getRole( entry.getKey() );
+				String associationRole = tupleTypeContext.getRole( entry.getKey() );
 				AssociatedEntityKeyMetadata associatedEntityKeyMetadata = entry.getValue();
 				EntityKeyMetadata targetKeyMetadata = associatedEntityKeyMetadata.getEntityKeyMetadata();
 				StringBuilder queryBuilder = new StringBuilder( "MATCH " );
@@ -249,12 +249,12 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 		return Collections.emptyMap();
 	}
 
-	private Map<String, String> initFindAssociatedEntityQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleContext tupleContext) {
-		if ( tupleContext != null ) {
-			Map<String, AssociatedEntityKeyMetadata> allAssociatedEntityKeyMetadata = tupleContext.getAllAssociatedEntityKeyMetadata();
+	private Map<String, String> initFindAssociatedEntityQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		if ( tupleTypeContext != null ) {
+			Map<String, AssociatedEntityKeyMetadata> allAssociatedEntityKeyMetadata = tupleTypeContext.getAllAssociatedEntityKeyMetadata();
 			Map<String, String> queries = new HashMap<>( allAssociatedEntityKeyMetadata.size() );
 			for ( Entry<String, AssociatedEntityKeyMetadata> entry : allAssociatedEntityKeyMetadata.entrySet() ) {
-				String associationRole = tupleContext.getRole( entry.getKey() );
+				String associationRole = tupleTypeContext.getRole( entry.getKey() );
 				StringBuilder queryBuilder = new StringBuilder( "MATCH " );
 				appendEntityNode( ENTITY_ALIAS, ownerEntityKeyMetadata, queryBuilder );
 				queryBuilder.append( " -[r:" );
@@ -268,10 +268,10 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 		return Collections.emptyMap();
 	}
 
-	private Map<String, String> initFindEmbeddedNodeQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleContext tupleContext) {
-		if ( tupleContext != null ) {
+	private Map<String, String> initFindEmbeddedNodeQuery(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		if ( tupleTypeContext != null ) {
 			Map<String, String> queries = new HashMap<>();
-			List<String> selectableColumns = tupleContext.getSelectableColumns();
+			List<String> selectableColumns = tupleTypeContext.getSelectableColumns();
 			for ( String column : selectableColumns ) {
 				if ( isPartOfEmbedded( column ) ) {
 					String embeddedPath = column.substring( 0, column.lastIndexOf( "." ) );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jEntityQueries;
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.util.impl.ArrayHelper;
@@ -33,8 +33,8 @@ public class EmbeddedNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 		this( entityKeyMetadata, null );
 	}
 
-	public EmbeddedNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		super( entityKeyMetadata, tupleContext, false );
+	public EmbeddedNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		super( entityKeyMetadata, tupleTypeContext, false );
 	}
 
 	/**

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jMapsTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jMapsTupleIterator.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 
@@ -38,7 +39,7 @@ public class EmbeddedNeo4jMapsTupleIterator implements ClosableIterator<Tuple> {
 	}
 
 	protected Tuple convert(Map<String, Object> next) {
-		return new Tuple( new MapTupleSnapshot( next ) );
+		return new Tuple( new MapTupleSnapshot( next ), SnapshotType.UPDATE );
 	}
 
 	@Override

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jNodesTupleIterator.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Result;
 
@@ -39,6 +40,6 @@ public class EmbeddedNeo4jNodesTupleIterator extends EmbeddedNeo4jMapsTupleItera
 	private Tuple createTuple(Node node) {
 		return new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( node,
 				tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(), tupleContext.getTupleTypeContext().getAllRoles(),
-				entityKeyMetadata ) );
+				entityKeyMetadata ), SnapshotType.UPDATE );
 	}
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jNodesTupleIterator.java
@@ -38,7 +38,7 @@ public class EmbeddedNeo4jNodesTupleIterator extends EmbeddedNeo4jMapsTupleItera
 
 	private Tuple createTuple(Node node) {
 		return new Tuple( EmbeddedNeo4jTupleSnapshot.fromNode( node,
-				tupleContext.getAllAssociatedEntityKeyMetadata(), tupleContext.getAllRoles(),
+				tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(), tupleContext.getTupleTypeContext().getAllRoles(),
 				entityKeyMetadata ) );
 	}
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleAssociationSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleAssociationSnapshot.java
@@ -32,8 +32,6 @@ public class EmbeddedNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 
 	private final Map<String, Object> properties;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public EmbeddedNeo4jTupleAssociationSnapshot(Relationship relationship, AssociationKey associationKey, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
 		properties = collectProperties( relationship, associationKey, associatedEntityKeyMetadata );
 	}
@@ -174,16 +172,6 @@ public class EmbeddedNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return properties.keySet();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleAssociationSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleAssociationSnapshot.java
@@ -32,6 +32,8 @@ public class EmbeddedNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 
 	private final Map<String, Object> properties;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public EmbeddedNeo4jTupleAssociationSnapshot(Relationship relationship, AssociationKey associationKey, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
 		properties = collectProperties( relationship, associationKey, associatedEntityKeyMetadata );
 	}
@@ -172,6 +174,16 @@ public class EmbeddedNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return properties.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleSnapshot.java
@@ -37,6 +37,8 @@ public final class EmbeddedNeo4jTupleSnapshot implements TupleSnapshot {
 	private final Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata;
 	private final Map<String, String> rolesByColumn;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	private EmbeddedNeo4jTupleSnapshot(Node node, Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata, Map<String, String> rolesByColumn, EntityKeyMetadata entityKeyMetadata) {
 		this.node = node;
 		this.associatedEntityKeyMetadata = associatedEntityKeyMetadata;
@@ -121,6 +123,16 @@ public final class EmbeddedNeo4jTupleSnapshot implements TupleSnapshot {
 		}
 
 		return names;
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	public Node getNode() {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jTupleSnapshot.java
@@ -37,8 +37,6 @@ public final class EmbeddedNeo4jTupleSnapshot implements TupleSnapshot {
 	private final Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata;
 	private final Map<String, String> rolesByColumn;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	private EmbeddedNeo4jTupleSnapshot(Node node, Map<String, AssociatedEntityKeyMetadata> associatedEntityKeyMetadata, Map<String, String> rolesByColumn, EntityKeyMetadata entityKeyMetadata) {
 		this.node = node;
 		this.associatedEntityKeyMetadata = associatedEntityKeyMetadata;
@@ -123,16 +121,6 @@ public final class EmbeddedNeo4jTupleSnapshot implements TupleSnapshot {
 		}
 
 		return names;
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	public Node getNode() {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jEntityQueries.java
@@ -32,7 +32,7 @@ import org.hibernate.ogm.datastore.neo4j.remote.json.impl.Statements;
 import org.hibernate.ogm.datastore.neo4j.remote.json.impl.StatementsResponse;
 import org.hibernate.ogm.datastore.neo4j.remote.util.impl.RemoteNeo4jHelper;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.util.impl.ArrayHelper;
@@ -51,8 +51,8 @@ public class RemoteNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 		this( entityKeyMetadata, null );
 	}
 
-	public RemoteNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleContext tupleContext) {
-		super( entityKeyMetadata, tupleContext, true );
+	public RemoteNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		super( entityKeyMetadata, tupleTypeContext, true );
 	}
 
 	public NodeWithEmbeddedNodes findEntity(RemoteNeo4jClient executionEngine, Long transactionId, Object[] columnValues) {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jMapsTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jMapsTupleIterator.java
@@ -17,6 +17,7 @@ import org.hibernate.ogm.datastore.neo4j.remote.json.impl.StatementResult;
 import org.hibernate.ogm.datastore.neo4j.remote.json.impl.StatementsResponse;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * Iterates over the results of a native query when each result is not mapped by an entity
@@ -52,7 +53,7 @@ public class RemoteNeo4jMapsTupleIterator implements ClosableIterator<Tuple> {
 		for ( int i = 0; i < columns.size(); i++ ) {
 			properties.put( columns.get( i ), next.getRow().get( i ) );
 		}
-		return new Tuple( new MapTupleSnapshot( properties ) );
+		return new Tuple( new MapTupleSnapshot( properties ), SnapshotType.UPDATE );
 	}
 
 	@Override

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
@@ -12,6 +12,7 @@ import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 
 /**
  * Iterates over the result of a native query when each result is a neo4j node. This is the case when the result of
@@ -46,7 +47,7 @@ public class RemoteNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 	private Tuple createTuple(NodeWithEmbeddedNodes node) {
 		return new Tuple(
 				new RemoteNeo4jTupleSnapshot( dataBase, txId, entityQueries, node, tupleTypeContext.getAllAssociatedEntityKeyMetadata(),
-						tupleTypeContext.getAllRoles(), entityKeyMetadata ) );
+						tupleTypeContext.getAllRoles(), entityKeyMetadata ), SnapshotType.UPDATE );
 	}
 
 	@Override

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
@@ -9,7 +9,7 @@ package org.hibernate.ogm.datastore.neo4j.remote.dialect.impl;
 import org.hibernate.ogm.datastore.neo4j.remote.impl.RemoteNeo4jClient;
 import org.hibernate.ogm.datastore.neo4j.remote.json.impl.StatementsResponse;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
-import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
 
@@ -25,7 +25,7 @@ public class RemoteNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 	private final RemoteNeo4jClient dataBase;
 	private final RemoteNeo4jEntityQueries entityQueries;
 	private final Long txId;
-	private final TupleContext tupleContext;
+	private final TupleTypeContext tupleTypeContext;
 	private final ClosableIterator<NodeWithEmbeddedNodes> entities;
 
 	public RemoteNeo4jNodesTupleIterator(RemoteNeo4jClient dataBase,
@@ -33,20 +33,20 @@ public class RemoteNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 			RemoteNeo4jEntityQueries entityQueries,
 			StatementsResponse response,
 			EntityKeyMetadata entityKeyMetadata,
-			TupleContext tupleContext,
+			TupleTypeContext tupleTypeContext,
 			ClosableIterator<NodeWithEmbeddedNodes> entities) {
 		this.dataBase = dataBase;
 		this.txId = txId;
 		this.entityQueries = entityQueries;
 		this.entityKeyMetadata = entityKeyMetadata;
-		this.tupleContext = tupleContext;
+		this.tupleTypeContext = tupleTypeContext;
 		this.entities = entities;
 	}
 
 	private Tuple createTuple(NodeWithEmbeddedNodes node) {
 		return new Tuple(
-				new RemoteNeo4jTupleSnapshot( dataBase, txId, entityQueries, node, tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
-						tupleContext.getTupleTypeContext().getAllRoles(), entityKeyMetadata ) );
+				new RemoteNeo4jTupleSnapshot( dataBase, txId, entityQueries, node, tupleTypeContext.getAllAssociatedEntityKeyMetadata(),
+						tupleTypeContext.getAllRoles(), entityKeyMetadata ) );
 	}
 
 	@Override
@@ -68,4 +68,5 @@ public class RemoteNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 	public void close() {
 		entities.close();
 	}
+
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jNodesTupleIterator.java
@@ -45,8 +45,8 @@ public class RemoteNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 
 	private Tuple createTuple(NodeWithEmbeddedNodes node) {
 		return new Tuple(
-				new RemoteNeo4jTupleSnapshot( dataBase, txId, entityQueries, node, tupleContext.getAllAssociatedEntityKeyMetadata(),
-						tupleContext.getAllRoles(), entityKeyMetadata ) );
+				new RemoteNeo4jTupleSnapshot( dataBase, txId, entityQueries, node, tupleContext.getTupleTypeContext().getAllAssociatedEntityKeyMetadata(),
+						tupleContext.getTupleTypeContext().getAllRoles(), entityKeyMetadata ) );
 	}
 
 	@Override

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleAssociationSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleAssociationSnapshot.java
@@ -24,6 +24,8 @@ public class RemoteNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 
 	private final Map<String, Object> properties;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public RemoteNeo4jTupleAssociationSnapshot(RemoteNeo4jClient neo4jClient, RemoteNeo4jAssociationQueries queries, RemoteNeo4jAssociationPropertiesRow row, AssociationKey associationKey, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
 		this.properties = collectProperties( neo4jClient, queries, row, associationKey, associatedEntityKeyMetadata );
 	}
@@ -99,6 +101,16 @@ public class RemoteNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return properties.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleAssociationSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleAssociationSnapshot.java
@@ -24,8 +24,6 @@ public class RemoteNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 
 	private final Map<String, Object> properties;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public RemoteNeo4jTupleAssociationSnapshot(RemoteNeo4jClient neo4jClient, RemoteNeo4jAssociationQueries queries, RemoteNeo4jAssociationPropertiesRow row, AssociationKey associationKey, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
 		this.properties = collectProperties( neo4jClient, queries, row, associationKey, associatedEntityKeyMetadata );
 	}
@@ -101,16 +99,6 @@ public class RemoteNeo4jTupleAssociationSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return properties.keySet();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleSnapshot.java
@@ -40,8 +40,6 @@ public final class RemoteNeo4jTupleSnapshot implements TupleSnapshot {
 	private final Long txId;
 	private final Map<String, Collection<Node>> embeddedNodes;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
-
 	public RemoteNeo4jTupleSnapshot(RemoteNeo4jClient neo4jClient, Long txId, RemoteNeo4jEntityQueries queries, NodeWithEmbeddedNodes node, EntityKeyMetadata entityKeyMetadata) {
 		this( neo4jClient, txId, queries, node, Collections.<String, AssociatedEntityKeyMetadata>emptyMap(), Collections.<String, String>emptyMap(),
 				entityKeyMetadata );
@@ -141,16 +139,6 @@ public final class RemoteNeo4jTupleSnapshot implements TupleSnapshot {
 
 	public Node getNode() {
 		return node;
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/dialect/impl/RemoteNeo4jTupleSnapshot.java
@@ -40,6 +40,8 @@ public final class RemoteNeo4jTupleSnapshot implements TupleSnapshot {
 	private final Long txId;
 	private final Map<String, Collection<Node>> embeddedNodes;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public RemoteNeo4jTupleSnapshot(RemoteNeo4jClient neo4jClient, Long txId, RemoteNeo4jEntityQueries queries, NodeWithEmbeddedNodes node, EntityKeyMetadata entityKeyMetadata) {
 		this( neo4jClient, txId, queries, node, Collections.<String, AssociatedEntityKeyMetadata>emptyMap(), Collections.<String, String>emptyMap(),
 				entityKeyMetadata );
@@ -140,4 +142,15 @@ public final class RemoteNeo4jTupleSnapshot implements TupleSnapshot {
 	public Node getNode() {
 		return node;
 	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
+	}
+
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/dsl/GraphAssertions.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/dsl/GraphAssertions.java
@@ -45,7 +45,7 @@ public class GraphAssertions {
 
 		StatementsResponse response = engine.executeQueriesInNewTransaction( statements );
 		validate( response );
-		assertThat( response.getResults().get( 0 ).getData() ).isNotEmpty().as( "Node ["  + node.getAlias() + "] not found, Looked for " + nodeAsCypher + " with parameters: " + node.getParams() );
+		assertThat( response.getResults().get( 0 ).getData() ).as( "Node ["  + node.getAlias() + "] not found, Looked for " + nodeAsCypher + " with parameters: " + node.getParams() ).isNotEmpty();
 		List<Node> nodes = response.getResults().get( 0 ).getData().get( 0 ).getGraph().getNodes();
 
 		Graph.Node nodeFound = nodes.get( 0 );
@@ -130,7 +130,7 @@ public class GraphAssertions {
 		validate( response );
 		List<Node> nodes = response.getResults().get( 0 ).getData().get( 0 ).getGraph().getNodes();
 
-		assertThat( nodes ).isNotEmpty().as( "Relationships not found, Looked for " + relationshipAsCypher + " with parameters: " + relationship.getParams() );
+		assertThat( nodes ).as( "Relationships not found, Looked for " + relationshipAsCypher + " with parameters: " + relationship.getParams() ).isNotEmpty();
 		assertThat( nodes ).hasSize( 1 );
 	}
 

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4JBackendTckHelper.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4JBackendTckHelper.java
@@ -18,6 +18,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(ClasspathSuite.class)
 //@ClasspathSuite.ClassnameFilters({ "org.hibernate.ogm.backendtck.*" })
-@ClasspathSuite.ClassnameFilters({ ".*BuiltInTypeTest" })
+@ClasspathSuite.ClassnameFilters({ ".*CompositeEmbeddedIdTest" })
 public class Neo4JBackendTckHelper {
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
@@ -195,7 +195,9 @@ public class Neo4jTestHelper implements GridDialectTestHelper {
 	}
 
 	private TupleContext tupleContext(Session session) {
-		return new GridDialectOperationContexts.TupleContextBuilder().transactionContext( session ).buildTupleContext();
+		return new GridDialectOperationContexts.TupleContextBuilder().transactionContext( session )
+				.tupleTypeContext( GridDialectOperationContexts.emptyTupleTypeContext() )
+				.buildTupleContext();
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
@@ -25,8 +25,8 @@ import org.hibernate.ogm.datastore.redis.impl.json.JsonSerializationStrategy;
 import org.hibernate.ogm.datastore.redis.logging.impl.Log;
 import org.hibernate.ogm.datastore.redis.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.redis.options.impl.TTLOption;
+import org.hibernate.ogm.dialect.impl.AbstractGroupingByEntityDialect;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
-import org.hibernate.ogm.dialect.spi.BaseGridDialect;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.entityentry.impl.TuplePointer;
@@ -47,7 +47,7 @@ import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode;
 /**
  * @author Mark Paluch
  */
-public abstract class AbstractRedisDialect extends BaseGridDialect {
+public abstract class AbstractRedisDialect extends AbstractGroupingByEntityDialect {
 
 	public static final String IDENTIFIERS = "Identifiers";
 	public static final String ASSOCIATIONS = "Associations";

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
@@ -195,8 +195,17 @@ public abstract class AbstractRedisDialect extends BaseGridDialect {
 		}
 	}
 
-	protected void removeAssociation(AssociationKey key) {
-		connection.del( associationId( key ) );
+	protected void removeAssociations(List<AssociationKey> keys) {
+		if ( keys.isEmpty() ) {
+			return;
+		}
+		String[] ids = new String[keys.size()];
+		int i = 0;
+		for ( AssociationKey key : keys ) {
+			ids[i] = associationId( key );
+			i++;
+		}
+		connection.del( ids );
 	}
 
 	protected void remove(EntityKey key) {
@@ -324,9 +333,15 @@ public abstract class AbstractRedisDialect extends BaseGridDialect {
 
 		connection.del( associationId );
 
-		String[] serializedRows = new String[association.getRows().size()];
+		List<Object> rows = association.getRows();
+
+		if ( rows.isEmpty() ) {
+			return;
+		}
+
+		String[] serializedRows = new String[rows.size()];
 		int i = 0;
-		for ( Object row : association.getRows() ) {
+		for ( Object row : rows ) {
 			serializedRows[i] = strategy.serialize( row );
 			i++;
 		}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/AbstractRedisDialect.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.ogm.datastore.redis;
 
+import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
+
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -19,7 +20,6 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hibernate.ogm.datastore.redis.dialect.model.impl.RedisTupleSnapshot;
 import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
 import org.hibernate.ogm.datastore.redis.impl.json.JsonSerializationStrategy;
 import org.hibernate.ogm.datastore.redis.logging.impl.Log;
@@ -42,8 +42,6 @@ import com.lambdaworks.redis.ScanArgs;
 import com.lambdaworks.redis.cluster.api.sync.RedisAdvancedClusterCommands;
 import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
 import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode;
-
-import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
 
 /**
  * @author Mark Paluch
@@ -96,11 +94,6 @@ public abstract class AbstractRedisDialect extends BaseGridDialect {
 
 		log.cannotDetermineRedisMode( info );
 		return null;
-	}
-
-	@Override
-	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
-		return new Tuple( new RedisTupleSnapshot( new HashMap<String, Object>() ) );
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationType;
@@ -272,7 +273,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 	}
 
 	@Override
-	public void forEachTuple(ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		KeyScanCursor<String> cursor = null;
 		String prefix = entityKeyMetadata.getTable() + ":";
 

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
@@ -27,7 +27,6 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.OperationContext;
-import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.entityentry.impl.TuplePointer;
@@ -110,12 +109,6 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 	}
 
 	@Override
-	public void insertOrUpdateTuple(
-			EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) throws TupleAlreadyExistsException {
-		throw new UnsupportedOperationException( "Method not supported by this dialect anymore" );
-	}
-
-	@Override
 	public Association getAssociation(
 			AssociationKey key, AssociationContext associationContext) {
 		RedisAssociation redisAssociation = null;
@@ -178,12 +171,6 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 		);
 	}
 
-	@Override
-	public void insertOrUpdateAssociation(
-			AssociationKey associationKey, Association association, AssociationContext associationContext) {
-		throw new UnsupportedOperationException( "Method not supported by this dialect anymore" );
-	}
-
 	private Object getAssociationRows(
 			Association association,
 			AssociationKey key) {
@@ -193,18 +180,6 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 		}
 
 		return rows;
-	}
-
-	@Override
-	public void removeAssociation(
-			AssociationKey key, AssociationContext associationContext) {
-		if ( isStoredInEntityStructure( key.getMetadata(), associationContext.getAssociationTypeContext() ) ) {
-			String entityId = entityId( key.getEntityKey() );
-			connection.hdel( entityId, key.getMetadata().getCollectionRole() );
-		}
-		else {
-			connection.del( associationId( key ) );
-		}
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
@@ -39,8 +39,8 @@ import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.model.spi.TupleOperation;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.type.Type;
@@ -84,12 +84,12 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 			objects = toEntity( operationContext.getTupleTypeContext(), hmget );
 		}
 
-		return new Tuple( new RedisHashTupleSnapshot( new HashEntity( objects ), SnapshotType.UPDATE ) );
+		return new Tuple( new RedisHashTupleSnapshot( new HashEntity( objects ) ), SnapshotType.UPDATE );
 	}
 
 	@Override
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
-		return new Tuple( new RedisHashTupleSnapshot( new HashEntity( new HashMap<String, String>() ), SnapshotType.INSERT ) );
+		return new Tuple( new RedisHashTupleSnapshot( new HashEntity( new HashMap<String, String>() ) ), SnapshotType.INSERT );
 	}
 
 	private Map<String, String> toEntity(TupleTypeContext tupleTypeContext, List<String> hmget) {
@@ -161,7 +161,7 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 			if ( owningEntity == null ) {
 				owningEntity = new HashEntity( new HashMap<String, String>() );
 				storeEntity( key.getEntityKey(), owningEntity, associationContext.getAssociationTypeContext().getOwnerEntityOptionsContext() );
-				tuplePointer.setTuple( new Tuple( new RedisHashTupleSnapshot( owningEntity, SnapshotType.UPDATE ) ) );
+				tuplePointer.setTuple( new Tuple( new RedisHashTupleSnapshot( owningEntity ), SnapshotType.UPDATE ) );
 			}
 
 			redisAssociation = RedisAssociation.fromHashEmbeddedAssociation( tuplePointer, key.getMetadata() );
@@ -231,7 +231,7 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 
 				properties.putAll( hgetall );
 				addKeyValuesFromKeyName( entityKeyMetadata, prefix, key, properties );
-				consumer.consume( new Tuple( new RedisHashTupleSnapshot( new HashEntity( properties ), SnapshotType.UPDATE ) ) );
+				consumer.consume( new Tuple( new RedisHashTupleSnapshot( new HashEntity( properties ) ), SnapshotType.UPDATE ) );
 			}
 
 		} while ( !cursor.isFinished() );
@@ -292,7 +292,7 @@ public class RedisHashDialect extends AbstractRedisDialect implements GroupingBy
 					}
 				}
 
-				tuple.getSnapshot().setSnapshotType( SnapshotType.UPDATE );
+				tuple.setSnapshotType( SnapshotType.UPDATE );
 
 				optionsContext = tupleContext.getTupleTypeContext().getOptionsContext();
 			}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
@@ -67,7 +67,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 		}
 
 		Map<String, Object> objects;
-		if ( tupleContext.getSelectableColumns().isEmpty() ) {
+		if ( tupleContext.getTupleTypeContext().getSelectableColumns().isEmpty() ) {
 			objects = (Map) connection.hgetall( entityIdString );
 		}
 		else {
@@ -85,8 +85,8 @@ public class RedisHashDialect extends AbstractRedisDialect {
 
 	private Map<String, Object> toEntity(TupleContext tupleContext, List<String> hmget) {
 		Map<String, Object> objects = new HashMap<>();
-		for ( int i = 0; i < tupleContext.getSelectableColumns().size(); i++ ) {
-			String columnName = tupleContext.getSelectableColumns().get( i );
+		for ( int i = 0; i < tupleContext.getTupleTypeContext().getSelectableColumns().size(); i++ ) {
+			String columnName = tupleContext.getTupleTypeContext().getSelectableColumns().get( i );
 			String value = hmget.get( i );
 			if ( value == null ) {
 				continue;
@@ -97,7 +97,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 	}
 
 	private String[] getFields(TupleContext tupleContext) {
-		return tupleContext.getSelectableColumns().toArray( new String[tupleContext.getSelectableColumns().size()] );
+		return tupleContext.getTupleTypeContext().getSelectableColumns().toArray( new String[tupleContext.getTupleTypeContext().getSelectableColumns().size()] );
 	}
 
 	@Override
@@ -111,7 +111,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 		List<String> toDelete = getKeysForRemoval( tuple );
 
 		String entityId = entityId( key );
-		Long ttl = getObjectTTL( entityId, tupleContext.getOptionsContext() );
+		Long ttl = getObjectTTL( entityId, tupleContext.getTupleTypeContext().getOptionsContext() );
 
 		if ( !toDelete.isEmpty() ) {
 			connection.hdel( entityId, toDelete.toArray( new String[toDelete.size()] ) );

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisHashDialect.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import org.hibernate.ogm.datastore.map.impl.MapHelpers;
 import org.hibernate.ogm.datastore.redis.dialect.model.impl.RedisAssociation;
 import org.hibernate.ogm.datastore.redis.dialect.model.impl.RedisAssociationSnapshot;
-import org.hibernate.ogm.datastore.redis.dialect.model.impl.RedisTupleSnapshot;
+import org.hibernate.ogm.datastore.redis.dialect.model.impl.RedisHashTupleSnapshot;
 import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
 import org.hibernate.ogm.datastore.redis.impl.RedisDatastoreProvider;
 import org.hibernate.ogm.datastore.redis.impl.hash.RedisHashTypeConverter;
@@ -75,7 +75,12 @@ public class RedisHashDialect extends AbstractRedisDialect {
 			objects = toEntity( tupleContext, hmget );
 		}
 
-		return new Tuple( new RedisTupleSnapshot( objects ) );
+		return new Tuple( new RedisHashTupleSnapshot( objects ) );
+	}
+
+	@Override
+	public Tuple createTuple(EntityKey key, TupleContext tupleContext) {
+		return new Tuple( new RedisHashTupleSnapshot( new HashMap<String, Object>() ) );
 	}
 
 	private Map<String, Object> toEntity(TupleContext tupleContext, List<String> hmget) {
@@ -99,7 +104,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 	public void insertOrUpdateTuple(
 			EntityKey key, Tuple tuple, TupleContext tupleContext) throws TupleAlreadyExistsException {
 
-		Map<String, Object> map = ( (RedisTupleSnapshot) tuple.getSnapshot() ).getMap();
+		Map<String, Object> map = ( (RedisHashTupleSnapshot) tuple.getSnapshot() ).getMap();
 		MapHelpers.applyTupleOpsOnMap( tuple, map );
 
 		Map<String, String> entity = getEntityForUpdate( key, tuple );
@@ -278,7 +283,7 @@ public class RedisHashDialect extends AbstractRedisDialect {
 
 				entity.putAll( hgetall );
 				addKeyValuesFromKeyName( entityKeyMetadata, prefix, key, entity );
-				consumer.consume( new Tuple( new RedisTupleSnapshot( entity ) ) );
+				consumer.consume( new Tuple( new RedisHashTupleSnapshot( entity ) ) );
 			}
 
 		} while ( !cursor.isFinished() );

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -312,14 +312,10 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 		storeEntity( key, entityDocument, optionsContext );
 	}
 
-	private void storeEntity(
-			EntityKey key,
-			Entity document,
-			OptionsContext optionsContext) {
-
+	private void storeEntity(EntityKey key, Entity entity, OptionsContext optionsContext) {
 		Long currentTtl = getCurrentTtl( entityId( key ) );
 
-		entityStorageStrategy.storeEntity( entityId( key ), document );
+		entityStorageStrategy.storeEntity( entityId( key ), entity );
 
 		setEntityTTL( key, currentTtl, getTTL( optionsContext ) );
 	}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -240,14 +240,11 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 			);
 		}
 		else {
-			Long currentTtl = getCurrentTtl( entityId( associationKey.getEntityKey() ) );
+			String associationId = associationId( associationKey );
+			Long ttl = getObjectTTL( associationId, associationContext.getAssociationTypeContext().getOptionsContext() );
 			storeAssociation( associationKey, (Association) redisAssociation.getOwningDocument() );
-			setAssociationTTL( associationKey, associationContext, currentTtl );
+			setObjectTTL( associationId, ttl );
 		}
-	}
-
-	private Long getCurrentTtl(String objectKey) {
-		return connection.pttl( objectKey );
 	}
 
 	/**
@@ -265,7 +262,6 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 			AssociationKey key,
 			AssociationContext associationContext) {
 
-
 		boolean organizeByRowKey = DotPatternMapHelpers.organizeAssociationMapByRowKey(
 				association,
 				key,
@@ -277,7 +273,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 				key.getMetadata(),
 				associationContext.getAssociationTypeContext()
 		) && organizeByRowKey ) {
-			String rowKeyColumn = organizeByRowKey ? key.getMetadata().getRowKeyIndexColumnNames()[0] : null;
+			String rowKeyColumn = key.getMetadata().getRowKeyIndexColumnNames()[0];
 			Map<String, Object> rows = new HashMap<>();
 
 			for ( RowKey rowKey : association.getKeys() ) {
@@ -341,11 +337,12 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 	}
 
 	private void storeEntity(EntityKey key, Entity entity, OptionsContext optionsContext) {
-		Long currentTtl = getCurrentTtl( entityId( key ) );
+		String entityId = entityId( key );
+		Long currentTtl = getObjectTTL( entityId, optionsContext );
 
-		entityStorageStrategy.storeEntity( entityId( key ), entity );
+		entityStorageStrategy.storeEntity( entityId, entity );
 
-		setEntityTTL( key, currentTtl, getTTL( optionsContext ) );
+		setObjectTTL( entityId, currentTtl );
 	}
 
 	public JsonEntityStorageStrategy getEntityStorageStrategy() {

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -152,6 +152,8 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 					}
 				}
 
+				tuple.getSnapshot().setSnapshotType( SnapshotType.UPDATE );
+
 				optionsContext = tupleContext.getTupleTypeContext().getOptionsContext();
 			}
 			else if ( operation instanceof InsertOrUpdateAssociationOperation ) {
@@ -303,17 +305,6 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 		}
 
 		return association;
-	}
-
-	// Retrieve entity that contains the association, do not enhance with entity key
-	private TuplePointer getEmbeddingEntityTuplePointer(AssociationKey key, AssociationContext associationContext) {
-		TuplePointer tuplePointer = associationContext.getEntityTuplePointer();
-
-		if ( tuplePointer.getTuple() == null ) {
-			tuplePointer.setTuple( getTuple( key.getEntityKey(), associationContext ) );
-		}
-
-		return tuplePointer;
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -234,9 +234,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 	}
 
 	@Override
-	public org.hibernate.ogm.model.spi.Association getAssociation(
-			AssociationKey key,
-			AssociationContext associationContext) {
+	public org.hibernate.ogm.model.spi.Association getAssociation(AssociationKey key, AssociationContext associationContext) {
 		RedisAssociation redisAssociation = null;
 
 		if ( isStoredInEntityStructure( key.getMetadata(), associationContext.getAssociationTypeContext() ) ) {
@@ -311,7 +309,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 	private TuplePointer getEmbeddingEntityTuplePointer(AssociationKey key, AssociationContext associationContext) {
 		TuplePointer tuplePointer = associationContext.getEntityTuplePointer();
 
-		if (tuplePointer.getTuple() == null) {
+		if ( tuplePointer.getTuple() == null ) {
 			tuplePointer.setTuple( getTuple( key.getEntityKey(), associationContext ) );
 		}
 

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -100,11 +100,6 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 	}
 
 	@Override
-	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
-		throw new UnsupportedOperationException( "Method not supported in GridDialect anymore" );
-	}
-
-	@Override
 	public void executeGroupedChangesToEntity(GroupedChangesToEntityOperation groupedOperation) {
 		Entity owningEntity = null;
 		List<AssociationKey> associationsToRemove = new ArrayList<>();
@@ -304,13 +299,6 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 		return association;
 	}
 
-	@Override
-	public void insertOrUpdateAssociation(
-			AssociationKey associationKey, org.hibernate.ogm.model.spi.Association association,
-			AssociationContext associationContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
-	}
-
 	/**
 	 * Returns the rows of the given association as to be stored in the database. Elements of the returned list are
 	 * either
@@ -363,11 +351,6 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 		}
 
 		return rows;
-	}
-
-	@Override
-	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
-		throw new UnsupportedOperationException("Method not supported in GridDialect anymore");
 	}
 
 	@Override

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -149,7 +149,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 					}
 				}
 
-				optionsContext = tupleContext.getOptionsContext();
+				optionsContext = tupleContext.getTupleTypeContext().getOptionsContext();
 			}
 			else if ( operation instanceof InsertOrUpdateAssociationOperation ) {
 				InsertOrUpdateAssociationOperation insertOrUpdateAssociationOperation = (InsertOrUpdateAssociationOperation) operation;

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.ogm.datastore.redis;
 
-import static org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType.INSERT;
-import static org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType.UPDATE;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,8 +45,8 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.model.spi.TupleOperation;
-import org.hibernate.ogm.model.spi.TupleSnapshot.SnapshotType;
 import org.hibernate.ogm.options.spi.OptionsContext;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.type.Type;
@@ -87,7 +84,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 		Entity entity = entityStorageStrategy.getEntity( entityId( key ) );
 
 		if ( entity != null ) {
-			return new Tuple( new RedisJsonTupleSnapshot( entity, UPDATE ) );
+			return new Tuple( new RedisJsonTupleSnapshot( entity ), SnapshotType.UPDATE );
 		}
 		else if ( isInTheInsertionQueue( key, operationContext ) ) {
 			return createTuple( key, operationContext );
@@ -99,7 +96,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 
 	@Override
 	public Tuple createTuple(EntityKey key, OperationContext operationContext) {
-		return new Tuple( new RedisJsonTupleSnapshot( new Entity(), INSERT ) );
+		return new Tuple( new RedisJsonTupleSnapshot( new Entity() ), SnapshotType.INSERT );
 	}
 
 	@Override
@@ -152,7 +149,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 					}
 				}
 
-				tuple.getSnapshot().setSnapshotType( SnapshotType.UPDATE );
+				tuple.setSnapshotType( SnapshotType.UPDATE );
 
 				optionsContext = tupleContext.getTupleTypeContext().getOptionsContext();
 			}
@@ -282,7 +279,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 			if ( owningEntity == null ) {
 				owningEntity = new Entity();
 				storeEntity( key.getEntityKey(), owningEntity, associationContext.getAssociationTypeContext().getOwnerEntityOptionsContext() );
-				tuplePointer.setTuple( new Tuple( new RedisJsonTupleSnapshot( owningEntity, UPDATE ) ) );
+				tuplePointer.setTuple( new Tuple( new RedisJsonTupleSnapshot( owningEntity ), SnapshotType.UPDATE ) );
 			}
 
 			redisAssociation = RedisAssociation.fromEmbeddedAssociation( tuplePointer, key.getMetadata() );
@@ -387,7 +384,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 
 				addKeyValuesFromKeyName( entityKeyMetadata, prefix, key, document );
 
-				consumer.consume( new Tuple( new RedisJsonTupleSnapshot( document, SnapshotType.UPDATE ) ) );
+				consumer.consume( new Tuple( new RedisJsonTupleSnapshot( document ), SnapshotType.UPDATE ) );
 			}
 
 		} while ( !cursor.isFinished() );
@@ -436,7 +433,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 			if ( entity != null ) {
 				EntityKey key = keys[i];
 				addIdToEntity( entity, key.getColumnNames(), key.getColumnValues() );
-				tuples.add( new Tuple( new RedisJsonTupleSnapshot( entity, SnapshotType.UPDATE ) ) );
+				tuples.add( new Tuple( new RedisJsonTupleSnapshot( entity ), SnapshotType.UPDATE ) );
 			}
 			else {
 				tuples.add( null );

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/RedisJsonDialect.java
@@ -37,6 +37,7 @@ import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKind;
@@ -368,7 +369,7 @@ public class RedisJsonDialect extends AbstractRedisDialect implements MultigetGr
 	}
 
 	@Override
-	public void forEachTuple(final ModelConsumer consumer, TupleContext tupleContext, EntityKeyMetadata entityKeyMetadata) {
+	public void forEachTuple(final ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
 		KeyScanCursor<String> cursor = null;
 		String prefix = entityKeyMetadata.getTable() + ":";
 

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/EmbeddedAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/EmbeddedAssociation.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;
 import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
 import org.hibernate.ogm.datastore.redis.dialect.value.StructuredValue;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationType;
 
@@ -23,16 +24,18 @@ import org.hibernate.ogm.model.key.spi.AssociationType;
  */
 class EmbeddedAssociation extends RedisAssociation {
 
-	private final Entity entity;
+	private final TuplePointer tuplePointer;
 	private final AssociationKeyMetadata associationKeyMetadata;
 
-	public EmbeddedAssociation(Entity entity, AssociationKeyMetadata associationKeyMetadata) {
-		this.entity = entity;
+	public EmbeddedAssociation(TuplePointer tuplePointer, AssociationKeyMetadata associationKeyMetadata) {
+		this.tuplePointer = tuplePointer;
 		this.associationKeyMetadata = associationKeyMetadata;
 	}
 
 	@Override
 	public Object getRows() {
+		Entity entity = getEntity();
+
 		Object rows;
 		Object fieldValue = DotPatternMapHelpers.getValueOrNull(
 				entity.getPropertiesAsHierarchy(), associationKeyMetadata.getCollectionRole()
@@ -53,6 +56,7 @@ class EmbeddedAssociation extends RedisAssociation {
 
 	@Override
 	public void setRows(Object rows) {
+		Entity entity = getEntity();
 		if ( isEmpty( rows ) ) {
 			entity.unset( associationKeyMetadata.getCollectionRole() );
 		}
@@ -88,6 +92,10 @@ class EmbeddedAssociation extends RedisAssociation {
 
 	@Override
 	public StructuredValue getOwningDocument() {
-		return entity;
+		return getEntity();
+	}
+
+	private Entity getEntity() {
+		return ( (RedisJsonTupleSnapshot) tuplePointer.getTuple().getSnapshot() ).getEntity();
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/EmbeddedAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/EmbeddedAssociation.java
@@ -54,11 +54,11 @@ class EmbeddedAssociation extends RedisAssociation {
 	@Override
 	public void setRows(Object rows) {
 		if ( isEmpty( rows ) ) {
-			entity.removeAssociation( associationKeyMetadata.getCollectionRole() );
+			entity.unset( associationKeyMetadata.getCollectionRole() );
 		}
 		else {
 
-			entity.removeAssociation( associationKeyMetadata.getCollectionRole() );
+			entity.unset( associationKeyMetadata.getCollectionRole() );
 			if ( associationKeyMetadata.getAssociationType() == AssociationType.ONE_TO_ONE && rows instanceof Collection ) {
 				Object value = ( (Collection) rows ).iterator().next();
 				entity.set( associationKeyMetadata.getCollectionRole(), value );

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/HashEmbeddedAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/HashEmbeddedAssociation.java
@@ -7,12 +7,12 @@
 package org.hibernate.ogm.datastore.redis.dialect.model.impl;
 
 import java.util.Collection;
-import java.util.Map;
 
 import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
 import org.hibernate.ogm.datastore.redis.dialect.value.StructuredValue;
 import org.hibernate.ogm.datastore.redis.logging.impl.Log;
 import org.hibernate.ogm.datastore.redis.logging.impl.LoggerFactory;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationType;
 
@@ -25,30 +25,28 @@ class HashEmbeddedAssociation extends RedisAssociation {
 
 	private static final Log log = LoggerFactory.getLogger();
 
-	private final Map<String, String> entity;
-	private final HashEntity hashEntity;
+	private final TuplePointer tuplePointer;
 	private final AssociationKeyMetadata associationKeyMetadata;
 
-	public HashEmbeddedAssociation(Map<String, String> entity, AssociationKeyMetadata associationKeyMetadata) {
-		this.entity = entity;
+	public HashEmbeddedAssociation(TuplePointer tuplePointer, AssociationKeyMetadata associationKeyMetadata) {
 		this.associationKeyMetadata = associationKeyMetadata;
-		hashEntity = new HashEntity( entity );
+		this.tuplePointer = tuplePointer;
 	}
 
 	@Override
 	public Object getRows() {
-		return entity.get( associationKeyMetadata.getCollectionRole() );
+		return getEntity().get( associationKeyMetadata.getCollectionRole() );
 	}
 
 	@Override
 	public void setRows(Object rows) {
 		if ( isEmpty( rows ) ) {
-			entity.put( associationKeyMetadata.getCollectionRole(), null );
+			getEntity().set( associationKeyMetadata.getCollectionRole(), null );
 		}
 		else {
 			if ( associationKeyMetadata.getAssociationType() == AssociationType.ONE_TO_ONE && rows instanceof Collection ) {
 				Object value = ( (Collection<?>) rows ).iterator().next();
-				entity.put( associationKeyMetadata.getCollectionRole(), (String) value );
+				getEntity().set( associationKeyMetadata.getCollectionRole(), (String) value );
 			}
 			else {
 				throw log.embeddedToManyAssociationsNotSupportByRedisHash( associationKeyMetadata.getEntityKeyMetadata().getTable(),
@@ -58,7 +56,6 @@ class HashEmbeddedAssociation extends RedisAssociation {
 	}
 
 	protected boolean isEmpty(Object rows) {
-
 		if ( rows == null ) {
 			return true;
 		}
@@ -72,6 +69,10 @@ class HashEmbeddedAssociation extends RedisAssociation {
 
 	@Override
 	public StructuredValue getOwningDocument() {
-		return hashEntity;
+		return getEntity();
+	}
+
+	private HashEntity getEntity() {
+		return ( (RedisHashTupleSnapshot) tuplePointer.getTuple().getSnapshot() ).getEntity();
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.hibernate.ogm.datastore.redis.dialect.value.Association;
 import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
+import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
 import org.hibernate.ogm.datastore.redis.dialect.value.StructuredValue;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 
@@ -79,7 +80,7 @@ public abstract class RedisAssociation {
 	public abstract void setRows(Object rows);
 
 	/**
-	 * Returns the Redis value which owns this association, either an {@link Association} or an
+	 * Returns the Redis value which owns this association, either an {@link Association}, an {@link HashEntity} or an
 	 * {@link Entity}.
 	 *
 	 * @return the {@link StructuredValue} representing the owner of the association

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.ogm.datastore.redis.dialect.model.impl;
 
-import java.util.Map;
-
 import org.hibernate.ogm.datastore.redis.dialect.value.Association;
 import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
 import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
@@ -27,7 +25,7 @@ import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 public abstract class RedisAssociation {
 
 	/**
-	 * Creates a {@link RedisAssociation} from the given {@link Entity} and association name.
+	 * Creates a {@link RedisAssociation} from the given {@link TuplePointer} and association name.
 	 *
 	 * @param tuplePointer a pointer to the owner of the association
 	 * @param associationKeyMetadata association key meta-data
@@ -43,15 +41,15 @@ public abstract class RedisAssociation {
 	/**
 	 * Creates a {@link RedisAssociation} from the given {@link java.util.Map} and association name.
 	 *
-	 * @param entity the owner of the association
+	 * @param tuplePointer a pointer to the owner of the association
 	 * @param associationKeyMetadata association key meta-data
 	 *
 	 * @return a {@link RedisAssociation} representing the association
 	 */
-	public static RedisAssociation fromEmbeddedAssociation(
-			Map<String, String> entity,
+	public static RedisAssociation fromHashEmbeddedAssociation(
+			TuplePointer tuplePointer,
 			AssociationKeyMetadata associationKeyMetadata) {
-		return new HashEmbeddedAssociation( entity, associationKeyMetadata );
+		return new HashEmbeddedAssociation( tuplePointer, associationKeyMetadata );
 	}
 
 	/**

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisAssociation.java
@@ -12,6 +12,7 @@ import org.hibernate.ogm.datastore.redis.dialect.value.Association;
 import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
 import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
 import org.hibernate.ogm.datastore.redis.dialect.value.StructuredValue;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 
 /**
@@ -28,15 +29,15 @@ public abstract class RedisAssociation {
 	/**
 	 * Creates a {@link RedisAssociation} from the given {@link Entity} and association name.
 	 *
-	 * @param entity the owner of the association
+	 * @param tuplePointer a pointer to the owner of the association
 	 * @param associationKeyMetadata association key meta-data
 	 *
 	 * @return a {@link RedisAssociation} representing the association
 	 */
 	public static RedisAssociation fromEmbeddedAssociation(
-			Entity entity,
+			TuplePointer tuplePointer,
 			AssociationKeyMetadata associationKeyMetadata) {
-		return new EmbeddedAssociation( entity, associationKeyMetadata );
+		return new EmbeddedAssociation( tuplePointer, associationKeyMetadata );
 	}
 
 	/**

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
@@ -18,11 +18,9 @@ public class RedisHashTupleSnapshot implements TupleSnapshot {
 
 	private final HashEntity entity;
 
-	private SnapshotType snapshotType;
 
-	public RedisHashTupleSnapshot(HashEntity entity, SnapshotType snapshotType) {
+	public RedisHashTupleSnapshot(HashEntity entity) {
 		this.entity = entity;
-		this.snapshotType = snapshotType;
 	}
 
 	@Override
@@ -38,16 +36,6 @@ public class RedisHashTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return entity.getColumnNames();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	@Override
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	public HashEntity getEntity() {

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.redis.dialect.model.impl;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.ogm.model.spi.TupleSnapshot;
+
+/**
+ * @author Seiya Kawashima &lt;skawashima@uchicago.edu&gt;
+ */
+public class RedisHashTupleSnapshot implements TupleSnapshot {
+
+	private final Map<String, Object> map;
+
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
+	public RedisHashTupleSnapshot(Map<String, Object> map) {
+		this.map = map;
+	}
+
+	@Override
+	public Object get(String column) {
+		return map.get( column );
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	@Override
+	public Set<String> getColumnNames() {
+		return map.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
+	}
+
+	public Map<String, Object> getMap() {
+		return map;
+	}
+}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisHashTupleSnapshot.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.ogm.datastore.redis.dialect.model.impl;
 
-import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.ogm.datastore.redis.dialect.value.HashEntity;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
 
 /**
@@ -16,27 +16,28 @@ import org.hibernate.ogm.model.spi.TupleSnapshot;
  */
 public class RedisHashTupleSnapshot implements TupleSnapshot {
 
-	private final Map<String, Object> map;
+	private final HashEntity entity;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+	private SnapshotType snapshotType;
 
-	public RedisHashTupleSnapshot(Map<String, Object> map) {
-		this.map = map;
+	public RedisHashTupleSnapshot(HashEntity entity, SnapshotType snapshotType) {
+		this.entity = entity;
+		this.snapshotType = snapshotType;
 	}
 
 	@Override
 	public Object get(String column) {
-		return map.get( column );
+		return entity.get( column );
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return map.isEmpty();
+		return entity.isEmpty();
 	}
 
 	@Override
 	public Set<String> getColumnNames() {
-		return map.keySet();
+		return entity.getColumnNames();
 	}
 
 	@Override
@@ -49,7 +50,7 @@ public class RedisHashTupleSnapshot implements TupleSnapshot {
 		this.snapshotType = snapshotType;
 	}
 
-	public Map<String, Object> getMap() {
-		return map;
+	public HashEntity getEntity() {
+		return entity;
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
@@ -18,11 +18,8 @@ public class RedisJsonTupleSnapshot implements TupleSnapshot {
 
 	private final Entity entity;
 
-	private SnapshotType snapshotType;
-
-	public RedisJsonTupleSnapshot(Entity entity, SnapshotType snapshotType) {
+	public RedisJsonTupleSnapshot(Entity entity) {
 		this.entity = entity;
-		this.snapshotType = snapshotType;
 	}
 
 	@Override
@@ -38,15 +35,6 @@ public class RedisJsonTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return entity.getKeys();
-	}
-
-	@Override
-	public SnapshotType getSnapshotType() {
-		return snapshotType;
-	}
-
-	public void setSnapshotType(SnapshotType snapshotType) {
-		this.snapshotType = snapshotType;
 	}
 
 	public Entity getEntity() {

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
@@ -6,37 +6,38 @@
  */
 package org.hibernate.ogm.datastore.redis.dialect.model.impl;
 
-import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.ogm.datastore.redis.dialect.value.Entity;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
 
 /**
  * @author Seiya Kawashima &lt;skawashima@uchicago.edu&gt;
  */
-public class RedisTupleSnapshot implements TupleSnapshot {
+public class RedisJsonTupleSnapshot implements TupleSnapshot {
 
-	private final Map<String, Object> map;
+	private final Entity entity;
 
-	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+	private SnapshotType snapshotType;
 
-	public RedisTupleSnapshot(Map<String, Object> map) {
-		this.map = map;
+	public RedisJsonTupleSnapshot(Entity entity, SnapshotType snapshotType) {
+		this.entity = entity;
+		this.snapshotType = snapshotType;
 	}
 
 	@Override
 	public Object get(String column) {
-		return map.get( column );
+		return entity.getProperty( column );
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return map.isEmpty();
+		return entity.isEmpty();
 	}
 
 	@Override
 	public Set<String> getColumnNames() {
-		return map.keySet();
+		return entity.getKeys();
 	}
 
 	@Override
@@ -44,12 +45,12 @@ public class RedisTupleSnapshot implements TupleSnapshot {
 		return snapshotType;
 	}
 
-	@Override
+
 	public void setSnapshotType(SnapshotType snapshotType) {
 		this.snapshotType = snapshotType;
 	}
 
-	public Map<String, Object> getMap() {
-		return map;
+	public Entity getEntity() {
+		return entity;
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisJsonTupleSnapshot.java
@@ -45,7 +45,6 @@ public class RedisJsonTupleSnapshot implements TupleSnapshot {
 		return snapshotType;
 	}
 
-
 	public void setSnapshotType(SnapshotType snapshotType) {
 		this.snapshotType = snapshotType;
 	}

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisTupleSnapshot.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/model/impl/RedisTupleSnapshot.java
@@ -18,6 +18,8 @@ public class RedisTupleSnapshot implements TupleSnapshot {
 
 	private final Map<String, Object> map;
 
+	private SnapshotType snapshotType = SnapshotType.UNKNOWN;
+
 	public RedisTupleSnapshot(Map<String, Object> map) {
 		this.map = map;
 	}
@@ -35,6 +37,16 @@ public class RedisTupleSnapshot implements TupleSnapshot {
 	@Override
 	public Set<String> getColumnNames() {
 		return map.keySet();
+	}
+
+	@Override
+	public SnapshotType getSnapshotType() {
+		return snapshotType;
+	}
+
+	@Override
+	public void setSnapshotType(SnapshotType snapshotType) {
+		this.snapshotType = snapshotType;
 	}
 
 	public Map<String, Object> getMap() {

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/Entity.java
@@ -162,7 +162,7 @@ public class Entity extends StructuredValue {
 	}
 
 	@JsonIgnore
-	public void removeAssociation(String name) {
+	public void unset(String name) {
 		if ( properties.containsKey( name ) ) {
 			properties.remove( name );
 		}
@@ -170,11 +170,26 @@ public class Entity extends StructuredValue {
 			Set<String> keys = new HashSet<String>( properties.keySet() );
 			for ( String key : keys ) {
 				if ( key.startsWith( name + "." ) ) {
-					removeAssociation( key );
+					unset( key );
 				}
 			}
 
 			DotPatternMapHelpers.resetValue( properties, name );
 		}
+	}
+
+	@JsonIgnore
+	public boolean isEmpty() {
+		return properties.isEmpty();
+	}
+
+	@JsonIgnore
+	public Set<String> getKeys() {
+		return properties.keySet();
+	}
+
+	@JsonIgnore
+	public Object getProperty(String dotPath) {
+		return properties.get( dotPath );
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/HashEntity.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/dialect/value/HashEntity.java
@@ -7,20 +7,58 @@
 package org.hibernate.ogm.datastore.redis.dialect.value;
 
 import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * Entity stored using a Redis Hash.
  *
+ * Note that with Redis hash, all the data types are encoded as strings.
+ *
  * @author Mark Paluch
  */
 public class HashEntity extends StructuredValue {
-	private final Map<String, String> entity;
+	private final Map<String, String> properties;
 
-	public HashEntity(Map<String, String> entity) {
-		this.entity = entity;
+	public HashEntity(Map<String, String> properties) {
+		this.properties = properties;
 	}
 
-	public Map<String, String> getEntity() {
-		return entity;
+	@JsonAnyGetter
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	@JsonAnySetter
+	public void set(String name, String value) {
+		properties.put( name, value );
+	}
+
+	@JsonIgnore
+	public void unset(String name) {
+		properties.remove( name );
+	}
+
+	@JsonIgnore
+	public Object get(String column) {
+		return properties.get( column );
+	}
+
+	@JsonIgnore
+	public boolean has(String column) {
+		return properties.containsKey( column );
+	}
+
+	@JsonIgnore
+	public boolean isEmpty() {
+		return properties.isEmpty();
+	}
+
+	@JsonIgnore
+	public Set<String> getColumnNames() {
+		return properties.keySet();
 	}
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/logging/impl/Log.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/logging/impl/Log.java
@@ -56,4 +56,7 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 
 	@Message(id = 1709, value = "The connection is configured for standalone mode but Redis runs in '%s' mode")
 	HibernateException redisModeMismatchStandaloneModeConfigured(String redisMode);
+
+	@Message(id = 1710, value = "Redis Hash dialect does not support *ToMany associations embedded in the entity %1$s#%2$s")
+	HibernateException embeddedToManyAssociationsNotSupportByRedisHash(String entityName, String collectionRole);
 }

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisEntityContextImpl.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisEntityContextImpl.java
@@ -42,7 +42,7 @@ public abstract class RedisEntityContextImpl
 	@Override
 	public RedisEntityContext ttl(
 			long value, TimeUnit timeUnit) {
-		Contracts.assertTrue( value > 0, "value must be greater 0" );
+		Contracts.assertTrue( value > 0, "value must be greater than 0" );
 		Contracts.assertParameterNotNull( timeUnit, "timeUnit" );
 		addEntityOption( new TTLOption(), timeUnit.toMillis( value ) );
 		return this;

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisGlobalContextImpl.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisGlobalContextImpl.java
@@ -42,7 +42,7 @@ public abstract class RedisGlobalContextImpl
 	@Override
 	public RedisGlobalContext ttl(
 			long value, TimeUnit timeUnit) {
-		Contracts.assertTrue( value > 0, "value must be greater 0" );
+		Contracts.assertTrue( value > 0, "value must be greater than 0" );
 		Contracts.assertParameterNotNull( timeUnit, "timeUnit" );
 		addGlobalOption( new TTLOption(), timeUnit.toMillis( value ) );
 		return this;

--- a/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisPropertyContextImpl.java
+++ b/redis/src/main/java/org/hibernate/ogm/datastore/redis/options/navigation/impl/RedisPropertyContextImpl.java
@@ -42,7 +42,7 @@ public abstract class RedisPropertyContextImpl
 	@Override
 	public RedisPropertyContext ttl(
 			long value, TimeUnit timeUnit) {
-		Contracts.assertTrue( value > 0, "value must be greater 0" );
+		Contracts.assertTrue( value > 0, "value must be greater than 0" );
 		Contracts.assertParameterNotNull( timeUnit, "timeUnit" );
 		addEntityOption( new TTLOption(), timeUnit.toMillis( value ) );
 		return this;

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/performance/RedisPerformanceTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/performance/RedisPerformanceTest.java
@@ -64,7 +64,7 @@ public class RedisPerformanceTest extends RedisOgmTestCase {
 		int getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
 		int storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "storeEntity" );
 		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
-		assertThat( storeEntityInvocationCount ).isEqualTo( 2 );
+		assertThat( storeEntityInvocationCount ).isEqualTo( 1 );
 
 		// Check that all the counters have been reset to 0
 		getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
@@ -82,7 +82,7 @@ public class RedisPerformanceTest extends RedisOgmTestCase {
 		getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
 		storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "storeEntity" );
 		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
-		assertThat( storeEntityInvocationCount ).isEqualTo( 3 );
+		assertThat( storeEntityInvocationCount ).isEqualTo( 1 );
 
 		// Assert removal has been propagated
 		tx = session.beginTransaction();

--- a/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/performance/RedisPerformanceTest.java
+++ b/redis/src/test/java/org/hibernate/ogm/datastore/redis/test/performance/RedisPerformanceTest.java
@@ -43,12 +43,7 @@ public class RedisPerformanceTest extends RedisOgmTestCase {
 					targetMethod = "getEntity(java.lang.String)",
 					helper = "org.hibernate.ogm.utils.BytemanHelper",
 					action = "countInvocation(\"getEntity\")",
-					name = "countGetEntity"),
-			@BMRule(targetClass = "org.hibernate.ogm.datastore.redis.RedisJsonDialect",
-					targetMethod = "getCurrentTtl(java.lang.String)",
-					helper = "org.hibernate.ogm.utils.BytemanHelper",
-					action = "countInvocation(\"getTtl\")",
-					name = "countGetTtl")
+					name = "countGetEntity")
 	})
 	public void testNumberOfCallsToDatastore() throws Exception {
 		//insert entity with embedded collection
@@ -68,20 +63,16 @@ public class RedisPerformanceTest extends RedisOgmTestCase {
 
 		int getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
 		int storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "storeEntity" );
-		int pttlInvocationCount = BytemanHelper.getAndResetInvocationCount( "getTtl" );
-		assertThat( getEntityInvocationCount ).isEqualTo( 3 );
+		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
 		assertThat( storeEntityInvocationCount ).isEqualTo( 2 );
-		assertThat( pttlInvocationCount ).isEqualTo( 2 );
 
 		// Check that all the counters have been reset to 0
 		getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
 		storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "storeEntity" );
-		pttlInvocationCount = BytemanHelper.getAndResetInvocationCount( "getTtl" );
 		assertThat( getEntityInvocationCount ).isEqualTo( 0 );
 		assertThat( storeEntityInvocationCount ).isEqualTo( 0 );
-		assertThat( pttlInvocationCount ).isEqualTo( 0 );
 
-		//remove one of the elements and add a new one
+		// Remove one of the elements
 		tx = session.beginTransaction();
 		grandMother = (GrandMother) session.get( GrandMother.class, grandMother.getId() );
 		grandMother.getGrandChildren().remove( 0 );
@@ -90,12 +81,10 @@ public class RedisPerformanceTest extends RedisOgmTestCase {
 
 		getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getEntity" );
 		storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "storeEntity" );
-		pttlInvocationCount = BytemanHelper.getAndResetInvocationCount( "getTtl" );
-		assertThat( getEntityInvocationCount ).isEqualTo( 5 );
+		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
 		assertThat( storeEntityInvocationCount ).isEqualTo( 3 );
-		assertThat( pttlInvocationCount ).isEqualTo( 3 );
 
-		//assert removal has been propagated
+		// Assert removal has been propagated
 		tx = session.beginTransaction();
 		grandMother = (GrandMother) session.get( GrandMother.class, grandMother.getId() );
 		assertThat( grandMother.getGrandChildren() ).onProperty( "name" ).containsExactly( "Leia" );


### PR DESCRIPTION
So... looks like I finally got something in shape.

I tried to separate the commits in logical units even if it's probably not perfect. I spent quite some time splitting, rebasing and so on so I hope it will help the review.

I implemented grouping for:
- Redis Json & Hash
- CouchDB (I don't think it brings us much due to the fact that we have generated properties but it was interesting as I found a few bugs)
and improved the existing batching for:
- MongoDB

I haven't touched Neo4j and Infinispan as there was a lot of work going on there in parallel.

## Open questions

### ~~OgmEntityEntryState and inverse associations~~

~~I had to comment one test:
ManyToOneGlobalTest>ManyToOneTest.testRemovalOfTransientEntityWithAssociation~~

~~I'll send a mail about that to the list shortly so that we can discuss it.~~

-> **Fixed, we now remove the navigational information when we delete an entity.**

### Properties generated by the datastore

I did what we discuss the other day: if there are generated properties, I flush the pending operations to the datastore.

In the case of CouchDB, as we usually have a generated property for the revision, the grouping is mostly useless...

Funny enough, I found a bug in the new CouchDBDialect and once fixed, the initial issue goes away. The fact is that the revision is updated in the Tuple when we save the document to CouchDB - the protocol returns the updated revision.

I don't think we can make the difference between "the only generated property is the revision" and "we have other generated properties" so, even if suboptimal, it's probably the best we can do.

### OGM-1156

See https://hibernate.atlassian.net/projects/OGM/issues/OGM-1156 . My patch mitigates this issue *except* if there are generated properties (so in the case of CouchDB, always...). I think we should probably try to improve the situation anyway.

### OgmEntityExtraState lifecycle

We need to decide what should be the lifecycle of the values stored in the OgmEntityExtraState.

### Share more code

Once we agree on the general approach, we should probably try to share more code between the grouping aware dialects.

I suspect Infinispan and Neo4j will bring different approaches to the plate so I would like to wait for them to be grouping aware.

### Merge BatchableGridDialect and GroupingByEntityDialect

They started as 2 different beasts but they now have the same behavior so I think we should probably merge them.