### PR TITLE
OGM-1162 Validate configuration for HotRod

### DIFF
--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteProperties.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteProperties.java
@@ -7,11 +7,35 @@
 package org.hibernate.ogm.datastore.infinispanremote;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.ogm.datastore.infinispanremote.configuration.impl.InfinispanRemoteConfiguration;
 import org.hibernate.ogm.datastore.keyvalue.cfg.KeyValueStoreProperties;
 
 /**
  * Properties for configuring the Infinispan Remote datastore via {@code persistence.xml} or
  * {@link StandardServiceRegistryBuilder}.
+ * <p>
+ * It also contains the properites to configure the Hot Rod client.
+ * There are two ways to configure the client:
+ * <ul>
+ *   <li>Using an external Hot Rod properties file; see {@link InfinispanRemoteProperties#CONFIGURATION_RESOURCE_NAME}
+ *   <li>Defining the properties of the client using {@value InfinispanRemoteProperties#HOT_ROD_CLIENT_PREFIX}
+ * </ul>
+ * <p>
+ * When a property of the Hot Rod client is set in the hibernate configuration, it should be prefixed
+ * with {@value InfinispanRemoteProperties#HOT_ROD_CLIENT_PREFIX}.
+ * For example, the property {@code infinispan.client.hotrod.server_list}
+ * becomes {@code hibernate.ogm.infinispan_remote.client.server_list}.
+ * <p>
+ * Currently, some properties in the Hot Rod client don't have a prefix, in this case it must be added
+ * in the hibernate configuration.
+ * For example, the property {@code maxActive} becomes {@code hibernate.ogm.infinispan_remote.client.maxActive}
+ * <p>
+ * Properties with the Hibernate OGM prefix ({@value InfinispanRemoteProperties#HOT_ROD_CLIENT_PREFIX}) will
+ * override corresponding properties defined in the external Hot Rod configuration file.
+ *
+ * @see InfinispanRemoteConfiguration
+ *
+ * @author Davide D'Alto
  */
 public final class InfinispanRemoteProperties implements KeyValueStoreProperties {
 
@@ -20,6 +44,11 @@ public final class InfinispanRemoteProperties implements KeyValueStoreProperties
 	 * for the Hot Rod (Infinispan remote) client.
 	 */
 	public static final String CONFIGURATION_RESOURCE_NAME = "hibernate.ogm.infinispan_remote.configuration_resource_name";
+
+	/**
+	 * Prefix for the Hot Rod (Infinispan remote) client properties.
+	 */
+	public static final String HOT_ROD_CLIENT_PREFIX = "hibernate.ogm.infinispan_remote.client.";
 
 	/**
 	 * You can inject an instance of {@link org.hibernate.ogm.datastore.infinispanremote.schema.spi.SchemaCapture} into

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
@@ -179,9 +179,7 @@ public class InfinispanRemoteConfiguration {
 		Properties hotRodConfiguration = new Properties();
 		loadResourceFile( configurationResourceUrl, hotRodConfiguration );
 		setAdditionalProperties( configurationMap, propertyReader, hotRodConfiguration );
-		if ( hotRodConfiguration.isEmpty() ) {
-			throw log.hotrodClientConfigurationMissing();
-		}
+		setExpectedPropertiesIfNull( hotRodConfiguration );
 		validate( hotRodConfiguration );
 		return hotRodConfiguration;
 	}
@@ -218,6 +216,19 @@ public class InfinispanRemoteConfiguration {
 					hotRodProperty = HOT_ROD_ORIGINAL_PREFIX + hotRodProperty;
 				}
 				hotRodConfiguration.setProperty( hotRodProperty, value );
+			}
+		}
+	}
+
+	/*
+	 * We provide some default values in case some properties are not set
+	 */
+	private void setExpectedPropertiesIfNull(Properties hotRodConfiguration) {
+		for ( int i = 0; i < expectedValuesForHotRod.length; i++ ) {
+			String property = expectedValuesForHotRod[i][0];
+			String expectedValue = expectedValuesForHotRod[i][1];
+			if ( !hotRodConfiguration.containsKey( property ) ) {
+				hotRodConfiguration.setProperty( property, expectedValue );
 			}
 		}
 	}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
@@ -134,7 +134,7 @@ public class InfinispanRemoteConfiguration {
 	}
 
 	/**
-	 * Initialize the internal values form the given {@link Map}.
+	 * Initialize the internal values from the given {@link Map}.
 	 *
 	 * @param configurationMap
 	 *            The values to use as configuration

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/HotRodClientBuilder.java
@@ -6,11 +6,6 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote.impl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Properties;
-
 import org.hibernate.ogm.datastore.infinispanremote.configuration.impl.InfinispanRemoteConfiguration;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
@@ -44,29 +39,8 @@ public class HotRodClientBuilder {
 		return new RemoteCacheManager(
 				new ConfigurationBuilder()
 					.classLoader( HotRodClientBuilder.class.getClassLoader() )
-					.withProperties( getHotRodConfigurationProperties() )
+					.withProperties( config.getClientProperties() )
 					.marshaller( marshaller )
 					.build() );
 	}
-
-	private Properties getHotRodConfigurationProperties() {
-		if ( config != null ) {
-			URL configurationResourceUrl = config.getConfigurationResourceUrl();
-			if ( configurationResourceUrl == null ) {
-				throw log.hotrodClientConfigurationMissing();
-			}
-			Properties p = new Properties();
-			try ( InputStream openStream = configurationResourceUrl.openStream() ) {
-				p.load( openStream );
-			}
-			catch (IOException e) {
-				throw log.failedLoadingHotRodConfigurationProperties( e );
-			}
-			return p;
-		}
-		else {
-			throw log.hotrodClientConfigurationMissing();
-		}
-	}
-
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
@@ -74,4 +74,6 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1714, value = "A remote read returned null while this entry was definitely initialized before. Possible data loss on the Infinispan server?" )
 	HibernateException criticalDataLossDetected();
 
+	@Message(id = 1715, value = "Property <%s> has to be set to <%s> but it's set to <%s>" )
+	HibernateException invalidConfigurationValue(String property, String expectedValue, String actualValue);
 }

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemoteConfigurationTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemoteConfigurationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME;
+import static org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties.HOT_ROD_CLIENT_PREFIX;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.DEFAULT_EXECUTOR_FACTORY_QUEUE_SIZE;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.TCP_NO_DELAY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.datastore.infinispanremote.configuration.impl.InfinispanRemoteConfiguration;
+import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
+import org.hibernate.ogm.utils.GridDialectType;
+import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test that the properties are set in the right way.
+ * <p>
+ * It is possible to override properties in the resource file programmatically.
+ *
+ * @author Davide D'Alto
+ */
+public class InfinispanRemoteConfigurationTest {
+
+	/**
+	 * Properties name to use in the hibernate configuration (when no resource file is used).
+	 */
+	private static final String OGM_EVICTION_MILLIS_PROPERTY = HOT_ROD_CLIENT_PREFIX + "timeBetweenEvictionRunsMillis";
+	private static final String OGM_DEFAULT_EXECUTOR_FACTORY_QUEUE_SIZE_PROPERTY = HOT_ROD_CLIENT_PREFIX + "default_executor_factory.queue_size";
+
+	private static final String EVICTION_MILLIS_PROPERTY = "timeBetweenEvictionRunsMillis";
+	private static final String RESOURCE_NAME = "hotrod-client-testingconfiguration.properties";
+
+	@Rule
+	public RemoteHotRodServerRule hotRodServer = new RemoteHotRodServerRule();
+
+	@Test
+	public void shouldBeAbleToReadTheResourceFile() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, GridDialectType.INFINISPAN_REMOTE.name() );
+		settings.put( CONFIGURATION_RESOURCE_NAME, RESOURCE_NAME );
+
+		Properties clientProperties = extractClientConfiguration( settings );
+
+		assertThat( clientProperties ).isNotEmpty();
+		assertThat( clientProperties.getProperty( TCP_NO_DELAY ) ).isEqualTo( "true" );
+		assertThat( clientProperties.getProperty( DEFAULT_EXECUTOR_FACTORY_QUEUE_SIZE ) ).isEqualTo( "100" );
+		assertThat( clientProperties.getProperty( EVICTION_MILLIS_PROPERTY ) ).isEqualTo( "120000" );
+	}
+
+	@Test
+	public void shouldOverrideConfigurationInResourceFile() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, GridDialectType.INFINISPAN_REMOTE.name() );
+		settings.put( CONFIGURATION_RESOURCE_NAME, RESOURCE_NAME );
+
+		// Set the same property in the resource file
+		settings.put( OGM_DEFAULT_EXECUTOR_FACTORY_QUEUE_SIZE_PROPERTY, "99" );
+		settings.put( OGM_EVICTION_MILLIS_PROPERTY, "129999" );
+
+		Properties clientProperties = extractClientConfiguration( settings );
+
+		assertThat( clientProperties ).isNotEmpty();
+
+		// From the resource file (didn't replace this)
+		assertThat( clientProperties.getProperty( TCP_NO_DELAY ) ).isEqualTo( "true" );
+
+		// The one I set manually
+		assertThat( clientProperties.getProperty( DEFAULT_EXECUTOR_FACTORY_QUEUE_SIZE ) ).isEqualTo( "99" );
+		assertThat( clientProperties.getProperty( EVICTION_MILLIS_PROPERTY ) ).isEqualTo( "129999" );
+	}
+
+	private Properties extractClientConfiguration(Map<String, Object> settings) {
+		try ( SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings ) ) {
+			ServiceRegistryImplementor serviceRegistry = ( (SessionFactoryImplementor) sessionFactory ).getServiceRegistry();
+			InfinispanRemoteConfiguration conf = new InfinispanRemoteConfiguration();
+			conf.initConfiguration( settings, serviceRegistry );
+			return conf.getClientProperties();
+		}
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemoteConfigurationTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemoteConfigurationTest.java
@@ -82,6 +82,18 @@ public class InfinispanRemoteConfigurationTest {
 	}
 
 	@Test
+	public void shouldSetDefaultValues() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( OgmProperties.DATASTORE_PROVIDER, GridDialectType.INFINISPAN_REMOTE.name() );
+
+		Properties clientProperties = extractClientConfiguration( settings );
+
+		assertThat( clientProperties ).isNotEmpty();
+		assertThat( clientProperties.getProperty( MARSHALLER ) ).isEqualTo( OgmProtoStreamMarshaller.class.getName() );
+		assertThat( clientProperties.getProperty( FORCE_RETURN_VALUES ) ).isEqualTo( "true" );
+	}
+
+	@Test
 	public void shouldNormalizeTheValueBeforeValidation() {
 		Map<String, Object> settings = new HashMap<>();
 		settings.put( OgmProperties.DATASTORE_PROVIDER, GridDialectType.INFINISPAN_REMOTE.name() );

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
@@ -180,10 +180,6 @@ public class InfinispanRemoteTestHelper implements GridDialectTestHelper {
 
 	// Various static helpers below:
 
-	private static SessionFactoryImplementor getSessionFactoryImplementor(Session session) {
-		return getSessionFactoryImplementor( session.getSessionFactory() );
-	}
-
 	private static SessionFactoryImplementor getSessionFactoryImplementor(SessionFactory sessionFactory) {
 		return ( (SessionFactoryImplementor) sessionFactory );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1162

I built this on top of https://github.com/hibernate/hibernate-ogm/pull/785
I think it is OK to provide a way to setup the client using parameters in addition to the resource file.
This allows a user to override default values or write tests more easily.

@Sanne let me know which other options you think we need to require. I didn't add a warning for those options that are harmless (it's easy to add if you feel strong about it).
