### PR TITLE
OGM-1238 Keep order of collections of elements in MongoDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRows.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/document/association/spi/AssociationRows.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.ogm.datastore.document.association.spi;
 
-import static org.hibernate.ogm.util.impl.CollectionHelper.newHashMap;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -17,6 +15,7 @@ import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.model.spi.AssociationSnapshot;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
+import org.hibernate.ogm.util.impl.CollectionHelper;
 
 /**
  * Represents the rows of an association in form of {@link AssociationRow}s.
@@ -28,7 +27,7 @@ public class AssociationRows implements AssociationSnapshot {
 	private final Map<RowKey, AssociationRow<?>> rows;
 
 	public AssociationRows(AssociationKey associationKey, Collection<?> wrapped, AssociationRowFactory associationRowFactory) {
-		this.rows = newHashMap( wrapped.size() );
+		this.rows = CollectionHelper.newHashMap( wrapped.size() );
 
 		for ( Object object : wrapped ) {
 			AssociationRow<?> row = associationRowFactory.createAssociationRow( associationKey, object );

--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDatastoreProvider.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDatastoreProvider.java
@@ -50,7 +50,7 @@ public final class MapDatastoreProvider extends BaseDatastoreProvider implements
 
 	private static final Log log = LoggerFactory.make();
 
-	private final ConcurrentMap<EntityKey,Map<String, Object>> entitiesKeyValueStorage = newConcurrentHashMap();
+	private final ConcurrentMap<EntityKey, Map<String, Object>> entitiesKeyValueStorage = newConcurrentHashMap();
 	private final ConcurrentMap<AssociationKey, Map<RowKey, Map<String, Object>>> associationsKeyValueStorage = newConcurrentHashMap();
 	private final ConcurrentMap<IdSourceKey, AtomicInteger> sequencesStorage = newConcurrentHashMap();
 	private final ConcurrentMap<Object, ReadWriteLock> dataLocks = newConcurrentHashMap();

--- a/core/src/main/java/org/hibernate/ogm/model/spi/Association.java
+++ b/core/src/main/java/org/hibernate/ogm/model/spi/Association.java
@@ -11,9 +11,8 @@ import static org.hibernate.ogm.model.spi.AssociationOperationType.REMOVE;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +20,7 @@ import java.util.Set;
 import org.hibernate.ogm.datastore.impl.EmptyAssociationSnapshot;
 import org.hibernate.ogm.dialect.spi.GridDialect;
 import org.hibernate.ogm.model.key.spi.RowKey;
+import org.hibernate.ogm.util.impl.CollectionHelper;
 import org.hibernate.ogm.util.impl.Contracts;
 import org.hibernate.ogm.util.impl.StringHelper;
 
@@ -42,7 +42,7 @@ import org.hibernate.ogm.util.impl.StringHelper;
  */
 public class Association {
 	private final AssociationSnapshot snapshot;
-	private final Map<RowKey, AssociationOperation> currentState = new HashMap<RowKey, AssociationOperation>();
+	private final Map<RowKey, AssociationOperation> currentState = new LinkedHashMap<RowKey, AssociationOperation>();
 	private boolean cleared;
 
 	/**
@@ -184,7 +184,7 @@ public class Association {
 		}
 		else {
 			// It may be a bit too large in case of removals, but that's fine for now
-			Set<RowKey> keys = new HashSet<RowKey>( cleared ? currentState.size() : snapshot.size() + currentState.size() );
+			Set<RowKey> keys = CollectionHelper.newLinkedHashSet( cleared ? currentState.size() : snapshot.size() + currentState.size() );
 
 			if ( !cleared ) {
 				// we add the snapshot RowKeys only if the association has not been cleared

--- a/core/src/main/java/org/hibernate/ogm/util/impl/CollectionHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/CollectionHelper.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +47,14 @@ public class CollectionHelper {
 			Collections.addAll( set, ts );
 			return Collections.unmodifiableSet( set );
 		}
+	}
+
+	public static <T> LinkedHashSet<T> newLinkedHashSet() {
+		return new LinkedHashSet<T>();
+	}
+
+	public static <T> LinkedHashSet<T> newLinkedHashSet(int initialCapacity) {
+		return new LinkedHashSet<T>( initialCapacity );
 	}
 
 	public static <K, V> HashMap<K, V> newHashMap() {

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/embeddable/ElementCollectionOrderWithJpaTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/embeddable/ElementCollectionOrderWithJpaTest.java
@@ -1,0 +1,167 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.embeddable;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "OGM-1238")
+public class ElementCollectionOrderWithJpaTest extends OgmJpaTestCase {
+
+	private static final String ENTITY_ID = "Entity";
+	private static final String[] EVENTS = {
+			"event 5",
+			"event 3",
+			"event 1",
+			"event 2",
+			"event 4",
+			"event 14",
+			"event x"
+	};
+
+	@Before
+	public void before() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = new PlainEntity();
+			entity.id = ENTITY_ID;
+			for ( Object event : EVENTS ) {
+				entity.events.add( (String) event );
+			}
+			em.persist( entity );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@After
+	public void after() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = em.find( PlainEntity.class, ENTITY_ID );
+			if ( entity != null ) {
+				em.remove( entity );
+			}
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testOrderWithFind() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = em.find( PlainEntity.class, ENTITY_ID );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testOrderWithGetReference() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = em.getReference( PlainEntity.class, ENTITY_ID );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testOrderWithQueryAndUniqueResult() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = (PlainEntity) em.createQuery( "from " + PlainEntity.class.getName() )
+					.getSingleResult();
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	public void testOrderWithQueryAndList() {
+		EntityManager em = getFactory().createEntityManager();
+		try {
+			em.getTransaction().begin();
+			PlainEntity entity = (PlainEntity) em.createQuery( "from " + PlainEntity.class.getName() )
+					.getResultList().get( 0 );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			em.getTransaction().commit();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	private void assertThatCollectionIsCorrect(List<String> actual, String[] expected) {
+		int i = 0;
+		for ( String entry : actual ) {
+			assertThat( entry ).isEqualTo( expected[i++] );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ PlainEntity.class };
+	}
+
+	@Entity
+	@Table(name = "PlainEntity")
+	static class PlainEntity {
+
+		@Id
+		String id;
+
+		@ElementCollection
+		@CollectionTable(name = "events")
+		List<String> events = new ArrayList<>();
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/embeddable/ElementCollectionOrderWithSessionTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/embeddable/ElementCollectionOrderWithSessionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.embeddable;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "OGM-1238")
+public class ElementCollectionOrderWithSessionTest extends OgmTestCase {
+
+	private static final String ENTITY_ID = "Entity";
+	private static final String[] EVENTS = {
+			"event 5",
+			"event 3",
+			"event 1",
+			"event 2",
+			"event 4",
+			"event 14",
+			"event x"
+	};
+
+	@Before
+	public void before() {
+		try ( OgmSession session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			PlainEntity entity = new PlainEntity();
+			entity.id = ENTITY_ID;
+			for ( Object event : EVENTS ) {
+				entity.events.add( (String) event );
+			}
+			session.persist( entity );
+			tx.commit();
+		}
+	}
+
+	@After
+	public void after() {
+		try ( OgmSession session = openSession() ) {
+			session.beginTransaction();
+			session.delete( session.get( PlainEntity.class, ENTITY_ID ) );
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	public void testOrderWithGet() {
+		try ( OgmSession session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			PlainEntity entity = session.get( PlainEntity.class, ENTITY_ID );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testOrderWithLoad() {
+		try ( OgmSession session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			PlainEntity entity = session.load( PlainEntity.class, ENTITY_ID );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testOrderWithQueryAndUniqueResult() {
+		try ( OgmSession session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			PlainEntity entity = (PlainEntity) session.createQuery( "from " + PlainEntity.class.getName() ).uniqueResult();
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testOrderWithQueryAndList() {
+		try ( OgmSession session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			PlainEntity entity = (PlainEntity) session.createQuery( "from " + PlainEntity.class.getName() ).list().get( 0 );
+
+			assertThat( entity ).isNotNull();
+			assertThatCollectionIsCorrect( entity.events, EVENTS );
+			tx.commit();
+		}
+	}
+
+	private void assertThatCollectionIsCorrect(List<String> actual, String[] expected) {
+		int i = 0;
+		for ( String entry : actual ) {
+			assertThat( entry ).isEqualTo( expected[i++] );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ PlainEntity.class };
+	}
+
+	@Entity
+	@Table(name = "PlainEntity")
+	static class PlainEntity {
+
+		@Id
+		String id;
+
+		@ElementCollection
+		@CollectionTable(name = "events")
+		List<String> events = new ArrayList<>();
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1238

The mongodb driver returns collection of elements in the same order they appear in the DB, we should do the same.