### PR TITLE
OGM-1169 Deprecate DatastoreProviderType.INFINISPAN and migrate to Da…

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderInitiator.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderInitiator.java
@@ -30,7 +30,7 @@ public final class DatastoreProviderInitiator implements StandardServiceInitiato
 	public static final DatastoreProviderInitiator INSTANCE = new DatastoreProviderInitiator();
 
 	private static final Log log = LoggerFactory.make();
-	private static final String DEFAULT_DATASTORE_PROVIDER = "infinispan";
+	private static final String DEFAULT_DATASTORE_PROVIDER = "infinispan_embedded";
 
 	@Override
 	public Class<DatastoreProvider> getServiceInitiated() {

--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
@@ -24,9 +24,9 @@ public enum DatastoreProviderType {
 	 * @deprecated use {@link #INFINISPAN_EMBEDDED} instead to avoid ambiguities.
 	 */
 	@Deprecated
-	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider" ),
+	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider" ),
 
-	INFINISPAN_EMBEDDED( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider" ),
+	INFINISPAN_EMBEDDED( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider" ),
 	EHCACHE( "org.hibernate.ogm.datastore.ehcache.impl.EhcacheDatastoreProvider" ),
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider" ),
 	FONGO( "org.hibernate.ogm.datastore.mongodb.impl.FongoDBDatastoreProvider" ),

--- a/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/impl/DatastoreProviderType.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.ogm.datastore.impl;
 
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
 /**
  * This enumeration describes all available datastore providers by providing some shortcuts.
  * It's used for the Datastore Provider initialization to find the provider to instantiate.
@@ -14,8 +17,16 @@ package org.hibernate.ogm.datastore.impl;
  * @author Gunnar Morling
  */
 public enum DatastoreProviderType {
+
 	MAP( "org.hibernate.ogm.datastore.map.impl.MapDatastoreProvider" ),
+
+	/**
+	 * @deprecated use {@link #INFINISPAN_EMBEDDED} instead to avoid ambiguities.
+	 */
+	@Deprecated
 	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider" ),
+
+	INFINISPAN_EMBEDDED( "org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider" ),
 	EHCACHE( "org.hibernate.ogm.datastore.ehcache.impl.EhcacheDatastoreProvider" ),
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider" ),
 	FONGO( "org.hibernate.ogm.datastore.mongodb.impl.FongoDBDatastoreProvider" ),
@@ -24,6 +35,8 @@ public enum DatastoreProviderType {
 	COUCHDB_EXPERIMENTAL( "org.hibernate.ogm.datastore.couchdb.impl.CouchDBDatastoreProvider" ),
 	CASSANDRA_EXPERIMENTAL( "org.hibernate.ogm.datastore.cassandra.impl.CassandraDatastoreProvider" ),
 	REDIS_EXPERIMENTAL( "org.hibernate.ogm.datastore.redis.impl.RedisDatastoreProvider" );
+
+	private static final Log log = LoggerFactory.make();
 
 	private String datastoreProviderClassName;
 
@@ -45,6 +58,9 @@ public enum DatastoreProviderType {
 	}
 
 	public static DatastoreProviderType byShortName(String shortName) {
+		if ( "infinispan".equalsIgnoreCase( shortName ) ) {
+			log.usingDeprecatedDatastoreProviderName( "infinispan", "infinispan_embedded" );
+		}
 		return DatastoreProviderType.valueOf( shortName.toUpperCase() );
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -295,4 +295,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 87, value = "The tuple context is not available, probably because we are dealing with more than a single entity type")
 	HibernateException tupleContextNotAvailable();
+
+	@LogMessage(level = WARN)
+	@Message(id = 88, value = "Configuration is referring to deprecated datastore provider name '%1$s'. Please use the new form '%2$s' instead.")
+	void usingDeprecatedDatastoreProviderName(String deprecatedName, String newName);
+
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderClassLevelSelfTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderClassLevelSelfTest.java
@@ -9,7 +9,7 @@ package org.hibernate.ogm.utils.test;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.CASSANDRA_EXPERIMENTAL;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.COUCHDB_EXPERIMENTAL;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.EHCACHE;
-import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.INFINISPAN;
+import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.INFINISPAN_EMBEDDED;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.MAP;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.MONGODB;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.NEO4J_EMBEDDED;
@@ -29,7 +29,7 @@ import org.junit.Test;
  * @author Mark Paluch
  */
 @SkipByDatastoreProvider({
-		MAP, INFINISPAN, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
+		MAP, INFINISPAN_EMBEDDED, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
 	})
 public class SkipByDatastoreProviderClassLevelSelfTest extends OgmTestCase {
 

--- a/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/test/SkipByDatastoreProviderSelfJpaTest.java
@@ -8,7 +8,7 @@ package org.hibernate.ogm.utils.test;
 
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.CASSANDRA_EXPERIMENTAL;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.COUCHDB_EXPERIMENTAL;
-import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.INFINISPAN;
+import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.INFINISPAN_EMBEDDED;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.MAP;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.EHCACHE;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.REDIS_EXPERIMENTAL;
@@ -31,7 +31,7 @@ public class SkipByDatastoreProviderSelfJpaTest extends OgmJpaTestCase {
 
 	@Test
 	@SkipByDatastoreProvider({
-		MAP, INFINISPAN, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
+		MAP, INFINISPAN_EMBEDDED, MONGODB, EHCACHE, NEO4J_EMBEDDED, COUCHDB_EXPERIMENTAL, REDIS_EXPERIMENTAL, CASSANDRA_EXPERIMENTAL
 	})
 	public void testWhichAlwaysFails() {
 		fail( "This should never be executed" );

--- a/documentation/examples/gettingstarted/src/main/resources/META-INF/persistence.xml
+++ b/documentation/examples/gettingstarted/src/main/resources/META-INF/persistence.xml
@@ -10,7 +10,7 @@
         <properties>
             <!-- Here you will pick which NoSQL technology to use, and configure it;
                  in this example we start a local in-memory Infinispan node. -->
-            <property name="hibernate.ogm.datastore.provider" value="infinispan"/>
+            <property name="hibernate.ogm.datastore.provider" value="infinispan_embedded"/>
             <!-- The following is not necessary, the purpose is to run the test quickly -->
             <property name="hibernate.ogm.infinispan.configuration_resource_name" value="infinispan-local.xml"/>
         </properties>

--- a/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/configuration.asciidoc
@@ -36,7 +36,7 @@ The provider name is [classname]`org.hibernate.ogm.jpa.HibernateOgmPersistence`.
             <property name="hibernate.transaction.jta.platform"
                       value="JBossTS" />
             <property name="hibernate.ogm.datastore.provider"
-                      value="infinispan" />
+                      value="infinispan_embedded" />
         </properties>
     </persistence-unit>
 </persistence>
@@ -99,7 +99,7 @@ StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
     //assuming JBoss TransactionManager in standalone mode
     .applySetting( AvailableSettings.JTA_PLATFORM, "JBossTS" )
     //assuming Infinispan as the backend, using the default settings
-    .applySetting( OgmProperties.DATASTORE_PROVIDER, Infinispan.DATASTORE_PROVIDER_NAME );
+    .applySetting( OgmProperties.DATASTORE_PROVIDER, InfinispanEmbedded.DATASTORE_PROVIDER_NAME );
     .build();
 
 //build the SessionFactory
@@ -181,7 +181,7 @@ This is not needed by Hibernate OGM: it will ignore the datasource, but JPA spec
         <jta-data-source>java:/DefaultDS</jta-data-source>
         <properties>
             <property name="hibernate.transaction.jta.platform" value="JBossAS" />
-            <property name="hibernate.ogm.datastore.provider" value="infinispan" />
+            <property name="hibernate.ogm.datastore.provider" value="infinispan_embedded" />
         </properties>
     </persistence-unit>
 </persistence>

--- a/documentation/manual/src/main/asciidoc/en-US/modules/getting-started.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/getting-started.asciidoc
@@ -174,7 +174,7 @@ Create a `META-INF/persistence.xml` file.
         <properties>
             <!-- Here you will pick which NoSQL technology to use, and configure it;
                  in this example we start a local in-memory Infinispan node. -->
-            <property name="hibernate.ogm.datastore.provider" value="infinispan"/>
+            <property name="hibernate.ogm.datastore.provider" value="infinispan_embedded"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/documentation/manual/src/main/asciidoc/en-US/modules/infinispan.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/infinispan.asciidoc
@@ -74,7 +74,7 @@ which is a good starting point for new users - you don't have to set any propert
 
 .Hibernate OGM properties for Infinispan
 `hibernate.ogm.datastore.provider`::
-Set it to `infinispan` to use Infinispan as the datastore provider.
+Set it to `infinispan_embedded` to use Infinispan as the datastore provider in embedded mode.
 `hibernate.ogm.infinispan.cachemanager_jndi_name`::
 If you have an Infinispan [classname]`EmbeddedCacheManager` registered in JNDI,
 provide the JNDI name and Hibernate OGM will use this instance

--- a/documentation/manual/src/main/asciidoc/en-US/modules/mapping.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/mapping.asciidoc
@@ -42,7 +42,7 @@ let us know (see <<ogm-howtocontribute-contribute>>).
 ====
 Some NoSQL databases can not provide an efficient implementation for IDENTITY or SEQUENCE,
 for these cases we recommend you use a UUID based generator.
-For example on Infinispan using IDENTITY is possible but it will require using cluster
+For example on Infinispan (in embedded mode) using IDENTITY is possible but it will require using cluster
 wide coordination to maintain the counters, which is not going to perform very well.
 
 [source, JAVA]

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanDialect.java
@@ -18,7 +18,7 @@ import org.hibernate.dialect.lock.OptimisticLockingStrategy;
 import org.hibernate.dialect.lock.PessimisticForceIncrementLockingStrategy;
 import org.hibernate.ogm.datastore.infinispan.dialect.impl.InfinispanPessimisticWriteLockingStrategy;
 import org.hibernate.ogm.datastore.infinispan.dialect.impl.InfinispanTupleSnapshot;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.impl.KeyProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.impl.LocalCacheManager;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.impl.LocalCacheManager.Bucket;
@@ -55,9 +55,9 @@ import org.infinispan.distexec.mapreduce.Reducer;
  */
 public class InfinispanDialect<EK,AK,ISK> extends BaseGridDialect {
 
-	private final InfinispanDatastoreProvider provider;
+	private final InfinispanEmbeddedDatastoreProvider provider;
 
-	public InfinispanDialect(InfinispanDatastoreProvider provider) {
+	public InfinispanDialect(InfinispanEmbeddedDatastoreProvider provider) {
 		this.provider = provider;
 	}
 

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanEmbedded.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/InfinispanEmbedded.java
@@ -16,13 +16,8 @@ import org.hibernate.ogm.options.navigation.spi.ConfigurationContext;
 
 /**
  * Allows to configure options specific to the Infinispan data store.
- *
- * @deprecated Use {@link InfinispanEmbedded}
- *
- * @author Gunnar Morling
  */
-@Deprecated
-public class Infinispan implements DatastoreConfiguration<InfinispanGlobalContext> {
+public class InfinispanEmbedded implements DatastoreConfiguration<InfinispanGlobalContext> {
 
 	/**
 	 * Short name of this data store provider.

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/configuration/impl/InfinispanConfiguration.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/configuration/impl/InfinispanConfiguration.java
@@ -10,13 +10,13 @@ import java.net.URL;
 import java.util.Map;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanProperties;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.util.configurationreader.spi.ConfigurationPropertyReader;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
 
 /**
- * Configuration for {@link InfinispanDatastoreProvider}.
+ * Configuration for {@link InfinispanEmbeddedDatastoreProvider}.
  *
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  */

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanPessimisticWriteLockingStrategy.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/dialect/impl/InfinispanPessimisticWriteLockingStrategy.java
@@ -14,7 +14,7 @@ import org.hibernate.StaleObjectStateException;
 import org.hibernate.dialect.lock.LockingStrategy;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.impl.KeyProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.impl.LocalCacheManager;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
@@ -39,7 +39,7 @@ public class InfinispanPessimisticWriteLockingStrategy<EK> implements LockingStr
 	private final LockMode lockMode;
 	private final Lockable lockable;
 
-	private final InfinispanDatastoreProvider provider;
+	private final InfinispanEmbeddedDatastoreProvider provider;
 
 	public InfinispanPessimisticWriteLockingStrategy(Lockable lockable, LockMode lockMode) {
 		this.lockMode = lockMode;
@@ -67,14 +67,14 @@ public class InfinispanPessimisticWriteLockingStrategy<EK> implements LockingStr
 		//FIXME check the version number as well and raise an optimistic lock exception if there is an issue JPA 2 spec: 3.4.4.2
 	}
 
-	private static InfinispanDatastoreProvider getProvider(SessionFactoryImplementor factory) {
+	private static InfinispanEmbeddedDatastoreProvider getProvider(SessionFactoryImplementor factory) {
 		DatastoreProvider service = factory.getServiceRegistry().getService( DatastoreProvider.class );
 
-		if ( service instanceof InfinispanDatastoreProvider ) {
-			return InfinispanDatastoreProvider.class.cast( service );
+		if ( service instanceof InfinispanEmbeddedDatastoreProvider ) {
+			return InfinispanEmbeddedDatastoreProvider.class.cast( service );
 		}
 		else {
-			throw log.unexpectedDatastoreProvider( service.getClass(), InfinispanDatastoreProvider.class );
+			throw log.unexpectedDatastoreProvider( service.getClass(), InfinispanEmbeddedDatastoreProvider.class );
 		}
 	}
 

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/CacheInitializer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/CacheInitializer.java
@@ -24,7 +24,7 @@ public class CacheInitializer extends BaseSchemaDefiner {
 		ServiceRegistryImplementor serviceRegistry = context.getSessionFactory().getServiceRegistry();
 
 		OptionsService optionsService = serviceRegistry.getService( OptionsService.class );
-		InfinispanDatastoreProvider provider = (InfinispanDatastoreProvider) serviceRegistry.getService( DatastoreProvider.class );
+		InfinispanEmbeddedDatastoreProvider provider = (InfinispanEmbeddedDatastoreProvider) serviceRegistry.getService( DatastoreProvider.class );
 
 		provider.initializePersistenceStrategy(
 				optionsService.context().getGlobalOptions().getUnique( CacheMappingOption.class ),

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/InfinispanEmbeddedDatastoreProvider.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/impl/InfinispanEmbeddedDatastoreProvider.java
@@ -40,7 +40,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
  * @author Sanne Grinovero
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
-public class InfinispanDatastoreProvider extends BaseDatastoreProvider implements Startable, Stoppable,
+public class InfinispanEmbeddedDatastoreProvider extends BaseDatastoreProvider implements Startable, Stoppable,
 													ServiceRegistryAwareService, Configurable {
 
 	private static final Log LOG = LoggerFactory.getLogger();

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/common/externalizer/impl/RowKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/common/externalizer/impl/RowKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 
@@ -22,7 +22,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/AssociationKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/AssociationKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
@@ -26,7 +26,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/EntityKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/EntityKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
@@ -25,7 +25,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/EntityKeyMetadataExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/EntityKeyMetadataExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
@@ -26,7 +26,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * nodes in order to find the matching entries from the global entity cache.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/IdSourceKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/kind/externalizer/impl/IdSourceKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.impl.DefaultIdSourceKeyMetadata;
@@ -26,7 +26,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentAssociationKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentAssociationKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -24,7 +24,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentEntityKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentEntityKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -24,7 +24,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentIdSourceKeyExternalizer.java
+++ b/infinispan/src/main/java/org/hibernate/ogm/datastore/infinispan/persistencestrategy/table/externalizer/impl/PersistentIdSourceKeyExternalizer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.ExternalizerIds;
 import org.hibernate.ogm.datastore.infinispan.persistencestrategy.common.externalizer.impl.VersionChecker;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
@@ -23,7 +23,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
  * {@link InfinispanDialect} which stores keys as is in the Infinispan data store.
  * <p>
  * This externalizer is automatically registered with the cache manager when starting the
- * {@link InfinispanDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
+ * {@link InfinispanEmbeddedDatastoreProvider}, so it's not required to configure the externalizer in the Infinispan
  * configuration file.
  *
  * @author Gunnar Morling

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CacheMappingTestBase.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CacheMappingTestBase.java
@@ -11,7 +11,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import java.util.Map;
 
 import org.hibernate.ogm.OgmSession;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.model.impl.DefaultAssociationKeyMetadata;
 import org.hibernate.ogm.model.impl.DefaultEntityKeyMetadata;
@@ -73,8 +73,8 @@ public abstract class CacheMappingTestBase extends OgmTestCase {
 				.getIdSourceCache( DefaultIdSourceKeyMetadata.forTable( tableName, "sequence_name", "next_val" ) );
 	}
 
-	private InfinispanDatastoreProvider getProvider() {
-		return (InfinispanDatastoreProvider) getSessionFactory()
+	private InfinispanEmbeddedDatastoreProvider getProvider() {
+		return (InfinispanEmbeddedDatastoreProvider) getSessionFactory()
 				.getServiceRegistry()
 				.getService( DatastoreProvider.class );
 	}

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CachePerKindConfiguredViaOptionCacheMappingTest.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/cachemapping/CachePerKindConfiguredViaOptionCacheMappingTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.hibernate.ogm.cfg.Configurable;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.cfg.OptionConfigurator;
-import org.hibernate.ogm.datastore.infinispan.Infinispan;
+import org.hibernate.ogm.datastore.infinispan.InfinispanEmbedded;
 import org.hibernate.ogm.datastore.keyvalue.options.CacheMappingType;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.infinispan.Cache;
@@ -47,7 +47,7 @@ public class CachePerKindConfiguredViaOptionCacheMappingTest extends CacheMappin
 
 			@Override
 			public void configure(Configurable configurable) {
-				configurable.configureOptionsFor( Infinispan.class )
+				configurable.configureOptionsFor( InfinispanEmbedded.class )
 					.cacheMapping( CacheMappingType.CACHE_PER_KIND );
 			}
 		} );

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/dialect/impl/InfinispanDialectWithClusteredConfigurationTest.java
@@ -22,7 +22,7 @@ import org.hibernate.engine.transaction.jta.platform.internal.JBossStandAloneJta
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
 import org.hibernate.ogm.datastore.infinispan.InfinispanProperties;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.ModelConsumer;
 import org.hibernate.ogm.dialect.spi.NextValueRequest;
@@ -53,7 +53,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test which makes sure that {@link InfinispanDialect} and {@link InfinispanDatastoreProvider} can operate
+ * Integration test which makes sure that {@link InfinispanDialect} and {@link InfinispanEmbeddedDatastoreProvider} can operate
  * in clustered mode, in particular that objects can be serialized and de-serialized when being written into and read
  * from the data grid.
  * <p>
@@ -62,8 +62,8 @@ import org.junit.Test;
  */
 public class InfinispanDialectWithClusteredConfigurationTest {
 
-	private static InfinispanDatastoreProvider provider1;
-	private static InfinispanDatastoreProvider provider2;
+	private static InfinispanEmbeddedDatastoreProvider provider1;
+	private static InfinispanEmbeddedDatastoreProvider provider2;
 	private static InfinispanDialect dialect1;
 	private static InfinispanDialect dialect2;
 
@@ -71,8 +71,8 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 	public static void setupProvidersAndDialects() throws Exception {
 		SessionFactoryImplementor sessionFactory1 = getSessionFactory();
 		SessionFactoryImplementor sessionFactory2 = getSessionFactory();
-		provider1 = (InfinispanDatastoreProvider) sessionFactory1.getServiceRegistry().getService( DatastoreProvider.class );
-		provider2 = (InfinispanDatastoreProvider) sessionFactory2.getServiceRegistry().getService( DatastoreProvider.class );
+		provider1 = (InfinispanEmbeddedDatastoreProvider) sessionFactory1.getServiceRegistry().getService( DatastoreProvider.class );
+		provider2 = (InfinispanEmbeddedDatastoreProvider) sessionFactory2.getServiceRegistry().getService( DatastoreProvider.class );
 		dialect1 = new InfinispanDialect( provider1 );
 		dialect2 = new InfinispanDialect( provider2 );
 
@@ -176,10 +176,10 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 		}
 	}
 
-	private static InfinispanDatastoreProvider createAndStartNewProvider(ServiceRegistryImplementor serviceRegistry) {
+	private static InfinispanEmbeddedDatastoreProvider createAndStartNewProvider(ServiceRegistryImplementor serviceRegistry) {
 		Map<String, Object> configurationValues = new HashMap<String, Object>();
 		configurationValues.put( InfinispanProperties.CONFIGURATION_RESOURCE_NAME, "infinispan-dist.xml" );
-		InfinispanDatastoreProvider provider = new InfinispanDatastoreProvider();
+		InfinispanEmbeddedDatastoreProvider provider = new InfinispanEmbeddedDatastoreProvider();
 
 		provider.configure( configurationValues );
 		provider.injectServices( serviceRegistry );
@@ -195,7 +195,7 @@ public class InfinispanDialectWithClusteredConfigurationTest {
 		jtaPlatform.injectServices( serviceRegistry );
 		when( serviceRegistry.getService( JtaPlatform.class ) ).thenReturn( jtaPlatform );
 
-		InfinispanDatastoreProvider provider = createAndStartNewProvider( serviceRegistry );
+		InfinispanEmbeddedDatastoreProvider provider = createAndStartNewProvider( serviceRegistry );
 		when( serviceRegistry.getService( DatastoreProvider.class ) ).thenReturn( provider );
 
 		when( serviceRegistry.getService( ClassLoaderService.class ) ).thenReturn( new ClassLoaderServiceImpl() );

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/initialize/WrongConfigurationBootTest.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/test/initialize/WrongConfigurationBootTest.java
@@ -53,7 +53,7 @@ public class WrongConfigurationBootTest {
 	 */
 	private void tryBoot(String configurationResourceName) {
 		Map<String, Object> settings = new HashMap<>();
-		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan" );
+		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_embedded" );
 		settings.put( InfinispanProperties.CONFIGURATION_RESOURCE_NAME, configurationResourceName );
 
 		SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings );

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
@@ -15,8 +15,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
-import org.hibernate.ogm.datastore.infinispan.Infinispan;
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
+import org.hibernate.ogm.datastore.infinispan.InfinispanEmbedded;
 import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.DatastoreConfiguration;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
@@ -129,6 +129,6 @@ public class InfinispanTestHelper implements GridDialectTestHelper {
 
 	@Override
 	public Class<? extends DatastoreConfiguration<?>> getDatastoreConfigurationType() {
-		return Infinispan.class;
+		return InfinispanEmbedded.class;
 	}
 }

--- a/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
+++ b/infinispan/src/test/java/org/hibernate/ogm/datastore/infinispan/utils/InfinispanTestHelper.java
@@ -17,7 +17,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.infinispan.InfinispanDialect;
 import org.hibernate.ogm.datastore.infinispan.InfinispanEmbedded;
-import org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispan.impl.InfinispanEmbeddedDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.DatastoreConfiguration;
 import org.hibernate.ogm.datastore.spi.DatastoreProvider;
 import org.hibernate.ogm.dialect.spi.GridDialect;
@@ -80,25 +80,25 @@ public class InfinispanTestHelper implements GridDialectTestHelper {
 
 	@Override
 	public Map<String, Object> extractEntityTuple(Session session, EntityKey key) {
-		InfinispanDatastoreProvider provider = getProvider( session.getSessionFactory() );
+		InfinispanEmbeddedDatastoreProvider provider = getProvider( session.getSessionFactory() );
 		return getEntityCache( session.getSessionFactory(), key.getMetadata() ).get( provider.getKeyProvider().getEntityCacheKey( key ) );
 	}
 
 	private static Cache<?, Map<String, Object>> getEntityCache(SessionFactory sessionFactory, EntityKeyMetadata entityKeyMetadata) {
-		InfinispanDatastoreProvider castProvider = getProvider( sessionFactory );
+		InfinispanEmbeddedDatastoreProvider castProvider = getProvider( sessionFactory );
 		return castProvider.getCacheManager().getEntityCache( entityKeyMetadata );
 	}
 
-	public static InfinispanDatastoreProvider getProvider(SessionFactory sessionFactory) {
+	public static InfinispanEmbeddedDatastoreProvider getProvider(SessionFactory sessionFactory) {
 		DatastoreProvider provider = ( (SessionFactoryImplementor) sessionFactory ).getServiceRegistry().getService( DatastoreProvider.class );
-		if ( !( InfinispanDatastoreProvider.class.isInstance( provider ) ) ) {
+		if ( !( InfinispanEmbeddedDatastoreProvider.class.isInstance( provider ) ) ) {
 			throw new RuntimeException( "Not testing with Infinispan, cannot extract underlying cache" );
 		}
-		return InfinispanDatastoreProvider.class.cast( provider );
+		return InfinispanEmbeddedDatastoreProvider.class.cast( provider );
 	}
 
 	private static Cache<?, ?> getAssociationCache(SessionFactory sessionFactory, AssociationKeyMetadata associationKeyMetadata) {
-		InfinispanDatastoreProvider castProvider = getProvider( sessionFactory );
+		InfinispanEmbeddedDatastoreProvider castProvider = getProvider( sessionFactory );
 		return castProvider.getCacheManager().getAssociationCache( associationKeyMetadata );
 	}
 
@@ -124,7 +124,7 @@ public class InfinispanTestHelper implements GridDialectTestHelper {
 
 	@Override
 	public GridDialect getGridDialect(DatastoreProvider datastoreProvider) {
-		return new InfinispanDialect( (InfinispanDatastoreProvider) datastoreProvider );
+		return new InfinispanDialect( (InfinispanEmbeddedDatastoreProvider) datastoreProvider );
 	}
 
 	@Override

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
@@ -40,7 +40,7 @@ public class InfinispanModuleMemberRegistrationIT extends ModuleMemberRegistrati
 				.name( "primary" )
 				.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
 				.getOrCreateProperties()
-				.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
+				.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_embedded" ).up()
 				.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 				.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
@@ -47,7 +47,7 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 					.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
 					.getOrCreateProperties()
 						.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
-						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan" ).up()
+						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_embedded" ).up()
 						.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 						.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "org.hibernate.search.orm:${hibernate-search.module.slot}" ).up()
 				.up().up();


### PR DESCRIPTION
…tastoreProviderType.INFINISPAN_EMBEDDED

 - https://hibernate.atlassian.net/browse/OGM-1169

Open questions:

1. rename the maven artifact id as well?
2. Should we similarly rename the class  `org.hibernate.ogm.datastore.infinispan.impl.InfinispanDatastoreProvider` ?