### PR TITLE
OGM-1271 Upgrade to Infinispan 8.2.6.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -50,7 +50,7 @@
         <asmVersion>5.0.3</asmVersion> <!-- used for Parboiled and Neo4j -->
 
         <!-- Infinispan -->
-        <infinispanVersion>8.2.5.Final</infinispanVersion>
+        <infinispanVersion>8.2.6.Final</infinispanVersion>
         <protostreamVersion>3.0.7.Final</protostreamVersion>
 
         <!-- Ehcache -->


### PR DESCRIPTION
Should be trivial, but you might have problems with Nexus.

If the `infinispan-remote` testsuite fails and you see any problem like:
 - https://paste.fedoraproject.org/paste/qpJ8NXACXhbnWMNKvKHquV5M1UNdIGYhyRLivL9gydE=/raw

that means you got a corrupted download from Nexus; delete `~/.m2/repository/org/infinispan/server/infinispan-server-build/8.2.6.Final/` and try again...

https://hibernate.atlassian.net/browse/OGM-1271