### PR TITLE
OGM-1191 Remove dead code warning in OgmLoader

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/loader/impl/OgmLoader.java
@@ -490,11 +490,6 @@ public class OgmLoader implements UniqueEntityLoader, BatchableEntityLoader, Tup
 
 		registerNonExists( keys, persisters, session );
 
-		//it's a non existing object: cut short
-		if ( resultset == null ) {
-			return null;
-		}
-
 		final Object[] row = getRow(
 				tuple,
 				persisters,


### PR DESCRIPTION
  With the current code the resultSet can never be null, if that happens,
  you have NullPointerException before calling the method.

  I prefer to remove the code for now and eventually put the check back if we
  have a use case where it makes sense.