### PR TITLE
OGM-1240, OGM-1241 MongoDB authentication fails

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -57,7 +57,7 @@
         <ehcacheVersion>2.6.11</ehcacheVersion>
 
         <!-- MongoDB -->
-        <mongodbDriverVersion>3.4.1</mongodbDriverVersion>
+        <mongodbDriverVersion>3.4.2</mongodbDriverVersion>
         <mongodbVersion>3.4.1</mongodbVersion>
         <fongodbVersion>2.0.7</fongodbVersion>
 

--- a/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/en-US/modules/mongodb.asciidoc
@@ -100,6 +100,9 @@ Define the authentication mechanism to use. Possible values are:
 * `GSSAPI`: The GSSAPI mechanism. See the http://tools.ietf.org/html/rfc4752[RFC]
 * `MONGODB_X509`: The MongoDB X.509
 * `PLAIN`: The PLAIN mechanism.  See the http://www.ietf.org/rfc/rfc4616.txt[RFC]
+hibernate.ogm.mongodb.authentication_database::
+Defines the name of the authentication database.
+The property default value is `admin`.
 hibernate.ogm.datastore.document.association_storage::
 Defines the way OGM stores association information in MongoDB.
 The following two strategies exist (values of the `org.hibernate.ogm.datastore.document.options.AssociationStorageType` enum):

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBProperties.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBProperties.java
@@ -74,6 +74,11 @@ public final class MongoDBProperties implements DocumentStoreProperties {
 	public static final String AUTHENTICATION_MECHANISM = "hibernate.ogm.mongodb.authentication_mechanism";
 
 	/**
+	 * Specify the authentication database to use to check the credentials.
+	 */
+	public static final String AUTHENTICATION_DATABASE = "hibernate.ogm.mongodb.authentication_database";
+
+	/**
 	 * Property prefix for MongoDB driver settings which needs to be passed on to the driver. Refer to
 	 * the options of {@link com.mongodb.MongoClientOptions.Builder} for a list of available properties.
 	 * All string, int and boolean builder methods can be configured, eg {@code hibernate.ogm.mongodb.driver.maxWaitTime = 1000}.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1240
https://hibernate.atlassian.net/browse/OGM-1241

MongoDB uses an authentication database to verify the credentials, this might differ fomr the database we want to connect. I've added a new property with default value to admin.

THe only problem that I have with this issue is that it is complicated to test with a job.
I've created [OGM-1242](https://hibernate.atlassian.net/browse/OGM-1242) to keep track of it.

I've also upgraded the driver in the process.