### PR TITLE
OGM-1285 Infinispan Grouping

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
+++ b/core/src/main/java/org/hibernate/ogm/persister/impl/OgmEntityPersister.java
@@ -73,6 +73,7 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
 import org.hibernate.ogm.options.spi.OptionsService;
 import org.hibernate.ogm.options.spi.OptionsService.OptionsServiceContext;
 import org.hibernate.ogm.type.spi.GridType;
@@ -1220,6 +1221,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 				TuplePointer tuplePointer = getSharedTuplePointer( key, object, session );
 				Tuple resultset = tuplePointer.getTuple();
 				resultset = createNewResultSetIfNull( key, resultset, id, session );
+				resultset.setSnapshotType( SnapshotType.UPDATE );
 				saveSharedTuple( object, resultset, session );
 
 				if ( mightManageInverseAssociations ) {
@@ -1448,6 +1450,7 @@ public abstract class OgmEntityPersister extends AbstractEntityPersister impleme
 			}
 
 			resultset = createNewResultSetIfNull( key, resultset, id, session );
+			resultset.setSnapshotType( SnapshotType.INSERT );
 			TuplePointer tuplePointer = saveSharedTuple( object, resultset, session );
 
 			// add the discriminator

--- a/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationsForElementCollectionTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationsForElementCollectionTest.java
@@ -32,9 +32,9 @@ import org.junit.Test;
  * @author Emmanuel Bernard emmanuel@hibernate.org
  * @author Guillaume Smet
  */
-@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.INFINISPAN_REMOTE },
+@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED },
 		comment = "For Neo4j, the getAssociation always return an association, thus we don't have the createAssociation call. " +
-				"Redis Hash is just weird. Infinispan Remote needs to be investigated.")
+				"Redis Hash is just weird.")
 @TestForIssue(jiraKey = "OGM-1152")
 public class GridDialectOperationInvocationsForElementCollectionTest extends AbstractGridDialectOperationInvocationsTest {
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationsForOneToOneTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/dialectinvocations/GridDialectOperationInvocationsForOneToOneTest.java
@@ -25,9 +25,9 @@ import org.junit.Test;
  * @author Emmanuel Bernard emmanuel@hibernate.org
  * @author Guillaume Smet
  */
-@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED, GridDialectType.INFINISPAN_REMOTE  },
+@SkipByGridDialect(value = { GridDialectType.NEO4J_REMOTE, GridDialectType.NEO4J_EMBEDDED },
 		comment = "For Cassandra and Neo4j, the getAssociation always return an association, thus we don't have the createAssociation call. " +
-					"Redis Hash is just weird. Infinispan Remote needs to be investigated.")
+					"Redis Hash is just weird.")
 @TestForIssue(jiraKey = "OGM-1152")
 public class GridDialectOperationInvocationsForOneToOneTest extends AbstractGridDialectOperationInvocationsTest {
 

--- a/infinispan-remote/infinispan-server-testconfig/wildfly-trimmed-config.xml
+++ b/infinispan-remote/infinispan-server-testconfig/wildfly-trimmed-config.xml
@@ -238,6 +238,9 @@
         <local-cache name="FORUM_USER" />
         <local-cache name="ForumUser_issues" />
 
+        <local-cache name="DisneyGrandMother" />
+        <local-cache name="DisneyGrandMother_grandChildren" />
+
         <local-cache name="sequences" />
         <local-cache name="hibernate_sequences" />
             </cache-container>

--- a/infinispan-remote/infinispan-server-testconfig/wildfly-trimmed-config.xml
+++ b/infinispan-remote/infinispan-server-testconfig/wildfly-trimmed-config.xml
@@ -222,6 +222,7 @@
         <local-cache name="Race_Runners" />
         <local-cache name="Runner" />
         <local-cache name="Printer" />
+        <local-cache name="StockItem" />
 
         <local-cache name="INITIAL_VALUE_GENERATOR_TABLE" />
         <local-cache name="THREAD_SAFETY_GENERATOR_TABLE" />

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
@@ -167,7 +167,7 @@ public class InfinispanRemoteDialect<EK,AK,ISK> extends AbstractGroupingByEntity
 
 		private final EntityKey ownerEntityKey;
 
-		// A representation/ of the entity that we want to create or insert
+		// A representation of the entity that we want to create or insert
 		private Map<String, Object> owningEntity;
 
 		// If the entity already exists in the datastore or not
@@ -255,20 +255,20 @@ public class InfinispanRemoteDialect<EK,AK,ISK> extends AbstractGroupingByEntity
 		}
 
 		public void removeAssociation(RemoveAssociationOperation removeAssociationOperation) {
-				AssociationKey associationKey = removeAssociationOperation.getAssociationKey();
-				AssociationContext associationContext = removeAssociationOperation.getContext();
-				// N.B. 'key' might match multiple entries
-				if ( associationStoredWithinEntityEntry( associationKey, associationContext ) ) {
-					// The entity contains the association
-					if ( owningEntity == null ) {
-						TuplePointer entityTuplePointer = getEmbeddingEntityTuplePointer( provider, associationKey, associationContext );
-						applyOperations( entityTuplePointer.getTuple() );
-					}
+			AssociationKey associationKey = removeAssociationOperation.getAssociationKey();
+			AssociationContext associationContext = removeAssociationOperation.getContext();
+			// N.B. 'key' might match multiple entries
+			if ( associationStoredWithinEntityEntry( associationKey, associationContext ) ) {
+				// The entity contains the association
+				if ( owningEntity == null ) {
+					TuplePointer entityTuplePointer = getEmbeddingEntityTuplePointer( provider, associationKey, associationContext );
+					applyOperations( entityTuplePointer.getTuple() );
 				}
-				else {
-					// The association is mapped with a bridge "table"
-					associationsToRemove.add( associationKey );
-				}
+			}
+			else {
+				// The association is mapped with a bridge "table"
+				associationsToRemove.add( associationKey );
+			}
 		}
 
 		/**

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/DisneyGrandChild.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/DisneyGrandChild.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+
+import javax.persistence.Embeddable;
+
+/**
+ * @author Davide D'Alto
+ */
+@Embeddable
+public class DisneyGrandChild {
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/DisneyGrandMother.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/DisneyGrandMother.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OrderColumn;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+public class DisneyGrandMother {
+
+	private String id;
+	private List<DisneyGrandChild> grandChildren = new ArrayList<DisneyGrandChild>();
+
+	public DisneyGrandMother() {
+	}
+
+	public DisneyGrandMother(String id) {
+		this.id = id;
+	}
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@ElementCollection
+	@OrderColumn(name = "birthorder")
+	public List<DisneyGrandChild> getGrandChildren() {
+		return grandChildren;
+	}
+
+	public void setGrandChildren(List<DisneyGrandChild> children) {
+		this.grandChildren = children;
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemotePerformanceTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/InfinispanRemotePerformanceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.initialize;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
+import org.hibernate.ogm.utils.BytemanHelper;
+import org.hibernate.ogm.utils.BytemanHelperStateCleanup;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(InfinispanRemoteServerRunner.class)
+public class InfinispanRemotePerformanceTest extends OgmTestCase {
+
+	@Rule
+	public BytemanHelperStateCleanup bytemanState = new BytemanHelperStateCleanup();
+
+	@Test
+	@BMRules(rules = {
+			@BMRule(targetClass = "org.infinispan.commons.api.BasicCache",
+					isInterface = true,
+					targetMethod = "put(Object, Object)",
+					helper = "org.hibernate.ogm.utils.BytemanHelper",
+					action = "countInvocation(\"put\")",
+					name = "update"),
+			@BMRule(targetClass = "org.infinispan.commons.api.BasicCache",
+					isInterface = true,
+					targetMethod = "putIfAbsent(Object, Object)",
+					helper = "org.hibernate.ogm.utils.BytemanHelper",
+					action = "countInvocation(\"putIfAbsent\")",
+					name = "insert"),
+			@BMRule(targetClass = "org.infinispan.client.hotrod.impl.RemoteCacheImpl",
+					isInterface = false,
+					targetMethod = "remove(Object)",
+					helper = "org.hibernate.ogm.utils.BytemanHelper",
+					action = "countInvocation(\"remove\")",
+					name = "remove"),
+			@BMRule(targetClass = "org.infinispan.client.hotrod.impl.RemoteCacheImpl",
+					targetMethod = "getVersioned(Object)",
+					isInterface = false,
+					helper = "org.hibernate.ogm.utils.BytemanHelper",
+					action = "countInvocation(\"getVersioned\")",
+					name = "getVersioned")
+	})
+	public void testNumberOfCallsToDatastore() throws Exception {
+		DisneyGrandMother grandMother = new DisneyGrandMother( "Grandma Duck" );
+
+		// insert entity with embedded collection
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			DisneyGrandChild donald = new DisneyGrandChild();
+			donald.setName( "Donald Duck" );
+			DisneyGrandChild gus = new DisneyGrandChild();
+			gus.setName( "Gus Goose" );
+			grandMother.getGrandChildren().add( gus );
+			grandMother.getGrandChildren().add( donald );
+			session.persist( grandMother );
+			tx.commit();
+		}
+
+		// Load the entity
+		int getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getVersioned" );
+		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
+
+		// Insert the entity
+		int storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "putIfAbsent" );
+		assertThat( storeEntityInvocationCount ).isEqualTo( 1 );
+
+		// Insert embeddeds
+		int putInvocationCount = BytemanHelper.getAndResetInvocationCount( "put" );
+		assertThat( putInvocationCount ).isEqualTo( 2 );
+
+		// Nothing to remove so far
+		int removeInvocationCount = BytemanHelper.getAndResetInvocationCount( "remove" );
+		assertThat( removeInvocationCount ).isEqualTo( 0 );
+
+		// Remove one of the elements
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			grandMother = (DisneyGrandMother) session.get( DisneyGrandMother.class, grandMother.getId() );
+			grandMother.getGrandChildren().remove( 0 );
+			tx.commit();
+			session.clear();
+		}
+
+		// Load the entity
+		getEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "getVersioned" );
+		assertThat( getEntityInvocationCount ).isEqualTo( 1 );
+
+		// We are not adding anything new
+		storeEntityInvocationCount = BytemanHelper.getAndResetInvocationCount( "putIfAbsent" );
+		assertThat( storeEntityInvocationCount ).isEqualTo( 0 );
+
+		// Update the index of remaining element
+		putInvocationCount = BytemanHelper.getAndResetInvocationCount( "put" );
+		assertThat( putInvocationCount ).isEqualTo( 1 );
+
+		// Remove the element
+		removeInvocationCount = BytemanHelper.getAndResetInvocationCount( "remove" );
+		assertThat( removeInvocationCount ).isEqualTo( 1 );
+
+		// Assert removal has been propagated
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			grandMother = (DisneyGrandMother) session.get( DisneyGrandMother.class, grandMother.getId() );
+			assertThat( grandMother.getGrandChildren() ).onProperty( "name" ).containsExactly( "Donald Duck" );
+
+			session.delete( grandMother );
+			tx.commit();
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{
+				DisneyGrandMother.class,
+		};
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteServerRunner.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteServerRunner.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.utils;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.ogm.utils.OgmTestRunner;
+import org.junit.BeforeClass;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * Start the Infinispan Remote server before running anything else.
+ * <p>
+ * It extends {@link OgmTestRunner} and makes sure that the {@link SessionFactory} is created
+ * after the server is started. It means that you can access the factory in the {@link BeforeClass}
+ * methods if you need to.
+ *
+ * @author Davide D'Alto
+ */
+public class InfinispanRemoteServerRunner extends OgmTestRunner {
+
+	public static RemoteHotRodServerRule hotrodServer = new RemoteHotRodServerRule();
+
+	public InfinispanRemoteServerRunner(Class<?> klass) throws InitializationError {
+		super( klass );
+	}
+
+	@Override
+	public void run(RunNotifier notifier) {
+		try {
+			hotrodServer.before();
+			super.run( notifier );
+		}
+		catch (Exception e) {
+			throw new RuntimeException( e );
+		}
+		finally {
+			hotrodServer.after();
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <arquillianVersion>1.1.5.Final</arquillianVersion>
         <jmhVersion>1.0</jmhVersion>
         <jbossLoggingProcessorVersion>1.2.0.Final</jbossLoggingProcessorVersion>
-        <bytemanVersion>3.0.6</bytemanVersion>
+        <bytemanVersion>3.0.10</bytemanVersion>
 
         <!--
              Following is the default jgroups mcast address.  If you find the testsuite runs very slowly, there


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1285
https://hibernate.atlassian.net/browse/OGM-1291

~~This is my attempt to apply the grouping interface to infinispan, I couldn't figure out why but some operations are executed 3 times instead of 1. It seems that the queue contains more operations than needed.~~

I also removed the method `insertOrUpdateAssociationEmbeddedInEntity( key, association, associationContext );` in the `InfinispanRemoteDialect` and everything still passes all the tests.

I think it's a good time to have another pair of eyes on the code.  

