### PR TITLE
OGM-1210 Add discriminator value as label for a node in Neo4j

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
@@ -18,6 +18,7 @@ import org.hibernate.ogm.util.impl.StringHelper;
 /**
  * Represents all information used to load an entity with some specific characteristics like a projection
  *
+ * @author Davide D'Alto
  * @author Guillaume Scheibel &lt;guillaume.scheibel@gmail.com&gt;
  * @author Gunnar Morling
  */
@@ -25,6 +26,7 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 
 	private final List<String> selectableColumns;
 	private final OptionsContext optionsContext;
+	private final Object discriminatorValue;
 
 	/**
 	 * Information of the associated entity stored per foreign key column names
@@ -34,6 +36,7 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 	private final Map<String, String> roles;
 
 	public TupleTypeContextImpl(List<String> selectableColumns,
+			Object discriminatorValue,
 			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
 			Map<String, String> roles,
 			OptionsContext optionsContext) {
@@ -42,11 +45,17 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
 		this.roles = Collections.unmodifiableMap( roles );
 		this.optionsContext = optionsContext;
+		this.discriminatorValue = discriminatorValue;
 	}
 
 	@Override
 	public List<String> getSelectableColumns() {
 		return selectableColumns;
+	}
+
+	@Override
+	public Object getDiscriminatorValue() {
+		return discriminatorValue;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
@@ -79,4 +79,11 @@ public interface TupleTypeContext {
 	 */
 	Map<String, String> getAllRoles();
 
+	/**
+	 * The value used to discriminate an entity in a hierarchy.
+	 *
+	 * @return the value used to discriminate the entity or {@code null}
+	 */
+	Object getDiscriminatorValue();
+
 }

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -123,6 +123,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 	private static final Log log = LoggerFactory.make();
 
 	private final EntityDiscriminator discriminator;
+	private final Object discriminatorValue;
 
 	private final String tableName;
 	private final String[] constraintOrderedTableNames;
@@ -247,6 +248,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 		);
 
 		this.discriminator = discriminator;
+		this.discriminatorValue = discriminatorValue( persistentClass, discriminator );
 
 		// TODO batch logic copied from AbstractEntityPersister
 		// remove copy by increasing visibility in super class
@@ -595,10 +597,19 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 		return new TupleTypeContextImpl(
 				selectableColumnNames( discriminator ),
+				discriminatorValue,
 				associatedEntityKeyMetadata,
 				roles,
 				optionsService.context().getEntityOptions( getMappedClass() )
 		);
+	}
+
+	private static Object discriminatorValue(final PersistentClass persistentClass, final EntityDiscriminator discriminator) {
+		if ( discriminator.isNeeded() ) {
+			return ColumnBasedDiscriminator.value( persistentClass, discriminator.getType() );
+		}
+
+		return null;
 	}
 
 	public GridType getGridIdentifierType() {

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -6,8 +6,12 @@
  */
 package org.hibernate.ogm.utils;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,9 +59,9 @@ public class GridDialectOperationContexts {
 	public static class TupleTypeContextBuilder {
 
 		private OptionsContext optionsContext = EmptyOptionsContext.INSTANCE;
-		private List<String> selectableColumns = Collections.<String>emptyList();
-		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = Collections.<String, AssociatedEntityKeyMetadata>emptyMap();
-		private Map<String, String> roles = Collections.<String, String>emptyMap();
+		private List<String> selectableColumns = emptyList();
+		private Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata = emptyMap();
+		private Map<String, String> roles = emptyMap();
 
 		public TupleTypeContextBuilder selectableColumns(String... columns) {
 			this.selectableColumns = Arrays.asList( columns );
@@ -80,8 +84,8 @@ public class GridDialectOperationContexts {
 		}
 
 		public TupleTypeContext buildTupleTypeContext() {
-			return new TupleTypeContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
-					Collections.unmodifiableMap( roles ), optionsContext );
+			return new TupleTypeContextImpl( unmodifiableList( selectableColumns ), null, unmodifiableMap( associatedEntityMetadata ),
+					unmodifiableMap( roles ), optionsContext );
 		}
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/EntityKeyMetadataWithDiscriminator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/EntityKeyMetadataWithDiscriminator.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.dialect.impl;
+
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+
+/**
+ * This class is an {@link EntityKeyMetadata} that kepp tracks of the discriminator value required to keep track of
+ * entities whne dealing with single table per class inheritance.
+ * <p>
+ * Normally, Hibernate ORM add a discriminator column and use the value in it to select the right tuples. Neo4j can
+ * keepo track of the different entities using labels, therfore the discriminator value becomes another metdata
+ * identifier.
+ * <p>
+ * This class is used to select the right queries to use with the dialect. {@link EntityKeyMetadata} is not enough
+ * because it is the same for all the entities in the hierarchy.
+ *
+ * @author Davide D'Alto
+ */
+public class EntityKeyMetadataWithDiscriminator implements EntityKeyMetadata {
+
+	private final EntityKeyMetadata entityKeyMetadata;
+	private final Object discriminatorValue;
+
+	public EntityKeyMetadataWithDiscriminator(EntityKeyMetadata entityKeyMetadata, Object discriminatorValue) {
+		this.entityKeyMetadata = entityKeyMetadata;
+		this.discriminatorValue = discriminatorValue;
+	}
+
+	public Object getDiscriminatorValue() {
+		return discriminatorValue;
+	}
+
+	@Override
+	public String getTable() {
+		return entityKeyMetadata.getTable();
+	}
+
+	@Override
+	public String[] getColumnNames() {
+		return entityKeyMetadata.getColumnNames();
+	}
+
+	@Override
+	public boolean isKeyColumn(String columnName) {
+		return entityKeyMetadata.isKeyColumn( columnName );
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( discriminatorValue == null ) ? 0 : discriminatorValue.hashCode() );
+		result = prime * result + ( ( entityKeyMetadata == null ) ? 0 : entityKeyMetadata.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		EntityKeyMetadataWithDiscriminator other = (EntityKeyMetadataWithDiscriminator) obj;
+		if ( discriminatorValue == null ) {
+			if ( other.discriminatorValue != null ) {
+				return false;
+			}
+		}
+		else if ( !discriminatorValue.equals( other.discriminatorValue ) ) {
+			return false;
+		}
+		if ( entityKeyMetadata == null ) {
+			if ( other.entityKeyMetadata != null ) {
+				return false;
+			}
+		}
+		else if ( !entityKeyMetadata.equals( other.entityKeyMetadata ) ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jAssociationQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jAssociationQueries.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jAssociationQueries;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -37,8 +38,8 @@ import org.neo4j.graphdb.Result;
  */
 public class EmbeddedNeo4jAssociationQueries extends BaseNeo4jAssociationQueries {
 
-	public EmbeddedNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, AssociationKeyMetadata associationKeyMetadata) {
-		super( ownerEntityKeyMetadata, associationKeyMetadata );
+	public EmbeddedNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext tupleTypeContext, AssociationKeyMetadata associationKeyMetadata) {
+		super( ownerEntityKeyMetadata, tupleTypeContext, associationKeyMetadata );
 	}
 
 	/**

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
@@ -29,10 +29,6 @@ import org.neo4j.graphdb.Result;
  */
 public class EmbeddedNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 
-	public EmbeddedNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata) {
-		this( entityKeyMetadata, null );
-	}
-
 	public EmbeddedNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
 		super( entityKeyMetadata, tupleTypeContext, false );
 	}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociationQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociationQueries.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jAssociationQueries;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -25,8 +26,8 @@ import org.neo4j.driver.v1.types.Relationship;
  */
 public class BoltNeo4jAssociationQueries extends BaseNeo4jAssociationQueries {
 
-	public BoltNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, AssociationKeyMetadata associationKeyMetadata) {
-		super( ownerEntityKeyMetadata, associationKeyMetadata );
+	public BoltNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext ownerTupleTypeContext, AssociationKeyMetadata associationKeyMetadata) {
+		super( ownerEntityKeyMetadata, ownerTupleTypeContext, associationKeyMetadata );
 	}
 
 	public void removeAssociation(Transaction tx, AssociationKey associationKey) {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jAssociationQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jAssociationQueries.java
@@ -15,11 +15,12 @@ import org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jAssociationQuerie
 import org.hibernate.ogm.datastore.neo4j.remote.http.impl.HttpNeo4jClient;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.ErrorResponse;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Graph;
+import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Graph.Relationship;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Row;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.StatementResult;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Statements;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.StatementsResponse;
-import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Graph.Relationship;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
@@ -32,8 +33,8 @@ import org.hibernate.ogm.util.impl.ArrayHelper;
  */
 public class HttpNeo4jAssociationQueries extends BaseNeo4jAssociationQueries {
 
-	public HttpNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, AssociationKeyMetadata associationKeyMetadata) {
-		super( ownerEntityKeyMetadata, associationKeyMetadata );
+	public HttpNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, TupleTypeContext ownerTupleTypeContext, AssociationKeyMetadata associationKeyMetadata) {
+		super( ownerEntityKeyMetadata, ownerTupleTypeContext, associationKeyMetadata );
 	}
 
 	public void removeAssociation(HttpNeo4jClient dataBase, Long txId, AssociationKey associationKey) {

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleTableInheritanceTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleTableInheritanceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.mapping;
+
+import static org.hibernate.ogm.datastore.neo4j.dialect.impl.NodeLabel.ENTITY;
+import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.node;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class SingleTableInheritanceTest extends Neo4jJpaTestCase {
+
+	private Person joe = new Person( "Joe" );
+	private CommunityMember sergey = new CommunityMember( "Sergey", "Hibernate OGM" );
+	private Employee davide = new Employee( "Davide", "Hibernate OGM", "Red Hat" );
+
+	@Before
+	public void setUp() {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+		em.persist( joe );
+		em.persist( davide );
+		em.persist( sergey );
+		em.getTransaction().commit();
+		em.close();
+	}
+
+	@Test
+	public void testMapping() throws Exception {
+		NodeForGraphAssertions davideNode = node( "d", Person.class.getSimpleName(), "EMP", ENTITY.name() )
+				.property( "DTYPE", "EMP" )
+				.property( "name", davide.name )
+				.property( "project", davide.project )
+				.property( "employer", davide.employer );
+
+		NodeForGraphAssertions sergeyNode = node( "s", Person.class.getSimpleName(), "CMM", ENTITY.name() )
+				.property( "DTYPE", "CMM" )
+				.property( "project", sergey.project )
+				.property( "name", sergey.name );
+
+		NodeForGraphAssertions joeNode = node( "j", Person.class.getSimpleName(), "PRS", ENTITY.name() )
+				.property( "DTYPE", "PRS" )
+				.property( "name", joe.name );
+
+		assertThatOnlyTheseNodesExist( joeNode, davideNode, sergeyNode );
+		assertNumberOfRelationships( 0 );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, CommunityMember.class, Employee.class };
+	}
+
+	@Entity
+	@Table(name = "Person")
+	@DiscriminatorValue(value = "PRS")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	class Person {
+
+		@Id
+		public String name;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	@Table(name = "CommunityMember")
+	@DiscriminatorValue(value = "CMM")
+	class CommunityMember extends Person {
+
+		public String project;
+
+		public CommunityMember() {
+		}
+
+		public CommunityMember(String name, String project) {
+			super( name );
+			this.project = project;
+		}
+	}
+
+	@Entity
+	@Table(name = "Employee")
+	@DiscriminatorValue(value = "EMP")
+	class Employee extends CommunityMember {
+
+		public String employer;
+
+		public Employee() {
+		}
+
+		public Employee(String name, String project, String employer) {
+			super( name, project );
+			this.employer = employer;
+		}
+	}
+
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/TablePerClassInheritanceTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/TablePerClassInheritanceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.mapping;
+
+import static org.hibernate.ogm.datastore.neo4j.dialect.impl.NodeLabel.ENTITY;
+import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.node;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class TablePerClassInheritanceTest extends Neo4jJpaTestCase {
+
+	private Person joe = new Person( "Joe" );
+	private CommunityMember sergey = new CommunityMember( "Sergey", "Hibernate OGM" );
+	private Employee davide = new Employee( "Davide", "Hibernate OGM", "Red Hat" );
+
+	@Before
+	public void setUp() {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+		em.persist( joe );
+		em.persist( davide );
+		em.persist( sergey );
+		em.getTransaction().commit();
+		em.close();
+	}
+
+	@Test
+	public void testMapping() throws Exception {
+		NodeForGraphAssertions davideNode = node( "d", Employee.class.getSimpleName(), ENTITY.name() )
+				.property( "name", davide.name )
+				.property( "project", davide.project )
+				.property( "employer", davide.employer );
+
+		NodeForGraphAssertions sergeyNode = node( "s", CommunityMember.class.getSimpleName(), ENTITY.name() )
+				.property( "project", sergey.project )
+				.property( "name", sergey.name );
+
+		NodeForGraphAssertions joeNode = node( "j", Person.class.getSimpleName(), ENTITY.name() )
+				.property( "name", joe.name );
+
+		assertThatOnlyTheseNodesExist( joeNode, davideNode, sergeyNode );
+		assertNumberOfRelationships( 0 );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, CommunityMember.class, Employee.class };
+	}
+
+	@Entity
+	@Table(name = "Person")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	class Person {
+
+		@Id
+		public String name;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	@Table(name = "CommunityMember")
+	class CommunityMember extends Person {
+
+		public String project;
+
+		public CommunityMember() {
+		}
+
+		public CommunityMember(String name, String project) {
+			super( name );
+			this.project = project;
+		}
+	}
+
+	@Entity
+	@Table(name = "Employee")
+	class Employee extends CommunityMember {
+
+		public String employer;
+
+		public Employee() {
+		}
+
+		public Employee(String name, String project, String employer) {
+			super( name, project );
+			this.employer = employer;
+		}
+	}
+
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/Neo4jEntityQueriesTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/Neo4jEntityQueriesTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.datastore.neo4j.test.query;
 
 import static org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jEntityQueries.ENTITY_ALIAS;
+import static org.hibernate.ogm.utils.GridDialectOperationContexts.emptyTupleTypeContext;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -33,7 +34,7 @@ public class Neo4jEntityQueriesTest {
 
 		EntityKeyMetadata metadata = metadata( "Example", "id.name", "id.surname" );
 		GraphDatabaseService executionEngine = createExecutionEngine();
-		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata );
+		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata, emptyTupleTypeContext() );
 		entityQueries.insertEntity( executionEngine, new String[] { "Davide", "D'Alto" } );
 
 		verify( executionEngine ).execute( eq( expected ), anyMap() );
@@ -49,7 +50,7 @@ public class Neo4jEntityQueriesTest {
 
 		EntityKeyMetadata metadata = metadata( "Example", "id" );
 		GraphDatabaseService executionEngine = mock( GraphDatabaseService.class );
-		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata );
+		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata, emptyTupleTypeContext() );
 		entityQueries.updateEmbeddedColumn( executionEngine, metadata.getColumnNames(), embeddedColumn, "" );
 
 		verify( executionEngine ).execute( eq( expected ), anyMap() );
@@ -66,7 +67,7 @@ public class Neo4jEntityQueriesTest {
 
 		EntityKeyMetadata metadata = metadata( "Example", compositeIdColumns );
 		GraphDatabaseService executionEngine = mock( GraphDatabaseService.class );
-		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata );
+		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata, emptyTupleTypeContext() );
 		entityQueries.updateEmbeddedColumn( executionEngine, metadata.getColumnNames(), embeddedColumn, "" );
 
 		verify( executionEngine ).execute( eq( expected ), anyMap() );
@@ -83,7 +84,7 @@ public class Neo4jEntityQueriesTest {
 
 		GraphDatabaseService executionEngine = createExecutionEngine();
 		EntityKeyMetadata metadata = metadata( "Example", "id" );
-		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata );
+		EmbeddedNeo4jEntityQueries entityQueries = new EmbeddedNeo4jEntityQueries( metadata, emptyTupleTypeContext() );
 		entityQueries.updateEmbeddedColumn( executionEngine, metadata.getColumnNames(), embeddedColumn, "" );
 
 		verify( executionEngine ).execute( eq( expected ), anyMap() );

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/EmbeddedNeo4jTestHelperDelegate.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/EmbeddedNeo4jTestHelperDelegate.java
@@ -142,6 +142,10 @@ public class EmbeddedNeo4jTestHelperDelegate implements Neo4jTestHelperDelegate 
 		try {
 			ResourceIterator<Object> nodes = engine.execute( query, node.getParams() ).columnAs( node.getAlias() );
 
+			if ( !nodes.hasNext() ) {
+				return null;
+			}
+
 			PropertyContainer propertyContainer = (PropertyContainer) nodes.next();
 			if ( nodes.hasNext() ) {
 				throw new NotUniqueException();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1210

THis patch will add a new label the the node when it's created but won't remove the discriminator property. THis way the mapping is still backward compatible but a user can still execute native queries using the more natural approach.

This would be an intermediate step before removing the property in the next major release.

@Sanne @gunnarmorling WDYT?