### PR TITLE
OGM-732 Queries with entities having InheritanceType.SINGLE_TABLE

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -99,7 +99,6 @@ import org.hibernate.type.AssociationType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
 import org.hibernate.type.EntityType;
-import org.hibernate.type.IntegerType;
 import org.hibernate.type.OneToOneType;
 import org.hibernate.type.Type;
 /**
@@ -1805,7 +1804,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 
 	@Override
 	public Type getDiscriminatorType() {
-		return IntegerType.INSTANCE;
+		return discriminator.getType();
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/TablePerClassDiscriminator.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/TablePerClassDiscriminator.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Subclass;
+import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 
 /**
@@ -20,6 +21,8 @@ import org.hibernate.type.Type;
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
 public class TablePerClassDiscriminator implements EntityDiscriminator {
+
+	private static final String DISCRIMINATOR_ALIAS = "clazz_";
 
 	private final Integer subclassId;
 	private final Map<Object, String> subclassesByValue;
@@ -71,12 +74,12 @@ public class TablePerClassDiscriminator implements EntityDiscriminator {
 
 	@Override
 	public String getAlias() {
-		return null;
+		return DISCRIMINATOR_ALIAS;
 	}
 
 	@Override
 	public Type getType() {
-		return null;
+		return StandardBasicTypes.INTEGER;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -13,6 +13,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.Serializable;
 import java.lang.annotation.ElementType;
+import java.util.Collection;
 
 import javax.persistence.PersistenceException;
 import javax.transaction.SystemException;
@@ -301,4 +302,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 88, value = "Configuration is referring to deprecated datastore provider name '%1$s'. Please use the new form '%2$s' instead.")
 	void usingDeprecatedDatastoreProviderName(String deprecatedName, String newName);
 
+	@Message(id = 89, value = "%1$s does not support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy. You should try using SINGLE_TABLE instead. Entities: %2$s")
+	HibernateException queriesOnPolymorphicEntitiesAreNotSupportedWithTablePerClass( String datastore, Collection<String> subclassEntityNames );
 }

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithSingleTableInheritanceTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithSingleTableInheritanceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.queries;
+
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.TestSessionFactory;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ * @author Gunnar Morling
+ */
+public class SimpleQueriesWithSingleTableInheritanceTest extends OgmTestCase {
+
+	@TestSessionFactory
+	public static SessionFactory sessions;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	Person joe = new Person( "Joe" );
+	CommunityMember sergey = new CommunityMember( "Sergey", "Hibernate OGM" );
+	Employee davide = new Employee( "Davide", "Hibernate OGM", "Red Hat" );
+
+	@Before
+	public void prepareDb() {
+		try ( Session session = sessions.openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.persist( joe );
+			session.persist( davide );
+			session.persist( sergey );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@After
+	public void deleteData() {
+		try ( Session session = sessions.openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.delete( session.merge( joe ) );
+			session.delete( session.merge( davide ) );
+			session.delete( session.merge( sergey ) );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testResultsFromPerson() throws Exception {
+		try ( Session session = sessions.openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from Person" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name, sergey.name, joe.name );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testResultsFromCommunityMember() throws Exception {
+		try ( Session session = sessions.openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from CommunityMember" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name, sergey.name );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testResultsFromEmployee() throws Exception {
+		try ( Session session = sessions.openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from Employee" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name );
+
+			tx.commit();
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, CommunityMember.class, Employee.class };
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	@DiscriminatorValue(value = "PRS")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@Indexed
+	public static class Person {
+
+		@Id
+		public String name;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Person other = (Person) obj;
+			if ( name == null ) {
+				if ( other.name != null ) {
+					return false;
+				}
+			}
+			else if ( !name.equals( other.name ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	@Entity(name = "CommunityMember")
+	@DiscriminatorValue(value = "CMM")
+	@Indexed
+	public static class CommunityMember extends Person {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String project;
+
+		public CommunityMember() {
+		}
+
+		public CommunityMember(String name, String project) {
+			super( name );
+			this.project = project;
+		}
+
+		public String getProject() {
+			return project;
+		}
+
+		public void setProject(String project) {
+			this.project = project;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = super.hashCode();
+			result = prime * result + ( ( project == null ) ? 0 : project.hashCode() );
+			return result;
+		}
+	}
+
+	@Entity(name = "Employee")
+	@DiscriminatorValue(value = "EMP")
+	@Indexed
+	public static class Employee extends CommunityMember {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String employer;
+
+		public Employee() {
+		}
+
+		public Employee(String name, String project, String employer) {
+			super( name, project );
+			this.employer = employer;
+		}
+
+		public String getEmployer() {
+			return employer;
+		}
+
+		public void setEmployer(String employer) {
+			this.employer = employer;
+		}
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassInheritanceTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassInheritanceTest.java
@@ -1,0 +1,234 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.queries;
+
+import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ * @author Gunnar Morling
+ */
+public class SimpleQueriesWithTablePerClassInheritanceTest extends OgmTestCase {
+
+	private Person joe = new Person( "Joe" );
+	private CommunityMember sergey = new CommunityMember( "Sergey", "Hibernate OGM" );
+	private Employee davide = new Employee( "Davide", "Hibernate OGM", "Red Hat" );
+
+	@Before
+	public void prepareDb() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.persist( joe );
+			session.persist( davide );
+			session.persist( sergey );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@After
+	public void deleteData() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.delete( session.merge( joe ) );
+			session.delete( session.merge( davide ) );
+			session.delete( session.merge( sergey ) );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE })
+	public void testResultsFromPerson() throws Exception {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from Person p" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name, sergey.name, joe.name );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE })
+	public void testResultsFromCommunityMember() throws Exception {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from CommunityMember c" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name, sergey.name );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testResultsFromEmployee() throws Exception {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+
+			List<?> results = session.createQuery( "from Employee e" ).list();
+			assertThat( results ).onProperty( "name" ).containsOnly( davide.name );
+
+			tx.commit();
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, CommunityMember.class, Employee.class };
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Indexed
+	public static class Person {
+
+		@Id
+		public String name;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Person other = (Person) obj;
+			if ( name == null ) {
+				if ( other.name != null ) {
+					return false;
+				}
+			}
+			else if ( !name.equals( other.name ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	@Entity(name = "CommunityMember")
+	@Table(name = "CommunityMember")
+	@Indexed
+	public static class CommunityMember extends Person {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String project;
+
+		public CommunityMember() {
+		}
+
+		public CommunityMember(String name, String project) {
+			super( name );
+			this.project = project;
+		}
+
+		public String getProject() {
+			return project;
+		}
+
+		public void setProject(String project) {
+			this.project = project;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = super.hashCode();
+			result = prime * result + ( ( project == null ) ? 0 : project.hashCode() );
+			return result;
+		}
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	@Indexed
+	public static class Employee extends CommunityMember {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String employer;
+
+		public Employee() {
+		}
+
+		public Employee(String name, String project, String employer) {
+			super( name, project );
+			this.employer = employer;
+		}
+
+		public String getEmployer() {
+			return employer;
+		}
+
+		public void setEmployer(String employer) {
+			this.employer = employer;
+		}
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassNotSupportedTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassNotSupportedTest.java
@@ -1,0 +1,237 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.queries;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.utils.GridDialectType.CASSANDRA;
+import static org.hibernate.ogm.utils.GridDialectType.COUCHDB;
+import static org.hibernate.ogm.utils.GridDialectType.EHCACHE;
+import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
+import static org.hibernate.ogm.utils.GridDialectType.REDIS_HASH;
+import static org.hibernate.ogm.utils.GridDialectType.REDIS_JSON;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.fest.assertions.Fail;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test that the dialect that are not supporting queries on polymorfic entities throw the right exception.
+ */
+@SkipByGridDialect({ HASHMAP, INFINISPAN, INFINISPAN_REMOTE, REDIS_HASH, REDIS_JSON, CASSANDRA, COUCHDB, EHCACHE })
+public class SimpleQueriesWithTablePerClassNotSupportedTest extends OgmTestCase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private Person joe = new Person( "Joe" );
+	private CommunityMember sergey = new CommunityMember( "Sergey", "Hibernate OGM" );
+	private Employee davide = new Employee( "Davide", "Hibernate OGM", "Red Hat" );
+
+	@Before
+	public void prepareDb() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.persist( joe );
+			session.persist( davide );
+			session.persist( sergey );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@After
+	public void deleteData() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.delete( session.merge( joe ) );
+			session.delete( session.merge( davide ) );
+			session.delete( session.merge( sergey ) );
+			session.flush();
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testExceptionFromPerson() throws Exception {
+		assertExceptionIsThrown( "from Person p" );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-732")
+	public void testExceptionFromCommunityMember() throws Exception {
+		assertExceptionIsThrown( "from CommunityMember c" );
+	}
+
+	private void assertExceptionIsThrown(String queryString) {
+		try ( Session session = openSession() ) {
+			Transaction tx = null;
+			try {
+				tx = session.beginTransaction();
+				session.createQuery( queryString ).list();
+				tx.commit();
+				Fail.fail( "Expected exception for query: [" + queryString + "]" );
+			}
+			catch ( HibernateException e) {
+				assertThat( e ).isInstanceOf( HibernateException.class );
+				assertThat( e.getMessage() ).startsWith( "OGM000089: " );
+			}
+			finally {
+				if ( tx != null && tx.getStatus() == TransactionStatus.ACTIVE ) {
+					tx.rollback();
+				}
+			}
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, CommunityMember.class, Employee.class };
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Indexed
+	public static class Person {
+
+		@Id
+		public String name;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Person other = (Person) obj;
+			if ( name == null ) {
+				if ( other.name != null ) {
+					return false;
+				}
+			}
+			else if ( !name.equals( other.name ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	@Entity(name = "CommunityMember")
+	@Table(name = "CommunityMember")
+	@Indexed
+	public static class CommunityMember extends Person {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String project;
+
+		public CommunityMember() {
+		}
+
+		public CommunityMember(String name, String project) {
+			super( name );
+			this.project = project;
+		}
+
+		public String getProject() {
+			return project;
+		}
+
+		public void setProject(String project) {
+			this.project = project;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = super.hashCode();
+			result = prime * result + ( ( project == null ) ? 0 : project.hashCode() );
+			return result;
+		}
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	@Indexed
+	public static class Employee extends CommunityMember {
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		public String employer;
+
+		public Employee() {
+		}
+
+		public Employee(String name, String project, String employer) {
+			super( name, project );
+			this.employer = employer;
+		}
+
+		public String getEmployer() {
+			return employer;
+		}
+
+		public void setEmployer(String employer) {
+			this.employer = employer;
+		}
+	}
+
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/parser/MapBasedEntityNamesResolver.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/parser/MapBasedEntityNamesResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.utils.parser;
+
+import java.util.Map;
+
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ */
+public class MapBasedEntityNamesResolver implements EntityNamesResolver {
+
+	private final Map<String, Class<?>> entityNames;
+
+	public MapBasedEntityNamesResolver(Map<String, Class<?>> entityNames) {
+		this.entityNames = entityNames;
+	}
+
+	@Override
+	public Class<?> getClassFromName(String entityName) {
+		return entityNames.get( entityName );
+	}
+}

--- a/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
+++ b/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
@@ -155,6 +155,10 @@
         <local-cache name="INITIAL_VALUE_GENERATOR_SEQUENCE" />
         <local-cache name="THREAD_SAFETY_GENERATOR_SEQUENCE" />
 
+        <local-cache name="Person" />
+        <local-cache name="CommunityMember" />
+        <local-cache name="Employee" />
+
         <local-cache name="sequences" />
         <local-cache name="hibernate_sequences" />
 

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/Node.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/Node.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.inheritance;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Type;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class Node {
+
+	private Set<NodeLink> children;
+
+	private String id;
+	private String name;
+
+	public Node() {
+		children = new HashSet<>();
+	}
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Type(type = "objectid")
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@OneToMany(mappedBy = "source")
+	public Set<NodeLink> getChildren() {
+		return children;
+	}
+
+	void setChildren(Set<NodeLink> children) {
+		this.children = children;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( id == null ) ? 0 : id.hashCode() );
+		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		Node other = (Node) obj;
+		if ( id == null ) {
+			if ( other.id != null ) {
+				return false;
+			}
+		}
+		else if ( !id.equals( other.id ) ) {
+			return false;
+		}
+		if ( name == null ) {
+			if ( other.name != null ) {
+				return false;
+			}
+		}
+		else if ( !name.equals( other.name ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + id + ", " + name + ")";
+	}
+
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/NodeLink.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/NodeLink.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.inheritance;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.Type;
+
+@Entity
+public class NodeLink {
+
+	private String id;
+
+	private Node source;
+	private Node target;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Type(type = "objectid")
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@ManyToOne
+	public Node getSource() {
+		return source;
+	}
+
+	void setSource(Node source) {
+		this.source = source;
+	}
+
+	public void assignSource(Node source) {
+		setSource( source );
+		source.getChildren().add( this );
+	}
+
+	@ManyToOne
+	public Node getTarget() {
+		return target;
+	}
+
+	void setTarget(Node target) {
+		this.target = target;
+	}
+
+	public void assignTarget(Node target) {
+		setTarget( target );
+	}
+
+
+	@Override
+	public String toString() {
+		return "NodeLink(" + id + "):  " + source + " to " + target;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( id == null ) ? 0 : id.hashCode() );
+		result = prime * result + ( ( source == null ) ? 0 : source.hashCode() );
+		result = prime * result + ( ( target == null ) ? 0 : target.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		NodeLink other = (NodeLink) obj;
+		if ( id == null ) {
+			if ( other.id != null ) {
+				return false;
+			}
+		}
+		else if ( !id.equals( other.id ) ) {
+			return false;
+		}
+		if ( source == null ) {
+			if ( other.source != null ) {
+				return false;
+			}
+		}
+		else if ( !source.equals( other.source ) ) {
+			return false;
+		}
+		if ( target == null ) {
+			if ( other.target != null ) {
+				return false;
+			}
+		}
+		else if ( !target.equals( other.target ) ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/SimpleNode.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/SimpleNode.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.inheritance;
+
+import javax.persistence.Entity;
+
+@Entity
+public class SimpleNode extends Node {
+
+	public SimpleNode() {
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/SingleTableInheritanceTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/SingleTableInheritanceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.inheritance;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class SingleTableInheritanceTest extends OgmJpaTestCase {
+
+	private Node parent;
+	private Node simpleChild;
+	private TextNode textChild;
+	private NodeLink linkToSimple;
+	private NodeLink linkToText;
+
+	@Before
+	public void setUp() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+
+			parent = new SimpleNode();
+			parent.setName( "root" );
+
+			simpleChild = new SimpleNode();
+			simpleChild.setName( "children 1" );
+
+			textChild = new TextNode();
+			textChild.setName( "children 2" );
+			textChild.setText( "a text" );
+
+			linkToSimple = new NodeLink();
+			linkToSimple.assignSource( parent );
+			linkToSimple.assignTarget( simpleChild );
+
+			linkToText = new NodeLink();
+			linkToText.assignSource( parent );
+			linkToText.assignTarget( textChild );
+
+			em.persist( parent );
+			em.persist( simpleChild );
+			em.persist( textChild );
+			em.persist( linkToText );
+			em.persist( linkToSimple );
+
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testSubclassReturnedByNativeQuery() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			@SuppressWarnings("unchecked")
+			List<TextNode> resultList = em.createNativeQuery( "db.Node.find({'DTYPE': 'TextNode'})", TextNode.class ).getResultList();
+			assertThat( resultList ).containsExactly( textChild );
+			assertThat( ( (TextNode) resultList.get( 0 ) ).getText() ).isEqualTo( textChild.getText() );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testPolymorphismWithNativeQuery() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			@SuppressWarnings("unchecked")
+			List<SimpleNode> resultList = em.createNativeQuery( "{ $query : { DTYPE: 'SimpleNode' }, $orderby : { name : 1 } }", SimpleNode.class )
+					.getResultList();
+			assertThat( resultList ).containsExactly( simpleChild, parent );
+
+			SimpleNode actualSimple = resultList.get( 0 );
+			assertThat( actualSimple.getChildren() ).isEmpty();
+
+			SimpleNode actualRoot = resultList.get( 1 );
+			assertThat( actualRoot.getChildren() ).containsOnly( linkToSimple, linkToText );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testPolymorphismWithNativeQueryWithoutDiscriminator() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			@SuppressWarnings("unchecked")
+			List<Node> resultList = em.createNativeQuery( "{ $query : {}, $orderby : { name : 1 } }", Node.class )
+					.getResultList();
+			assertThat( resultList ).containsExactly( simpleChild, textChild, parent );
+
+			SimpleNode actualSimple = (SimpleNode) resultList.get( 0 );
+			assertThat( actualSimple.getChildren() ).isEmpty();
+
+			TextNode actualText = (TextNode) resultList.get( 1 );
+			assertThat( actualText.getChildren() ).isEmpty();
+
+			SimpleNode actualRoot = (SimpleNode) resultList.get( 2 );
+			assertThat( actualRoot.getChildren() ).containsOnly( linkToSimple, linkToText );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+	@After
+	public void tearDown() {
+		remove( parent, simpleChild, textChild );
+	}
+
+	private void remove(Node... nodes) {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			for ( Node node : nodes ) {
+				Node found = em.find( Node.class, node.getId() );
+				em.remove( found );
+			}
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Node.class, SimpleNode.class, TextNode.class, NodeLink.class };
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/TextNode.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/inheritance/TextNode.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.inheritance;
+
+import javax.persistence.Entity;
+
+@Entity
+public class TextNode extends Node {
+
+	private String text;
+
+	public TextNode() {
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/MongoDBQueryParsingTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/MongoDBQueryParsingTest.java
@@ -16,6 +16,9 @@ import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.impl.MongoDBProcessingChain;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.impl.MongoDBQueryParsingResult;
 import org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.IndexedEntity;
+import org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable.CommunityMemberST;
+import org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable.EmployeeST;
+import org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable.PersonST;
 import org.hibernate.ogm.datastore.mongodb.utils.MapBasedEntityNamesResolver;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.junit.Before;
@@ -41,6 +44,48 @@ public class MongoDBQueryParsingTest extends OgmTestCase {
 		assertMongoDbQuery(
 				"from IndexedEntity",
 				"{ }" );
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValue() {
+		assertMongoDbQuery(
+				"from EmployeeST",
+				"{ \"DTYPE\" : \"EMP\"}",
+				EmployeeST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValueWithFilter() {
+		assertMongoDbQuery(
+				"from EmployeeST e where e.employer = 'Red Hat'",
+				"{ \"$and\" : [ " +
+					"{ \"employer\" : \"Red Hat\"} , " +
+					"{ \"DTYPE\" : \"EMP\"}" +
+				"]}",
+				EmployeeST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValues() {
+		assertMongoDbQuery(
+				"from CommunityMemberST",
+				"{ \"DTYPE\" : " +
+					"{ \"$in\" : [ \"CMM\" , \"EMP\"]}" +
+				"}",
+				CommunityMemberST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValuesWithFilter() {
+		assertMongoDbQuery(
+				"from CommunityMemberST c where c.project = 'Hibernate OGM'",
+				"{ \"$and\" : [ " +
+					"{ \"project\" : \"Hibernate OGM\"} , " +
+					"{ \"DTYPE\" : " +
+						"{ \"$in\" : [ \"CMM\" , \"EMP\"]}" +
+					"}" +
+				"]}",
+				CommunityMemberST.class );
 	}
 
 	@Test
@@ -225,10 +270,18 @@ public class MongoDBQueryParsingTest extends OgmTestCase {
 		assertMongoDbQuery( queryString, null, expectedMongoDbQuery );
 	}
 
+	private void assertMongoDbQuery(String queryString, String expectedMongoDbQuery, Class<?> expectedEntityType) {
+		assertMongoDbQuery( queryString, null, expectedMongoDbQuery, expectedEntityType );
+	}
+
 	private void assertMongoDbQuery(String queryString, Map<String, Object> namedParameters, String expectedMongoDbQuery) {
+		assertMongoDbQuery( queryString, namedParameters, expectedMongoDbQuery, IndexedEntity.class );
+	}
+
+	private void assertMongoDbQuery(String queryString, Map<String, Object> namedParameters, String expectedMongoDbQuery, Class<?> expectedEntityType) {
 		MongoDBQueryParsingResult parsingResult = parseQuery( queryString, namedParameters );
 		assertThat( parsingResult ).isNotNull();
-		assertThat( parsingResult.getEntityType() ).isSameAs( IndexedEntity.class );
+		assertThat( parsingResult.getEntityType() ).isSameAs( expectedEntityType );
 
 		if ( expectedMongoDbQuery == null ) {
 			assertThat( parsingResult.getQuery() ).isNull();
@@ -254,6 +307,9 @@ public class MongoDBQueryParsingTest extends OgmTestCase {
 		Map<String, Class<?>> entityNames = new HashMap<String, Class<?>>();
 		entityNames.put( "com.acme.IndexedEntity", IndexedEntity.class );
 		entityNames.put( "IndexedEntity", IndexedEntity.class );
+		entityNames.put( "CommunityMemberST", CommunityMemberST.class );
+		entityNames.put( "PersonST", PersonST.class );
+		entityNames.put( "EmployeeST", EmployeeST.class );
 		EntityNamesResolver nameResolver = new MapBasedEntityNamesResolver( entityNames );
 
 		return new MongoDBProcessingChain( getSessionFactory(), nameResolver, namedParameters );
@@ -261,6 +317,6 @@ public class MongoDBQueryParsingTest extends OgmTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { IndexedEntity.class };
+		return new Class<?>[]{ IndexedEntity.class, PersonST.class, CommunityMemberST.class, EmployeeST.class };
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/CommunityMemberST.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/CommunityMemberST.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("CMM")
+public class CommunityMemberST extends PersonST {
+
+	private String project;
+
+	public String getProject() {
+		return project;
+	}
+
+	public void setProject(String project) {
+		this.project = project;
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/EmployeeST.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/EmployeeST.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("EMP")
+public class EmployeeST extends CommunityMemberST {
+
+	private String employer;
+
+	public String getEmployer() {
+		return employer;
+	}
+
+	public void setEmployer(String employer) {
+		this.employer = employer;
+	}
+
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/PersonST.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/model/inheritance/singletable/PersonST.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.parsing.model.inheritance.singletable;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorValue("PRS")
+public class PersonST {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/CypherQueryParsingTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/CypherQueryParsingTest.java
@@ -1,0 +1,274 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.hql.QueryParser;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jProcessingChain;
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jQueryParsingResult;
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jQueryRendererDelegate;
+import org.hibernate.ogm.datastore.neo4j.query.parsing.impl.Neo4jQueryResolverDelegate;
+import org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.IndexedEntity;
+import org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance.CommunityMemberST;
+import org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance.EmployeeST;
+import org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance.PersonST;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.parser.MapBasedEntityNamesResolver;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link Neo4jQueryRendererDelegate} and {@link Neo4jQueryResolverDelegate}.
+ *
+ * @author Davide D'Alto
+ */
+public class CypherQueryParsingTest extends OgmTestCase {
+
+	private QueryParser queryParser;
+
+	@Before
+	public void setupParser() {
+		queryParser = new QueryParser();
+	}
+
+	@Test
+	public void shouldCreateUnrestrictedQuery() {
+		assertQuery(
+				"from IndexedEntity",
+				"MATCH (`<gen:0>`:IndexedEntity) RETURN `<gen:0>`" );
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValue() {
+		assertQuery(
+				"from EmployeeST",
+				"MATCH (`<gen:0>`:PersonST) WHERE `<gen:0>`.DTYPE = \"EMP\" RETURN `<gen:0>`",
+				EmployeeST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValueWithFilter() {
+		assertQuery(
+				"from EmployeeST e where e.employer = 'Red Hat'",
+				"MATCH (e:PersonST) WHERE e.employer = \"Red Hat\" AND e.DTYPE = \"EMP\" RETURN e",
+				EmployeeST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValues() {
+		assertQuery(
+				"from CommunityMemberST",
+				"MATCH (`<gen:0>`:PersonST) WHERE `<gen:0>`.DTYPE IN [\"EMP\", \"CMM\"] RETURN `<gen:0>`",
+				CommunityMemberST.class );
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValuesWithFilter() {
+		assertQuery(
+				"from CommunityMemberST c where c.project = 'Hibernate OGM'",
+				"MATCH (c:PersonST) WHERE c.project = \"Hibernate OGM\" AND c.DTYPE IN [\"EMP\", \"CMM\"] RETURN c",
+				CommunityMemberST.class );
+	}
+
+	@Test
+	public void shouldCreateRestrictedQueryUsingSelect() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title = 'same'",
+				"MATCH (e:IndexedEntity) WHERE e.title = \"same\" RETURN e" );
+	}
+
+	@Test
+	public void shouldUseSpecialNameForIdPropertyInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where e.id = '1'",
+				"MATCH (e:IndexedEntity) WHERE e.id = \"1\" RETURN e" );
+	}
+
+	@Test
+	public void shouldUseColumnNameForPropertyInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where e.name = 'Bob'",
+				"MATCH (e:IndexedEntity) WHERE e.entityName = \"Bob\" RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateProjectionQuery() {
+		Neo4jQueryParsingResult parsingResult = parseQuery( "select e.id, e.name, e.position from IndexedEntity e" );
+
+		assertThat( parsingResult.getQueryObject() ).isEqualTo( "MATCH (e:IndexedEntity) RETURN e.id, e.entityName, e.position" );
+		assertThat( parsingResult.getProjections() ).containsExactly( "e.id", "e.entityName", "e.position" );
+	}
+
+	@Test
+	public void shouldAddNumberPropertyAsNumber() {
+		assertQuery(
+				"select e from IndexedEntity e where e.position = 2",
+				"MATCH (e:IndexedEntity) WHERE e.position = 2 RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateLessOrEqualQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.position <= 20",
+				"MATCH (e:IndexedEntity) WHERE e.position <= 20 RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateQueryWithNegationInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where e.name <> 'Bob'",
+				"MATCH (e:IndexedEntity) WHERE e.entityName <> \"Bob\" RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateQueryWithNestedNegationInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where NOT e.name <> 'Bob'",
+				"MATCH (e:IndexedEntity) WHERE e.entityName = \"Bob\" RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateQueryUsingSelectWithConjunctionInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title = 'same' and e.position = 1",
+				"MATCH (e:IndexedEntity) WHERE (e.title = \"same\") AND (e.position = 1) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateQueryWithNegationAndConjunctionInWhereClause() {
+		assertQuery(
+				"select e from IndexedEntity e where NOT ( e.name = 'Bob' AND e.position = 1 )",
+				"MATCH (e:IndexedEntity) WHERE (e.entityName <> \"Bob\") OR (e.position <> 1) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateNegatedRangeQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.name = 'Bob' and not e.position between 1 and 3",
+				"MATCH (e:IndexedEntity) WHERE (e.entityName = \"Bob\") AND (e.position < 1 OR e.position > 3) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateBooleanQueryUsingSelect() {
+		assertQuery(
+				"select e from IndexedEntity e where e.name = 'same' or ( e.id = 4 and e.name = 'booh')",
+				"MATCH (e:IndexedEntity) WHERE (e.entityName = \"same\") OR ((e.id = \"4\") AND (e.entityName = \"booh\")) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateNumericBetweenQuery() {
+		Map<String, Object> namedParameters = new HashMap<String, Object>();
+		namedParameters.put( "lower", 10L );
+		namedParameters.put( "upper", 20L );
+
+		assertQuery(
+				"select e from IndexedEntity e where e.position between :lower and :upper",
+				namedParameters,
+				"MATCH (e:IndexedEntity) WHERE e.position >= {lower} AND e.position <= {upper} RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateInQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title IN ( 'foo', 'bar', 'same')",
+				"MATCH (e:IndexedEntity) WHERE ANY( _x_ IN [\"foo\", \"bar\", \"same\"] WHERE e.title = _x_) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateNotInQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title NOT IN ( 'foo', 'bar', 'same')",
+				"MATCH (e:IndexedEntity) WHERE NOT EXISTS(e.title) OR  NONE( _x_ IN [\"foo\", \"bar\", \"same\"] WHERE e.title = _x_) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateLikeQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title like 'Ali_e%'",
+				"MATCH (e:IndexedEntity) WHERE e.title=~\"^\\\\QAli\\\\E.\\\\Qe\\\\E.*$\" RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateNotLikeQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title not like 'Ali_e%'",
+				"MATCH (e:IndexedEntity) WHERE NOT EXISTS(e.title) OR NOT(e.title=~\"^\\\\QAli\\\\E.\\\\Qe\\\\E.*$\") RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateIsNullQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title is null",
+				"MATCH (e:IndexedEntity) WHERE NOT EXISTS(e.title) RETURN e" );
+	}
+
+	@Test
+	public void shouldCreateIsNotNullQuery() {
+		assertQuery(
+				"select e from IndexedEntity e where e.title is not null",
+				"MATCH (e:IndexedEntity) WHERE EXISTS(e.title) RETURN e" );
+	}
+
+	private void assertQuery(String hqlQuery, String expectedQuery) {
+		assertQuery( hqlQuery, null, expectedQuery );
+	}
+
+	private void assertQuery(String hqlQuery, String expectedMongoDbQuery, Class<?> expectedEntityType) {
+		assertQuery( hqlQuery, null, expectedMongoDbQuery, expectedEntityType );
+	}
+
+	private void assertQuery(String hqlQuery, Map<String, Object> namedParameters, String expectedQuery) {
+		assertQuery( hqlQuery, namedParameters, expectedQuery, IndexedEntity.class );
+	}
+
+	private void assertQuery(String queryString, Map<String, Object> namedParameters, String expectedQuery, Class<?> expectedEntityType) {
+		Neo4jQueryParsingResult parsingResult = parseQuery( queryString, namedParameters );
+		assertThat( parsingResult ).isNotNull();
+		assertThat( parsingResult.getEntityType() ).isSameAs( expectedEntityType );
+
+		if ( expectedQuery == null ) {
+			assertThat( parsingResult.getQueryObject() ).isNull();
+		}
+		else {
+			assertThat( parsingResult.getQueryObject() ).isNotNull();
+			assertThat( parsingResult.getQueryObject() ).isEqualTo( expectedQuery );
+		}
+	}
+
+	private Neo4jQueryParsingResult parseQuery(String queryString) {
+		return parseQuery( queryString, null );
+	}
+
+	private Neo4jQueryParsingResult parseQuery(String queryString, Map<String, Object> namedParameters) {
+		return queryParser.parseQuery(
+				queryString,
+				setUpProcessingChain( namedParameters )
+				);
+	}
+
+	private Neo4jProcessingChain setUpProcessingChain(Map<String, Object> namedParameters) {
+		Map<String, Class<?>> entityNames = new HashMap<String, Class<?>>();
+		entityNames.put( "com.acme.IndexedEntity", IndexedEntity.class );
+		entityNames.put( "IndexedEntity", IndexedEntity.class );
+		entityNames.put( "CommunityMemberST", CommunityMemberST.class );
+		entityNames.put( "PersonST", PersonST.class );
+		entityNames.put( "EmployeeST", EmployeeST.class );
+		EntityNamesResolver nameResolver = new MapBasedEntityNamesResolver( entityNames );
+
+		return new Neo4jProcessingChain( getSessionFactory(), nameResolver, namedParameters );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ IndexedEntity.class, PersonST.class, CommunityMemberST.class, EmployeeST.class };
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/IndexedEntity.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/IndexedEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ */
+@Entity
+public class IndexedEntity {
+
+	private String id;
+	private String name;
+	private long position;
+	private int size;
+	private String title;
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Column(name = "entityName")
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public long getPosition() {
+		return position;
+	}
+
+	public void setPosition(long position) {
+		this.position = position;
+	}
+
+	public int getSize() {
+		return size;
+	}
+
+	public void setSize(int size) {
+		this.size = size;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/CommunityMemberST.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/CommunityMemberST.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("CMM")
+public class CommunityMemberST extends PersonST {
+
+	private String project;
+
+	public String getProject() {
+		return project;
+	}
+
+	public void setProject(String project) {
+		this.project = project;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/EmployeeST.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/EmployeeST.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("EMP")
+public class EmployeeST extends CommunityMemberST {
+
+	private String employer;
+
+	public String getEmployer() {
+		return employer;
+	}
+
+	public void setEmployer(String employer) {
+		this.employer = employer;
+	}
+
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/PersonST.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/query/parsing/model/inheritance/PersonST.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.query.parsing.model.inheritance;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorValue("PRS")
+public class PersonST {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-732

This patch make it possible to run queries on entity hierarchies when mapped with InheritanceType.SINGLE_CLASS. This wasn't working before for Neo4j and MongoDB.

I haven't implemented the TABLE_PER_CLASS approach, so , for now, it throws an exception

See also https://github.com/hibernate/hibernate-ogm/pull/803 for branch 5.0