### PR TITLE
OGM-1221 Null pointer in Neo4j with SINGLE_TABLE inheritance strategy

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/TupleTypeContextImpl.java
@@ -26,6 +26,9 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 	private final List<String> selectableColumns;
 	private final OptionsContext optionsContext;
 
+	private final String discriminatorColumn;
+	private final Object discriminatorValue;
+
 	/**
 	 * Information of the associated entity stored per foreign key column names
 	 */
@@ -36,12 +39,16 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 	public TupleTypeContextImpl(List<String> selectableColumns,
 			Map<String, AssociatedEntityKeyMetadata> associatedEntityMetadata,
 			Map<String, String> roles,
-			OptionsContext optionsContext) {
+			OptionsContext optionsContext,
+			String discriminatorColumn,
+			Object discriminatorValue) {
 
 		this.selectableColumns = Collections.unmodifiableList( selectableColumns );
 		this.associatedEntityMetadata = Collections.unmodifiableMap( associatedEntityMetadata );
 		this.roles = Collections.unmodifiableMap( roles );
 		this.optionsContext = optionsContext;
+		this.discriminatorColumn = discriminatorColumn;
+		this.discriminatorValue = discriminatorValue;
 	}
 
 	@Override
@@ -77,6 +84,16 @@ public class TupleTypeContextImpl implements TupleTypeContext {
 	@Override
 	public Map<String, String> getAllRoles() {
 		return roles;
+	}
+
+	@Override
+	public String getDiscriminatorColumn() {
+		return discriminatorColumn;
+	}
+
+	@Override
+	public Object getDiscriminatorValue() {
+		return discriminatorValue;
 	}
 
 	@Override

--- a/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/spi/TupleTypeContext.java
@@ -79,4 +79,18 @@ public interface TupleTypeContext {
 	 */
 	Map<String, String> getAllRoles();
 
+	/**
+	 * Get the name of the column with the discriminator.
+	 *
+	 * @return the name of the column or null if the discriminator is not column based
+	 */
+	String getDiscriminatorColumn();
+
+	/**
+	 * The discriminator value for dealing with inheritance; it might be {@code null} because some strategies don't need
+	 * it.
+	 *
+	 * @return the value of the discriminator. It can return {@code null}.
+	 */
+	Object getDiscriminatorValue();
 }

--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -596,7 +596,9 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				selectableColumnNames( discriminator ),
 				associatedEntityKeyMetadata,
 				roles,
-				optionsService.context().getEntityOptions( getMappedClass() )
+				optionsService.context().getEntityOptions( getMappedClass() ),
+				getDiscriminatorColumnName(),
+				getDiscriminatorValue()
 		);
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Child.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Child.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.singletable.family;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("CHILD")
+class Child extends Person {
+
+	@OneToOne
+	private Woman mother;
+
+	@OneToOne
+	private Man father;
+
+	public Child() {
+	}
+
+	public Child(String name) {
+		super( name );
+	}
+
+	public Man getFather() {
+		return father;
+	}
+
+	public void setFather(Man father) {
+		this.father = father;
+	}
+
+	public Woman getMother() {
+		return mother;
+	}
+
+	public void setMother(Woman mother) {
+		this.mother = mother;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Man.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Man.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.singletable.family;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("MAN")
+class Man extends Person {
+
+	@OneToOne
+	private Woman wife;
+
+	@OneToMany(mappedBy = "father")
+	private List<Child> children = new ArrayList<>();
+
+	public Man() {
+	}
+
+	public Man(String name) {
+		super( name );
+	}
+
+	public Woman getWife() {
+		return wife;
+	}
+
+	public void setWife(Woman wife) {
+		this.wife = wife;
+	}
+
+	public List<Child> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Child> children) {
+		this.children = children;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Person.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Person.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.singletable.family;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "TYPE", discriminatorType = DiscriminatorType.STRING)
+class Person {
+	@Id
+	@GeneratedValue(generator = "uuid")
+	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	private String id;
+
+	private String name;
+
+
+	public Person() {
+	}
+
+	public Person(String name) {
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/SingleTablenheritancePersistTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/SingleTablenheritancePersistTest.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.singletable.family;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "OGM-1221")
+public class SingleTablenheritancePersistTest extends OgmJpaTestCase {
+
+	private EntityManager em;
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testPersistEntititesWithoutErrors() {
+		Man john = new Man( "John" );
+		Woman jane = new Woman( "Jane" );
+		Child susan = new Child( "Susan" );
+		Child mark = new Child( "Mark" );
+
+		List<Child> children = new ArrayList<Child>( Arrays.asList( susan, mark ) );
+
+		jane.setHusband( john );
+		jane.setChildren( children );
+
+		john.setWife( jane );
+		john.setChildren( children );
+
+		for ( Child child : children ) {
+			child.setFather( john );
+			child.setMother( jane );
+		}
+
+		persist( john, jane, susan, mark );
+	}
+
+	private void persist(Object... entities) {
+		em.getTransaction().begin();
+		for ( Object entity : entities ) {
+			em.persist( entity );
+		}
+		em.flush();
+		em.getTransaction().commit();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Child.class, Man.class, Person.class, Woman.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Woman.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/singletable/family/Woman.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.singletable.family;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("WOMAN")
+class Woman extends Person {
+
+	@OneToOne(mappedBy = "wife")
+	private Man husband;
+
+	@OneToMany(mappedBy = "mother")
+	private List<Child> children = new ArrayList<>();
+
+	public Woman() {
+	}
+
+	public Woman(String name) {
+		super( name );
+	}
+
+	public Man getHusband() {
+		return husband;
+	}
+
+	public void setHusband(Man husband) {
+		this.husband = husband;
+	}
+
+	public List<Child> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Child> children) {
+		this.children = children;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Child.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Child.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("CHILD")
+class Child extends Person {
+
+	@OneToOne
+	private Woman mother;
+
+	@OneToOne
+	private Man father;
+
+	public Child() {
+	}
+
+	public Child(String name) {
+		super( name );
+	}
+
+	public Man getFather() {
+		return father;
+	}
+
+	public void setFather(Man father) {
+		this.father = father;
+	}
+
+	public Woman getMother() {
+		return mother;
+	}
+
+	public void setMother(Woman mother) {
+		this.mother = mother;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Man.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Man.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("MAN")
+class Man extends Person {
+
+	@OneToOne
+	private Woman wife;
+
+	@OneToMany(mappedBy = "mother")
+	private List<Child> children = new ArrayList<>();
+
+	public Man() {
+	}
+
+	public Man(String name) {
+		super( name );
+	}
+
+	public Woman getWife() {
+		return wife;
+	}
+
+	public void setWife(Woman wife) {
+		this.wife = wife;
+	}
+
+	public List<Child> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Child> children) {
+		this.children = children;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Person.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Person.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@DiscriminatorColumn(name = "TYPE", discriminatorType = DiscriminatorType.STRING)
+class Person {
+
+	@GeneratedValue(generator = "uuid")
+	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	@Id
+	private String id;
+
+	private String name;
+
+	public Person() {
+	}
+
+	public Person(String name) {
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/TablePerClassInheritancePersistTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/TablePerClassInheritancePersistTest.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "OGM-1221")
+public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
+
+	private EntityManager em;
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testPersistEntititesWithoutErrors() {
+		Man john = new Man( "John" );
+		Woman jane = new Woman( "Jane" );
+		Child susan = new Child( "Susan" );
+		Child mark = new Child( "Mark" );
+
+		List<Child> children = Arrays.asList( susan, mark );
+
+		jane.setHusband( john );
+		jane.setChildren( children );
+
+		john.setWife( jane );
+		john.setChildren( children );
+
+		for ( Child child : children ) {
+			child.setFather( john );
+			child.setMother( jane );
+		}
+
+		persist( john, jane, susan, mark );
+	}
+
+	private void persist(Object... entities) {
+		em.getTransaction().begin();
+		for ( Object entity : entities ) {
+			em.persist( entity );
+		}
+		em.getTransaction().commit();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Child.class, Man.class, Person.class, Woman.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Woman.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/Woman.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+@Entity
+@DiscriminatorValue("MAN")
+class Woman extends Person {
+
+	@OneToOne
+	private Man husband;
+
+	@OneToMany(mappedBy = "mother")
+	private List<Child> children = new ArrayList<>();
+
+	public Woman() {
+	}
+
+	public Woman(String name) {
+		super( name );
+	}
+
+	public Man getHusband() {
+		return husband;
+	}
+
+	public void setHusband(Man husband) {
+		this.husband = husband;
+	}
+
+	public List<Child> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Child> children) {
+		this.children = children;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectOperationContexts.java
@@ -81,7 +81,7 @@ public class GridDialectOperationContexts {
 
 		public TupleTypeContext buildTupleTypeContext() {
 			return new TupleTypeContextImpl( Collections.unmodifiableList( selectableColumns ), Collections.unmodifiableMap( associatedEntityMetadata ),
-					Collections.unmodifiableMap( roles ), optionsContext );
+					Collections.unmodifiableMap( roles ), optionsContext, null, null );
 		}
 	}
 

--- a/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
+++ b/infinispan-remote/src/test/resources/hotrod-server-singleton.xml
@@ -159,6 +159,9 @@
         <local-cache name="CommunityMember" />
         <local-cache name="Employee" />
 
+        <local-cache name="Man" />
+        <local-cache name="Woman" />
+
         <local-cache name="sequences" />
         <local-cache name="hibernate_sequences" />
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -10,7 +10,6 @@ import static org.hibernate.ogm.util.impl.EmbeddedHelper.split;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,7 +19,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.AssertionFailure;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.neo4j.embedded.dialect.impl.EmbeddedNeo4jAssociationQueries;
 import org.hibernate.ogm.datastore.neo4j.embedded.dialect.impl.EmbeddedNeo4jAssociationSnapshot;
 import org.hibernate.ogm.datastore.neo4j.embedded.dialect.impl.EmbeddedNeo4jBackendQueryResultIterator;
@@ -44,8 +42,8 @@ import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.TransactionContext;
 import org.hibernate.ogm.dialect.spi.TupleAlreadyExistsException;
 import org.hibernate.ogm.dialect.spi.TupleContext;
-import org.hibernate.ogm.dialect.spi.TuplesSupplier;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.dialect.spi.TuplesSupplier;
 import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
@@ -59,10 +57,6 @@ import org.hibernate.ogm.model.spi.EntityMetadataInformation;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.model.spi.TupleOperation;
-import org.hibernate.ogm.persister.impl.OgmCollectionPersister;
-import org.hibernate.ogm.persister.impl.OgmEntityPersister;
-import org.hibernate.persister.collection.CollectionPersister;
-import org.hibernate.persister.entity.EntityPersister;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -85,17 +79,13 @@ import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationK
  *
  * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
-public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
+public class EmbeddedNeo4jDialect extends BaseNeo4jDialect<EmbeddedNeo4jEntityQueries, EmbeddedNeo4jAssociationQueries> {
 
 	private static final Log log = LoggerFactory.getLogger();
 
 	private final GraphDatabaseService dataBase;
 
 	private final EmbeddedNeo4jSequenceGenerator sequenceGenerator;
-
-	private Map<EntityKeyMetadata, EmbeddedNeo4jEntityQueries> entityQueries;
-
-	private Map<AssociationKeyMetadata, EmbeddedNeo4jAssociationQueries> associationQueries;
 
 	public EmbeddedNeo4jDialect(EmbeddedNeo4jDatastoreProvider provider) {
 		super( EmbeddedNeo4jTypeConverter.INSTANCE );
@@ -104,53 +94,18 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	@Override
-	public void sessionFactoryCreated(SessionFactoryImplementor sessionFactoryImplementor) {
-		this.associationQueries = Collections.unmodifiableMap( initializeAssociationQueries( sessionFactoryImplementor ) );
-		this.entityQueries = Collections.unmodifiableMap( initializeEntityQueries( sessionFactoryImplementor, associationQueries ) );
+	protected EmbeddedNeo4jAssociationQueries createNeo4jAssociationQueries(EntityKeyMetadata ownerEntityKeyMetadata, AssociationKeyMetadata associationKeyMetadata) {
+		return new EmbeddedNeo4jAssociationQueries( ownerEntityKeyMetadata, associationKeyMetadata );
 	}
 
-	private Map<EntityKeyMetadata, EmbeddedNeo4jEntityQueries> initializeEntityQueries(SessionFactoryImplementor sessionFactoryImplementor,
-			Map<AssociationKeyMetadata, EmbeddedNeo4jAssociationQueries> associationQueries) {
-		Map<EntityKeyMetadata, EmbeddedNeo4jEntityQueries> entityQueries = initializeEntityQueries( sessionFactoryImplementor );
-		for ( AssociationKeyMetadata associationKeyMetadata : associationQueries.keySet() ) {
-			EntityKeyMetadata entityKeyMetadata = associationKeyMetadata.getAssociatedEntityKeyMetadata().getEntityKeyMetadata();
-			if ( !entityQueries.containsKey( entityKeyMetadata ) ) {
-				// Embeddables metadata
-				entityQueries.put( entityKeyMetadata, new EmbeddedNeo4jEntityQueries( entityKeyMetadata ) );
-			}
-		}
-		return entityQueries;
-	}
-
-	private Map<EntityKeyMetadata, EmbeddedNeo4jEntityQueries> initializeEntityQueries(SessionFactoryImplementor sessionFactoryImplementor) {
-		Map<EntityKeyMetadata, EmbeddedNeo4jEntityQueries> queryMap = new HashMap<EntityKeyMetadata, EmbeddedNeo4jEntityQueries>();
-		Collection<EntityPersister> entityPersisters = sessionFactoryImplementor.getEntityPersisters().values();
-		for ( EntityPersister entityPersister : entityPersisters ) {
-			if ( entityPersister instanceof OgmEntityPersister ) {
-				OgmEntityPersister ogmEntityPersister = (OgmEntityPersister) entityPersister;
-				queryMap.put( ogmEntityPersister.getEntityKeyMetadata(), new EmbeddedNeo4jEntityQueries( ogmEntityPersister.getEntityKeyMetadata() ) );
-			}
-		}
-		return queryMap;
-	}
-
-	private Map<AssociationKeyMetadata, EmbeddedNeo4jAssociationQueries> initializeAssociationQueries(SessionFactoryImplementor sessionFactoryImplementor) {
-		Map<AssociationKeyMetadata, EmbeddedNeo4jAssociationQueries> queryMap = new HashMap<AssociationKeyMetadata, EmbeddedNeo4jAssociationQueries>();
-		Collection<CollectionPersister> collectionPersisters = sessionFactoryImplementor.getCollectionPersisters().values();
-		for ( CollectionPersister collectionPersister : collectionPersisters ) {
-			if ( collectionPersister instanceof OgmCollectionPersister ) {
-				OgmCollectionPersister ogmCollectionPersister = (OgmCollectionPersister) collectionPersister;
-				EntityKeyMetadata ownerEntityKeyMetadata = ( (OgmEntityPersister) ( ogmCollectionPersister.getOwnerEntityPersister() ) ).getEntityKeyMetadata();
-				AssociationKeyMetadata associationKeyMetadata = ogmCollectionPersister.getAssociationKeyMetadata();
-				queryMap.put( associationKeyMetadata, new EmbeddedNeo4jAssociationQueries( ownerEntityKeyMetadata, associationKeyMetadata ) );
-			}
-		}
-		return queryMap;
+	@Override
+	protected EmbeddedNeo4jEntityQueries createNeo4jEntityQueries(EntityKeyMetadata entityKeyMetadata, TupleTypeContext tupleTypeContext) {
+		return new EmbeddedNeo4jEntityQueries( entityKeyMetadata, tupleTypeContext );
 	}
 
 	@Override
 	public Tuple getTuple(EntityKey key, OperationContext context) {
-		Node entityNode = entityQueries.get( key.getMetadata() ).findEntity( dataBase, key.getColumnValues() );
+		Node entityNode = getEntityQueries( key.getMetadata(), context ).findEntity( dataBase, key.getColumnValues() );
 		if ( entityNode == null ) {
 			return null;
 		}
@@ -174,7 +129,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		// We only supports one metadata for now
 		EntityKeyMetadata metadata = keys[0].getMetadata();
 		// The result returned by the query might not be in the same order as the keys.
-		ResourceIterator<Node> nodes = entityQueries.get( metadata ).findEntities( dataBase, keys );
+		ResourceIterator<Node> nodes = getEntityQueries( metadata, tupleContext.getTupleTypeContext() ).findEntities( dataBase, keys );
 		try {
 			return tuplesResult( keys, tupleContext, nodes );
 		}
@@ -230,7 +185,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 
 		// insert
 		if ( snapshot.isNew() ) {
-			Node node = insertTuple( key, tuple );
+			Node node = insertTuple( key, tuple, tupleContext.getTupleTypeContext() );
 			snapshot.setNode( node );
 			applyTupleOperations( key, tuple, node, tuple.getOperations(), tupleContext );
 			GraphLogger.log( "Inserted node: %1$s", node );
@@ -243,9 +198,9 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		}
 	}
 
-	private Node insertTuple(EntityKey key, Tuple tuple) {
+	private Node insertTuple(EntityKey key, Tuple tuple, TupleTypeContext tupleTypeContext) {
 		try {
-			return entityQueries.get( key.getMetadata() ).insertEntity( dataBase, key.getColumnValues() );
+			return getEntityQueries( key.getMetadata(), tupleTypeContext ).insertEntity( dataBase, key.getColumnValues() );
 		}
 		catch (QueryExecutionException qee) {
 			if ( CONSTRAINT_VIOLATION_CODE.equals( qee.getStatusCode() ) ) {
@@ -268,7 +223,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 
 	@Override
 	public void removeTuple(EntityKey key, TupleContext tupleContext) {
-		entityQueries.get( key.getMetadata() ).removeEntity( dataBase, key.getColumnValues() );
+		getEntityQueries( key.getMetadata(), tupleContext ).removeEntity( dataBase, key.getColumnValues() );
 	}
 
 	/**
@@ -277,13 +232,14 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	 * the first time with the information related to the owner of the association and the {@link RowKey},
 	 * the second time using the same {@link RowKey} but with the {@link AssociationKey} referring to the other side of the association.
 	 * @param associatedEntityKeyMetadata
+	 * @param associationContext
 	 */
-	private Relationship createRelationship(AssociationKey associationKey, Tuple associationRow, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
+	private Relationship createRelationship(AssociationKey associationKey, Tuple associationRow, AssociatedEntityKeyMetadata associatedEntityKeyMetadata, AssociationContext associationContext) {
 		switch ( associationKey.getMetadata().getAssociationKind() ) {
 			case EMBEDDED_COLLECTION:
 				return createRelationshipWithEmbeddedNode( associationKey, associationRow, associatedEntityKeyMetadata );
 			case ASSOCIATION:
-				return findOrCreateRelationshipWithEntityNode( associationKey, associationRow, associatedEntityKeyMetadata );
+				return findOrCreateRelationshipWithEntityNode( associationKey, associationRow, associatedEntityKeyMetadata, associationContext.getTupleTypeContext() );
 			default:
 				throw new AssertionFailure( "Unrecognized associationKind: " + associationKey.getMetadata().getAssociationKind() );
 		}
@@ -291,16 +247,23 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 
 	private Relationship createRelationshipWithEmbeddedNode(AssociationKey associationKey, Tuple associationRow, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
 		EntityKey embeddedKey = getEntityKey( associationRow, associatedEntityKeyMetadata );
-		Relationship relationship = associationQueries.get( associationKey.getMetadata() )
+		Relationship relationship = getAssociationQueries( associationKey.getMetadata() )
 				.createRelationshipForEmbeddedAssociation( dataBase, associationKey, embeddedKey );
 		applyProperties( associationKey, associationRow, relationship );
 		return relationship;
 	}
 
-	private Relationship findOrCreateRelationshipWithEntityNode(AssociationKey associationKey, Tuple associationRow, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
+	@Override
+	protected EntityKeyMetadata entityKeyMetadata(EntityKeyMetadata keyMetadata, TupleTypeContext tupleTypeContext) {
+		// This dialect use the programmatic API for the operations related to the associations and work with
+		// Single table and table per inheritance strategies without the need to keep track of the discriminator column.
+		return keyMetadata;
+	}
+
+	private Relationship findOrCreateRelationshipWithEntityNode(AssociationKey associationKey, Tuple associationRow, AssociatedEntityKeyMetadata associatedEntityKeyMetadata, TupleTypeContext tupleTypeContext) {
 		EntityKey targetEntityKey = getEntityKey( associationRow, associatedEntityKeyMetadata );
-		Node targetNode = entityQueries.get( targetEntityKey.getMetadata() ).findEntity( dataBase, targetEntityKey.getColumnValues() );
-		return createRelationshipWithTargetNode( associationKey, associationRow, targetNode );
+		Node targetNode = getEntityQueries( targetEntityKey.getMetadata(), (TupleTypeContext) null ).findEntity( dataBase, targetEntityKey.getColumnValues() );
+		return createRelationshipWithTargetNode( associationKey, associationRow, tupleTypeContext, targetNode );
 	}
 
 	/**
@@ -315,9 +278,9 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		}
 	}
 
-	private Relationship createRelationshipWithTargetNode(AssociationKey associationKey, Tuple associationRow, Node targetNode) {
+	private Relationship createRelationshipWithTargetNode(AssociationKey associationKey, Tuple associationRow, TupleTypeContext tupleTypeContext, Node targetNode) {
 		EntityKey entityKey = associationKey.getEntityKey();
-		Node ownerNode = entityQueries.get( entityKey.getMetadata() ).findEntity( dataBase, entityKey.getColumnValues() );
+		Node ownerNode = getEntityQueries( entityKey.getMetadata(), tupleTypeContext ).findEntity( dataBase, entityKey.getColumnValues() );
 		Relationship relationship = ownerNode.createRelationshipTo( targetNode, withName( associationKey.getMetadata().getCollectionRole() ) );
 		applyProperties( associationKey, associationRow, relationship );
 		return relationship;
@@ -326,7 +289,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	@Override
 	public Association getAssociation(AssociationKey associationKey, AssociationContext associationContext) {
 		EntityKey entityKey = associationKey.getEntityKey();
-		Node entityNode = entityQueries.get( entityKey.getMetadata() ).findEntity( dataBase, entityKey.getColumnValues() );
+		Node entityNode = getEntityQueries( entityKey.getMetadata(), associationContext ).findEntity( dataBase, entityKey.getColumnValues() );
 		GraphLogger.log( "Found owner node: %1$s", entityNode );
 		if ( entityNode == null ) {
 			return null;
@@ -338,7 +301,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 
 	private Map<RowKey, Tuple> createAssociationMap(AssociationKey associationKey, AssociationContext associationContext, EntityKey entityKey) {
 		String relationshipType = associationContext.getAssociationTypeContext().getRoleOnMainSide();
-		ResourceIterator<Relationship> relationships = entityQueries.get( entityKey.getMetadata() )
+		ResourceIterator<Relationship> relationships = getEntityQueries( entityKey.getMetadata(), associationContext )
 				.findAssociation( dataBase, entityKey.getColumnValues(), relationshipType );
 
 		Map<RowKey, Tuple> tuples = new HashMap<RowKey, Tuple>();
@@ -377,7 +340,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			return;
 		}
 
-		associationQueries.get( key.getMetadata() ).removeAssociation( dataBase, key );
+		getAssociationQueries( key.getMetadata() ).removeAssociation( dataBase, key );
 	}
 
 	private void applyAssociationOperation(Association association, AssociationKey key, AssociationOperation operation, AssociationContext associationContext) {
@@ -386,7 +349,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			removeAssociation( key, associationContext );
 			break;
 		case PUT:
-			putAssociationOperation( association, key, operation, associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata() );
+			putAssociationOperation( association, key, operation, associationContext );
 			break;
 		case REMOVE:
 			removeAssociationOperation( association, key, operation, associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata() );
@@ -394,8 +357,9 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 		}
 	}
 
-	private void putAssociationOperation(Association association, AssociationKey associationKey, AssociationOperation action, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
-		Relationship relationship = associationQueries.get( associationKey.getMetadata() ).findRelationship( dataBase, associationKey, action.getKey() );
+	private void putAssociationOperation(Association association, AssociationKey associationKey, AssociationOperation action, AssociationContext associationContext) {
+		AssociatedEntityKeyMetadata associatedEntityKeyMetadata = associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata();
+		Relationship relationship = getAssociationQueries( associationKey.getMetadata() ).findRelationship( dataBase, associationKey, action.getKey() );
 
 		if ( relationship != null ) {
 			for ( String relationshipProperty : associationKey.getMetadata().getRowKeyIndexColumnNames() ) {
@@ -411,7 +375,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			GraphLogger.log( "Updated relationship: %1$s", relationship );
 		}
 		else {
-			relationship = createRelationship( associationKey, action.getValue(), associatedEntityKeyMetadata );
+			relationship = createRelationship( associationKey, action.getValue(), associatedEntityKeyMetadata, associationContext );
 			GraphLogger.log( "Created relationship: %1$s", relationship );
 		}
 	}
@@ -428,7 +392,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 	}
 
 	private void removeAssociationOperation(Association association, AssociationKey associationKey, AssociationOperation action, AssociatedEntityKeyMetadata associatedEntityKeyMetadata) {
-		associationQueries.get( associationKey.getMetadata() ).removeAssociationRow( dataBase, associationKey, action.getKey() );
+		getAssociationQueries( associationKey.getMetadata() ).removeAssociationRow( dataBase, associationKey, action.getKey() );
 	}
 
 	private void applyTupleOperations(EntityKey entityKey, Tuple tuple, Node node, Set<TupleOperation> operations, TupleContext tupleContext) {
@@ -519,7 +483,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			putOneToOneAssociation( tuple, node, operation, tupleContext, processedAssociationRoles );
 		}
 		else if ( isPartOfRegularEmbedded( entityKey.getMetadata().getColumnNames(), operation.getColumn() ) ) {
-			entityQueries.get( entityKey.getMetadata() ).updateEmbeddedColumn( dataBase, entityKey.getColumnValues(), operation.getColumn(), operation.getValue() );
+			getEntityQueries( entityKey.getMetadata(), tupleContext ).updateEmbeddedColumn( dataBase, entityKey.getColumnValues(), operation.getColumn(), operation.getValue() );
 		}
 		else {
 			putProperty( entityKey, node, operation );
@@ -557,14 +521,14 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect {
 			}
 
 			// create a new relationship
-			Node targetNode = entityQueries.get( targetKey.getMetadata() ).findEntity( dataBase, targetKey.getColumnValues() );
+			Node targetNode = getEntityQueries( targetKey.getMetadata(), tupleContext ).findEntity( dataBase, targetKey.getColumnValues() );
 			node.createRelationshipTo( targetNode, withName( associationRole ) );
 		}
 	}
 
 	@Override
 	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
-		ResourceIterator<Node> queryNodes = entityQueries.get( entityKeyMetadata ).findEntities( dataBase );
+		ResourceIterator<Node> queryNodes = getEntityQueries( entityKeyMetadata, tupleTypeContext ).findEntities( dataBase );
 		consumer.consume( new EmbeddedNeo4jTuplesSupplier( queryNodes, tupleTypeContext, entityKeyMetadata ) );
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/DiscriminatorAwareKeyMetadata.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/DiscriminatorAwareKeyMetadata.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.dialect.impl;
+
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+
+/**
+ * An {@link EntityKeyMetadata} that keeps track of the discriminator value.
+ * <p>
+ * Entities in a hierarchy using single table inheritance strategy have the same {@link EntityKeyMetadata}, to make sure
+ * that the metadata key is unique for each entity type we also keep track of the discriminator value.
+ *
+ * @author Davide D'Alto
+ */
+public class DiscriminatorAwareKeyMetadata implements EntityKeyMetadata {
+
+	private final EntityKeyMetadata delegate;
+	private final Object discriminatorValue;
+
+	public DiscriminatorAwareKeyMetadata(EntityKeyMetadata delegate, Object discriminatorValue) {
+		this.delegate = delegate;
+		this.discriminatorValue = discriminatorValue;
+	}
+
+	public String getTable() {
+		return delegate.getTable();
+	}
+
+	public String[] getColumnNames() {
+		return delegate.getColumnNames();
+	}
+
+	public boolean isKeyColumn(String columnName) {
+		return delegate.isKeyColumn( columnName );
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( delegate == null ) ? 0 : delegate.hashCode() );
+		result = prime * result + ( ( discriminatorValue == null ) ? 0 : discriminatorValue.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		DiscriminatorAwareKeyMetadata other = (DiscriminatorAwareKeyMetadata) obj;
+		if ( delegate == null ) {
+			if ( other.delegate != null ) {
+				return false;
+			}
+		}
+		else if ( !delegate.equals( other.delegate ) ) {
+			return false;
+		}
+		if ( discriminatorValue == null ) {
+			if ( other.discriminatorValue != null ) {
+				return false;
+			}
+		}
+		else if ( !discriminatorValue.equals( other.discriminatorValue ) ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/Neo4jJpaTestCase.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/Neo4jJpaTestCase.java
@@ -11,6 +11,8 @@ import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.assertT
 
 import java.util.Map;
 
+import javax.persistence.EntityManager;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
 import org.hibernate.ogm.datastore.neo4j.test.dsl.RelationshipsChainForGraphAssertions;
@@ -95,5 +97,11 @@ public abstract class Neo4jJpaTestCase extends OgmJpaTestCase {
 			expectedNumberOfRelationships += relationship.getSize();
 		}
 		assertNumberOfRelationships( expectedNumberOfRelationships );
+	}
+
+	protected void persist(EntityManager em, Object... entities) {
+		for ( Object entity : entities ) {
+			em.persist( entity );
+		}
 	}
 }

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleTableInheritancePersistTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/SingleTableInheritancePersistTest.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.mapping;
+
+import static org.hibernate.ogm.datastore.neo4j.dialect.impl.NodeLabel.ENTITY;
+import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
+import org.hibernate.ogm.datastore.neo4j.test.dsl.RelationshipsChainForGraphAssertions;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class SingleTableInheritancePersistTest extends Neo4jJpaTestCase {
+
+	private Man john;
+	private Woman jane;
+	private Child susan;
+	private Child mark;
+
+	@Before
+	public void prepareDB() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+
+		john = new Man();
+		jane = new Woman();
+		susan = new Child();
+		mark = new Child();
+
+		john.name = "John";
+		john.wife = jane;
+		john.children.add( mark );
+		john.children.add( susan );
+
+		jane.name = "Jane";
+		jane.husband = john;
+		jane.children.add( mark );
+		jane.children.add( susan );
+
+		susan.name = "Susan";
+		susan.mother = jane;
+		susan.father = john;
+
+		mark.name = "Mark";
+		mark.mother = jane;
+		mark.father = john;
+
+		persist( em, john, jane, mark, susan );
+		em.getTransaction().commit();
+		em.close();
+	}
+
+	@Test
+	public void testMapping() throws Exception {
+		NodeForGraphAssertions johnNode = node( "john", Person.TABLE_NAME, ENTITY.name() )
+				.property( "TYPE", "MAN" )
+				.property( "name", john.name );
+
+		NodeForGraphAssertions janeNode = node( "jane", Person.TABLE_NAME, ENTITY.name() )
+				.property( "TYPE", "WOMAN" )
+				.property( "name", jane.name );
+
+		NodeForGraphAssertions susanNode = node( "susan", Person.TABLE_NAME, ENTITY.name() )
+				.property( "TYPE", "CHILD" )
+				.property( "name", susan.name );
+
+		NodeForGraphAssertions markNode = node( "mark", Person.TABLE_NAME, ENTITY.name() )
+				.property( "TYPE", "CHILD" )
+				.property( "name", mark.name );
+
+		RelationshipsChainForGraphAssertions johnWife = johnNode.relationshipTo( janeNode, "wife" );
+
+		RelationshipsChainForGraphAssertions susanMother = susanNode.relationshipTo( janeNode, "mother" );
+		RelationshipsChainForGraphAssertions susanFather = susanNode.relationshipTo( johnNode, "father" );
+
+		RelationshipsChainForGraphAssertions markMother = markNode.relationshipTo( janeNode, "mother" );
+		RelationshipsChainForGraphAssertions markFather = markNode.relationshipTo( johnNode, "father" );
+
+		assertThatOnlyTheseNodesExist( johnNode, janeNode, markNode, susanNode );
+		assertThatOnlyTheseRelationshipsExist( susanMother, susanFather, markMother, markFather, johnWife );
+
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, Man.class, Woman.class, Child.class };
+	}
+
+	@Entity
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "TYPE", discriminatorType = DiscriminatorType.STRING)
+	@Table( name = Person.TABLE_NAME )
+	class Person {
+
+		public static final String TABLE_NAME = "Person";
+
+		@Id
+		String name;
+	}
+
+	@Entity
+	@DiscriminatorValue("MAN")
+	class Man extends Person {
+
+		@OneToOne
+		Woman wife;
+
+		@OneToMany(mappedBy = "father")
+		List<Child> children = new ArrayList<>();
+	}
+
+	@Entity
+	@DiscriminatorValue("WOMAN")
+	class Woman extends Person {
+
+		@OneToOne(mappedBy = "wife")
+		Man husband;
+
+		@OneToMany(mappedBy = "mother")
+		List<Child> children = new ArrayList<>();
+	}
+
+	@Entity
+	@DiscriminatorValue("CHILD")
+	class Child extends Person {
+
+		@OneToOne
+		Woman mother;
+
+		@OneToOne
+		Man father;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/TablePerClassInheritancePersistTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/TablePerClassInheritancePersistTest.java
@@ -1,0 +1,160 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.neo4j.test.mapping;
+
+import static org.hibernate.ogm.datastore.neo4j.dialect.impl.NodeLabel.ENTITY;
+import static org.hibernate.ogm.datastore.neo4j.test.dsl.GraphAssertions.node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.neo4j.test.dsl.NodeForGraphAssertions;
+import org.hibernate.ogm.datastore.neo4j.test.dsl.RelationshipsChainForGraphAssertions;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class TablePerClassInheritancePersistTest extends Neo4jJpaTestCase {
+
+	private Man john;
+	private Woman jane;
+	private Child susan;
+	private Child mark;
+
+	@Before
+	public void prepareDB() throws Exception {
+		EntityManager em = getFactory().createEntityManager();
+		em.getTransaction().begin();
+
+		john = new Man();
+		jane = new Woman();
+		susan = new Child();
+		mark = new Child();
+
+		john.name = "John";
+		john.wife = jane;
+		john.children.add( mark );
+		john.children.add( susan );
+
+		jane.name = "Jane";
+		jane.husband = john;
+		jane.children.add( mark );
+		jane.children.add( susan );
+
+		susan.name = "Susan";
+		susan.mother = jane;
+		susan.father = john;
+
+		mark.name = "Mark";
+		mark.mother = jane;
+		mark.father = john;
+
+		persist( em, john, jane, mark, susan );
+		em.getTransaction().commit();
+		em.close();
+	}
+
+	@Test
+	public void testMapping() throws Exception {
+		NodeForGraphAssertions johnNode = node( "john", Man.TABLE_NAME, ENTITY.name() )
+				.property( "name", john.name );
+
+		NodeForGraphAssertions janeNode = node( "jane", Woman.TABLE_NAME, ENTITY.name() )
+				.property( "name", jane.name );
+
+		NodeForGraphAssertions susanNode = node( "susan", Child.TABLE_NAME, ENTITY.name() )
+				.property( "name", susan.name );
+
+		NodeForGraphAssertions markNode = node( "mark", Child.TABLE_NAME, ENTITY.name() )
+				.property( "name", mark.name );
+
+		RelationshipsChainForGraphAssertions johnWife = johnNode.relationshipTo( janeNode, "wife" );
+
+		RelationshipsChainForGraphAssertions susanMother = susanNode.relationshipTo( janeNode, "mother" );
+		RelationshipsChainForGraphAssertions susanFather = susanNode.relationshipTo( johnNode, "father" );
+
+		RelationshipsChainForGraphAssertions markMother = markNode.relationshipTo( janeNode, "mother" );
+		RelationshipsChainForGraphAssertions markFather = markNode.relationshipTo( johnNode, "father" );
+
+		assertThatOnlyTheseNodesExist( johnNode, janeNode, markNode, susanNode );
+		assertThatOnlyTheseRelationshipsExist( susanMother, susanFather, markMother, markFather, johnWife );
+
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Person.class, Man.class, Woman.class, Child.class };
+	}
+
+	@Entity
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@DiscriminatorColumn(name = "TYPE", discriminatorType = DiscriminatorType.STRING)
+	@Table( name = Person.TABLE_NAME )
+	class Person {
+
+		public static final String TABLE_NAME = "Person";
+
+		@Id
+		String name;
+	}
+
+	@Entity
+	@DiscriminatorValue("MAN")
+	@Table( name = Man.TABLE_NAME )
+	class Man extends Person {
+
+		public static final String TABLE_NAME = "Man";
+
+		@OneToOne
+		Woman wife;
+
+		@OneToMany(mappedBy = "father")
+		List<Child> children = new ArrayList<>();
+	}
+
+	@Entity
+	@DiscriminatorValue("WOMAN")
+	@Table( name = Woman.TABLE_NAME )
+	class Woman extends Person {
+
+		public static final String TABLE_NAME = "Woman";
+
+		@OneToOne(mappedBy = "wife")
+		Man husband;
+
+		@OneToMany(mappedBy = "mother")
+		List<Child> children = new ArrayList<>();
+	}
+
+	@Entity
+	@DiscriminatorValue("CHILD")
+	@Table( name = Child.TABLE_NAME )
+	class Child extends Person {
+
+		public static final String TABLE_NAME = "Child";
+
+		@OneToOne
+		Woman mother;
+
+		@OneToOne
+		Man father;
+	}
+}

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToManyTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/mapping/UnidirectionalManyToManyTest.java
@@ -52,12 +52,6 @@ public class UnidirectionalManyToManyTest extends Neo4jJpaTestCase {
 		em.close();
 	}
 
-	private void persist(EntityManager em, Object... entities) {
-		for ( Object entity : entities ) {
-			em.persist( entity );
-		}
-	}
-
 	@Test
 	public void testMapping() throws Exception {
 		NodeForGraphAssertions johnNode = node( "john", Student.class.getSimpleName(), ENTITY.name() )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1221

  Remote dialects create queries at start-up and use the entity key metadata as key of
  a map to find the right set of queries for an entity.

  Problem is that when we deal with single table per class inheritance the entity key metadata is
  the same for all the entities in the hierarchy. This was causing an error, because the queries
  created for an entities were replaced with the queries generated for another one.

  The code has also been refactored because it was starting to get too complicated to copy and
  paste fixes around the 3 different dialects.

  Note that the problem occured only with remote dialects because the embedded one execute some
  operations with the programmatic API.

  This bug was found by the user Mariusz Florek