### PR TITLE
OGM-1288 Constrain the edge direction when querying associations

### DIFF
--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BoltNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/BoltNeo4jDialect.java
@@ -421,7 +421,7 @@ public class BoltNeo4jDialect extends BaseNeo4jDialect<BoltNeo4jEntityQueries, B
 
 		Transaction tx = transaction( associationContext );
 		ClosableIterator<RemoteNeo4jAssociationPropertiesRow> relationships = getEntityQueries( entityKey.getMetadata(), associationContext )
-				.findAssociation( tx, entityKey.getColumnValues(), relationshipType );
+				.findAssociation( tx, entityKey.getColumnValues(), relationshipType, associationKey.getMetadata() );
 		while ( relationships.hasNext() ) {
 			RemoteNeo4jAssociationPropertiesRow row = relationships.next();
 			AssociatedEntityKeyMetadata associatedEntityKeyMetadata = associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata();

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -302,7 +302,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect<EmbeddedNeo4jEntityQu
 	private Map<RowKey, Tuple> createAssociationMap(AssociationKey associationKey, AssociationContext associationContext, EntityKey entityKey) {
 		String relationshipType = associationContext.getAssociationTypeContext().getRoleOnMainSide();
 		ResourceIterator<Relationship> relationships = getEntityQueries( entityKey.getMetadata(), associationContext )
-				.findAssociation( dataBase, entityKey.getColumnValues(), relationshipType );
+				.findAssociation( dataBase, entityKey.getColumnValues(), relationshipType, associationKey.getMetadata() );
 
 		Map<RowKey, Tuple> tuples = new HashMap<RowKey, Tuple>();
 		try {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/HttpNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/HttpNeo4jDialect.java
@@ -332,7 +332,7 @@ public class HttpNeo4jDialect extends BaseNeo4jDialect<HttpNeo4jEntityQueries, H
 
 		Long txId = transactionId( transactionContext );
 		ClosableIterator<RemoteNeo4jAssociationPropertiesRow> relationships = getEntityQueries( entityKey.getMetadata(), associationContext )
-				.findAssociation( client, txId, entityKey.getColumnValues(), relationshipType );
+				.findAssociation( client, txId, entityKey.getColumnValues(), relationshipType, associationKey.getMetadata() );
 		while ( relationships.hasNext() ) {
 			RemoteNeo4jAssociationPropertiesRow row = relationships.next();
 			AssociatedEntityKeyMetadata associatedEntityKeyMetadata = associationContext.getAssociationTypeContext().getAssociatedEntityKeyMetadata();

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jEntityQueries.java
@@ -384,8 +384,12 @@ public abstract class BaseNeo4jEntityQueries extends BaseNeo4jQueries {
 			queryBuilder.append( associationKeyMetadata.isInverse() ? " <-[r:" : " -[r:" );
 			appendRelationshipType( queryBuilder, relationshipType );
 			queryBuilder.append( associationKeyMetadata.isInverse() ? "]- " : "]-> " );
-			appendEntityNode("target", associationKeyMetadata.getAssociatedEntityKeyMetadata().getEntityKeyMetadata(),
-					queryBuilder, 0, false);
+			if (associationKeyMetadata.getAssociationKind() == AssociationKind.ASSOCIATION) {
+				appendEntityNode("target", associationKeyMetadata.getAssociatedEntityKeyMetadata().getEntityKeyMetadata(),
+						queryBuilder, 0, false);
+			} else {
+				queryBuilder.append("(target)");
+			}
 			queryBuilder.append(' ');
 		}
 		return queryBuilder;

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/BaseNeo4jQueries.java
@@ -79,13 +79,19 @@ class BaseNeo4jQueries {
 	}
 
 	protected static void appendEntityNode(String alias, EntityKeyMetadata entityKeyMetadata, StringBuilder queryBuilder, int offset) {
+		appendEntityNode(alias, entityKeyMetadata, queryBuilder, offset, true);
+	}
+
+	protected static void appendEntityNode(String alias, EntityKeyMetadata entityKeyMetadata, StringBuilder queryBuilder, int offset, boolean addProperties) {
 		queryBuilder.append( "(" );
 		queryBuilder.append( alias );
 		queryBuilder.append( ":" );
 		queryBuilder.append( ENTITY );
 		queryBuilder.append( ":" );
 		appendLabel( entityKeyMetadata, queryBuilder );
-		appendProperties( queryBuilder, entityKeyMetadata.getColumnNames(), offset );
+		if (addProperties) {
+			appendProperties( queryBuilder, entityKeyMetadata.getColumnNames(), offset );
+		}
 		queryBuilder.append( ")" );
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.ogm.datastore.neo4j.dialect.impl.BaseNeo4jEntityQueries;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.util.impl.ArrayHelper;
@@ -48,8 +49,8 @@ public class EmbeddedNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 	// We should move this in EmbeddedNeo4jAssociationQueries but, at the moment, having a query that only requires an
 	// EntityKeyMetadata make it easier
 	// to deal with the *ToOne scenario
-	public ResourceIterator<Relationship> findAssociation(GraphDatabaseService executionEngine, Object[] columnValues, String role) {
-		String query = getFindAssociationQuery( role );
+	public ResourceIterator<Relationship> findAssociation(GraphDatabaseService executionEngine, Object[] columnValues, String role, AssociationKeyMetadata associationKeyMetadata) {
+		String query = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
 		Map<String, Object> params = params( columnValues );
 		executionEngine.execute( query, params );
 		return executionEngine.execute( query, params( columnValues ) ).columnAs( "r" );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/dialect/impl/EmbeddedNeo4jEntityQueries.java
@@ -50,7 +50,7 @@ public class EmbeddedNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 	// EntityKeyMetadata make it easier
 	// to deal with the *ToOne scenario
 	public ResourceIterator<Relationship> findAssociation(GraphDatabaseService executionEngine, Object[] columnValues, String role, AssociationKeyMetadata associationKeyMetadata) {
-		String query = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
+		String query = getFindAssociationQuery( role, associationKeyMetadata );
 		Map<String, Object> params = params( columnValues );
 		executionEngine.execute( query, params );
 		return executionEngine.execute( query, params( columnValues ) ).columnAs( "r" );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jEntityQueries.java
@@ -20,6 +20,7 @@ import org.hibernate.ogm.datastore.neo4j.remote.common.dialect.impl.RemoteNeo4jA
 import org.hibernate.ogm.datastore.neo4j.remote.common.util.impl.RemoteNeo4jHelper;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.util.impl.ArrayHelper;
@@ -248,12 +249,12 @@ public class BoltNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 		transaction.run( getRemoveEntityQuery(), params( columnValues ) );
 	}
 
-	public ClosableIterator<RemoteNeo4jAssociationPropertiesRow> findAssociation(Transaction tx, Object[] columnValues, String role) {
+	public ClosableIterator<RemoteNeo4jAssociationPropertiesRow> findAssociation(Transaction tx, Object[] columnValues, String role, AssociationKeyMetadata associationKeyMetadata) {
 		// Find the target node
-		String queryForAssociation = getFindAssociationQuery( role );
+		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
 
 		// Find the embedded properties of the target node
-		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role );
+		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata.isInverse() );
 
 		// Execute the queries
 		Map<String, Object> params = params( columnValues );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jEntityQueries.java
@@ -251,10 +251,10 @@ public class BoltNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 
 	public ClosableIterator<RemoteNeo4jAssociationPropertiesRow> findAssociation(Transaction tx, Object[] columnValues, String role, AssociationKeyMetadata associationKeyMetadata) {
 		// Find the target node
-		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
+		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata );
 
 		// Find the embedded properties of the target node
-		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata.isInverse() );
+		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata );
 
 		// Execute the queries
 		Map<String, Object> params = params( columnValues );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jEntityQueries.java
@@ -369,10 +369,10 @@ public class HttpNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 	public ClosableIterator<RemoteNeo4jAssociationPropertiesRow> findAssociation(HttpNeo4jClient executionEngine, Long txId, Object[] columnValues,
 			  String role, AssociationKeyMetadata associationKeyMetadata) {
 		// Find the target node
-		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
+		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata );
 
 		// Find the embedded properties of the target node
-		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata.isInverse() );
+		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata );
 
 		// Execute the queries
 		Map<String, Object> params = params( columnValues );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jEntityQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jEntityQueries.java
@@ -34,6 +34,7 @@ import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.Statements;
 import org.hibernate.ogm.datastore.neo4j.remote.http.json.impl.StatementsResponse;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.util.impl.ArrayHelper;
@@ -366,12 +367,12 @@ public class HttpNeo4jEntityQueries extends BaseNeo4jEntityQueries {
 
 	@SuppressWarnings("unchecked")
 	public ClosableIterator<RemoteNeo4jAssociationPropertiesRow> findAssociation(HttpNeo4jClient executionEngine, Long txId, Object[] columnValues,
-			String role) {
+			  String role, AssociationKeyMetadata associationKeyMetadata) {
 		// Find the target node
-		String queryForAssociation = getFindAssociationQuery( role );
+		String queryForAssociation = getFindAssociationQuery( role, associationKeyMetadata.isInverse() );
 
 		// Find the embedded properties of the target node
-		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role );
+		String queryForEmbedded = getFindAssociationTargetEmbeddedValues( role, associationKeyMetadata.isInverse() );
 
 		// Execute the queries
 		Map<String, Object> params = params( columnValues );


### PR DESCRIPTION
Modifying BaseNeo4jEntityQueries.findAssociationPartialQuery to include
the edge direction between parent and owner.