### PR TITLE
OGM-1157 Check import of `org.hibernate.annotations.common`

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.WrongClassException;
-import org.hibernate.annotations.common.AssertionFailure;
 import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.TwoPhaseLoad;

--- a/core/src/main/java/org/hibernate/ogm/model/key/spi/AssociationKey.java
+++ b/core/src/main/java/org/hibernate/ogm/model/key/spi/AssociationKey.java
@@ -8,7 +8,7 @@ package org.hibernate.ogm.model.key.spi;
 
 import java.util.Arrays;
 
-import org.hibernate.annotations.common.AssertionFailure;
+import org.hibernate.AssertionFailure;
 
 /**
  * Represents the key used to link a property value and the id of its owning entity

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmCollectionPersister.java
@@ -13,10 +13,10 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.Session;
-import org.hibernate.annotations.common.AssertionFailure;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.collection.spi.PersistentCollection;

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Contracts.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Contracts.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.ogm.util.impl;
 
-import org.hibernate.annotations.common.AssertionFailure;
+import org.hibernate.AssertionFailure;
 
 /**
  * Utility for simple consistency checks of objects and parameters.

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.bson.types.ObjectId;
+import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
-import org.hibernate.annotations.common.AssertionFailure;
 import org.hibernate.ogm.datastore.document.association.impl.DocumentHelpers;
 import org.hibernate.ogm.datastore.document.cfg.DocumentStoreProperties;
 import org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers;

--- a/src/main/build-config/checkstyle.xml
+++ b/src/main/build-config/checkstyle.xml
@@ -90,6 +90,9 @@
 
             <!-- Dom4J is still being used internally by Hibernate ORM but we're getting rid of it. Avoid it in OGM -->
             <property name="illegalPkgs" value="org.dom4j"/>
+
+            <!-- Avoid org.hibernate.annotations.common.AssertionFailure. Check OGM-1157 -->
+            <property name="illegalPkgs" value="org.hibernate.annotations.common"/>
         </module>
     </module>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1157

  Some classes are using `org.hibernate.annotations.common.AssrtionFailure` instead of
  `org.hibernate.AssertionFailure`, this causes exception in modular environment.

  This change is more restrictive but it seems that we are not using any class
  under org.hibernate.annotations.common.*, so, I prefer to exclude all those classes instead
  of adding a custom checkstyle rule.