### PR TITLE
OGM-1246 Support for mapReduce native query added

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/map/impl/MapDialect.java
@@ -226,6 +226,11 @@ public class MapDialect extends BaseGridDialect implements MultigetGridDialect {
 		@Override
 		public void close() {
 		}
+
+		@Override
+		public void remove() {
+
+		}
 	}
 
 	private static Tuple createTuple(Map<EntityKey, Map<String, Object>> entityMap, EntityKey key) {

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -6,16 +6,13 @@
  */
 package org.hibernate.ogm.datastore.mongodb;
 
-import static java.lang.Boolean.FALSE;
-import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
-import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers.hasField;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -23,8 +20,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import org.bson.Document;
-import org.bson.types.ObjectId;
 import org.hibernate.AssertionFailure;
 import org.hibernate.ogm.datastore.document.association.impl.DocumentHelpers;
 import org.hibernate.ogm.datastore.document.cfg.DocumentStoreProperties;
@@ -106,10 +101,6 @@ import org.hibernate.type.MaterializedBlobType;
 import org.hibernate.type.SerializableToBlobType;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
-import org.parboiled.Parboiled;
-import org.parboiled.errors.ErrorUtils;
-import org.parboiled.parserunners.RecoveringParseRunner;
-import org.parboiled.support.ParsingResult;
 
 import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoBulkWriteException;
@@ -119,17 +110,34 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationAlternate;
+import com.mongodb.client.model.CollationCaseFirst;
+import com.mongodb.client.model.CollationMaxVariable;
+import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.parboiled.Parboiled;
+import org.parboiled.errors.ErrorUtils;
+import org.parboiled.parserunners.RecoveringParseRunner;
+import org.parboiled.support.ParsingResult;
+
+import static java.lang.Boolean.FALSE;
+import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
+import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers.hasField;
 
 /**
  * Each Tuple entry is stored as a property in a MongoDB document.
@@ -821,6 +829,8 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 				return doCount( queryDescriptor, collection );
 			case DISTINCT:
 				return doDistinct( queryDescriptor, collection );
+			case MAP_REDUCE:
+				return doMapReduce( queryDescriptor, collection );
 			case INSERT:
 			case REMOVE:
 			case UPDATE:
@@ -944,9 +954,10 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 	 */
 	private static ClosableIterator<Tuple> doDistinct(final MongoDBQueryDescriptor queryDescriptor, final MongoCollection<Document> collection) {
 		DistinctIterable<?> distinctFieldValues = collection.distinct( queryDescriptor.getDistinctFieldName(), queryDescriptor.getCriteria(), String.class );
-		if ( queryDescriptor.getCollation() != null ) {
-			distinctFieldValues = distinctFieldValues.collation( queryDescriptor.getCollation() );
-		}
+		Collation collation = getCollation( queryDescriptor.getOptions() );
+
+		distinctFieldValues = collation != null ? distinctFieldValues.collation( collation ) : distinctFieldValues;
+
 		MongoCursor<?> cursor = distinctFieldValues.iterator();
 		List<Object> documents = new ArrayList<>();
 		while ( cursor.hasNext() ) {
@@ -954,6 +965,104 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		}
 		MapTupleSnapshot snapshot = new MapTupleSnapshot( Collections.<String, Object>singletonMap( "n", documents ) );
 		return CollectionHelper.newClosableIterator( Collections.singletonList( new Tuple( snapshot, SnapshotType.UNKNOWN ) ) );
+	}
+
+	/**
+	 * do 'Map Reduce' operation
+	 * @param queryDescriptor descriptor of MongoDB map reduce query
+	 * @param collection collection on which operation will be performed
+	 * @return result iterator
+	 * @see <a href ="https://docs.mongodb.com/manual/reference/method/db.collection.mapReduce/">MapReduce</a>
+	 */
+	private static ClosableIterator<Tuple> doMapReduce(final MongoDBQueryDescriptor queryDescriptor, final MongoCollection<Document> collection) {
+
+		MapReduceIterable<Document> mapReduceIterable = collection.mapReduce( queryDescriptor.getMapFunction(), queryDescriptor.getReduceFunction() );
+		Document options = queryDescriptor.getOptions();
+		if ( options != null ) {
+			Document query = (Document) options.get( "query" );
+			Document sort = (Document) options.get( "sort" );
+			Integer limit = options.getInteger( "limit" );
+			String finalizeFunction = options.getString( "finalize" );
+			Document scope = (Document) options.get( "scope" );
+			Boolean jsMode = options.getBoolean( "jsMode" );
+			Boolean verbose = options.getBoolean( "verbose" );
+			Boolean bypassDocumentValidation = options.getBoolean( "bypassDocumentValidation" );
+			Collation collation = getCollation( (Document) options.get( "collation" ) );
+			MapReduceAction mapReduceAction = null;
+			String collectionName = null;
+			String dbName = null;
+			Boolean sharded = null;
+			Boolean nonAtomic = null;
+
+			Object out;
+			if ( ( out = options.get( "out" ) ) != null ) {
+				if ( out instanceof String ) {
+					collectionName = (String) out;
+				}
+				else if ( out instanceof Document ) {
+					Document outDocument = (Document) out;
+					if ( outDocument.containsKey( "merge" ) ) {
+						mapReduceAction = MapReduceAction.MERGE;
+						collectionName = outDocument.getString( "merge" );
+					}
+					else if ( outDocument.containsKey( "replace" ) ) {
+						mapReduceAction = MapReduceAction.REPLACE;
+						collectionName = outDocument.getString( "replace" );
+					}
+					else if ( ( (Document) out ).containsKey( "reduce" ) ) {
+						mapReduceAction = MapReduceAction.REDUCE;
+						collectionName = outDocument.getString( "reduce" );
+					}
+					dbName = outDocument.getString( "db" );
+					sharded = outDocument.getBoolean( "sharded" );
+					nonAtomic = outDocument.getBoolean( "nonAtomic" );
+				}
+			}
+			mapReduceIterable = ( query != null ) ? mapReduceIterable.filter( query ) : mapReduceIterable;
+			mapReduceIterable = ( sort != null ) ? mapReduceIterable.sort( sort ) : mapReduceIterable;
+			mapReduceIterable = ( limit != null ) ? mapReduceIterable.limit( limit ) : mapReduceIterable;
+			mapReduceIterable = ( finalizeFunction != null ) ? mapReduceIterable.finalizeFunction( finalizeFunction ) : mapReduceIterable;
+			mapReduceIterable = ( scope != null ) ? mapReduceIterable.scope( scope ) : mapReduceIterable;
+			mapReduceIterable = ( jsMode != null ) ? mapReduceIterable.jsMode( jsMode ) : mapReduceIterable;
+			mapReduceIterable = ( verbose != null ) ? mapReduceIterable.verbose( verbose ) : mapReduceIterable;
+			mapReduceIterable = ( bypassDocumentValidation != null ) ? mapReduceIterable.bypassDocumentValidation( bypassDocumentValidation ) : mapReduceIterable;
+			mapReduceIterable = ( collation != null ) ? mapReduceIterable.collation( collation ) : mapReduceIterable;
+			mapReduceIterable = ( mapReduceAction != null ) ? mapReduceIterable.action( mapReduceAction ) : mapReduceIterable;
+			mapReduceIterable = ( collectionName != null ) ? mapReduceIterable.collectionName( collectionName ) : mapReduceIterable;
+			mapReduceIterable = ( dbName != null ) ? mapReduceIterable.databaseName( dbName ) : mapReduceIterable;
+			mapReduceIterable = ( sharded != null ) ? mapReduceIterable.sharded( sharded ) : mapReduceIterable;
+			mapReduceIterable = ( nonAtomic != null ) ? mapReduceIterable.nonAtomic( nonAtomic ) : mapReduceIterable;
+		}
+
+		MongoCursor<Document> cursor = mapReduceIterable.iterator();
+		LinkedHashMap<Object, Object> documents = new LinkedHashMap<>();
+		while ( cursor.hasNext() ) {
+			Document doc = cursor.next();
+			documents.put( doc.get( "_id" ), doc.get( "value" ) );
+		}
+		MapTupleSnapshot snapshot = new MapTupleSnapshot( Collections.<String, Object>singletonMap( "n", documents ) );
+		return CollectionHelper.newClosableIterator( Collections.singletonList( new Tuple( snapshot, SnapshotType.UNKNOWN ) ) );
+	}
+
+	private static Collation getCollation(Document dbObject) {
+		Collation collation = null;
+		if ( dbObject != null ) {
+			String caseFirst = dbObject.getString( "caseFirst" );
+			Integer strength = dbObject.getInteger( "strength" );
+			String alternate = dbObject.getString( "alternate" );
+			String maxVariable = dbObject.getString( "maxVariable" );
+			collation =  Collation.builder()
+					.locale( (String) dbObject.get( "locale" ) )
+					.caseLevel( (Boolean) dbObject.get( "caseLevel" ) )
+					.numericOrdering( (Boolean) dbObject.get( "numericOrdering" ) )
+					.backwards( (Boolean) dbObject.get( "backwards" ) )
+					.collationCaseFirst( caseFirst == null ? null : CollationCaseFirst.fromString( caseFirst ) )
+					.collationStrength( strength == null ? null : CollationStrength.fromInt( strength ) )
+					.collationAlternate( alternate == null ? null : CollationAlternate.fromString( alternate ) )
+					.collationMaxVariable(  maxVariable == null ? null : CollationMaxVariable.fromString( maxVariable ) )
+					.build();
+		}
+		return collation;
 	}
 
 	private static ClosableIterator<Tuple> doFind(MongoDBQueryDescriptor query, QueryParameters queryParameters, MongoCollection<Document> collection,

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/impl/MongoDBQueryDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/impl/MongoDBQueryDescriptor.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.bson.Document;
-import com.mongodb.client.model.Collation;
 
 /**
  * Describes a query to be executed against MongoDB.
@@ -51,7 +50,8 @@ public class MongoDBQueryDescriptor implements Serializable {
 		 * This is used for native queries, when the user wants to execute a generic aggregation query.
 		 */
 		AGGREGATE_PIPELINE,
-		DISTINCT;
+		DISTINCT,
+		MAP_REDUCE;
 	}
 
 	private final String collectionName;
@@ -64,10 +64,8 @@ public class MongoDBQueryDescriptor implements Serializable {
 	 */
 	private final String distinctFieldName;
 
-	/**
-	 * Collation object will be used for Distinct Operation
-	 */
-	private final Collation collation; // As of now only applicable to distinct queries
+	private final String mapFunction;
+	private final String reduceFunction;
 
 	/**
 	 * The "update" (new values to apply) in case this is an UPDATE query or values to insert in case this is an INSERT query.
@@ -88,20 +86,6 @@ public class MongoDBQueryDescriptor implements Serializable {
 	private final List<String> unwinds;
 	private final List<Document> pipeline;
 
-	public MongoDBQueryDescriptor(String collectionName, Operation operation, Document criteria, Collation collation, String distinctFieldName) {
-		this.collectionName = collectionName;
-		this.operation = operation;
-		this.criteria = criteria;
-		this.projection = null;
-		this.orderBy = null;
-		this.options = null;
-		this.updateOrInsertOne = null;
-		this.updateOrInsertMany = null;
-		this.unwinds = null;
-		this.pipeline = Collections.<Document>emptyList();
-		this.distinctFieldName = distinctFieldName;
-		this.collation = collation;
-	}
 	public MongoDBQueryDescriptor(String collectionName, Operation operation, List<Document> pipeline) {
 		this.collectionName = collectionName;
 		this.operation = operation;
@@ -114,10 +98,11 @@ public class MongoDBQueryDescriptor implements Serializable {
 		this.unwinds = null;
 		this.pipeline = pipeline == null ? Collections.<Document>emptyList() : pipeline;
 		this.distinctFieldName = null;
-		this.collation = null;
+		this.mapFunction = null;
+		this.reduceFunction = null;
 	}
 
-	public MongoDBQueryDescriptor(String collectionName,Operation operation,Document criteria,	Document projection, Document orderBy,	Document options, Document updateOrInsertOne, List<Document> updateOrInsertMany, List<String> unwinds) {
+	public MongoDBQueryDescriptor(String collectionName, Operation operation, Document criteria, Document projection, Document orderBy, Document options, Document updateOrInsertOne, List<Document> updateOrInsertMany, List<String> unwinds, String distinctFieldName, String mapFunction, String reduceFunction) {
 		this.collectionName = collectionName;
 		this.operation = operation;
 		this.criteria = criteria;
@@ -128,8 +113,9 @@ public class MongoDBQueryDescriptor implements Serializable {
 		this.updateOrInsertMany = updateOrInsertMany;
 		this.unwinds = unwinds;
 		this.pipeline = Collections.<Document>emptyList();
-		this.distinctFieldName = null;
-		this.collation = null;
+		this.distinctFieldName = distinctFieldName;
+		this.mapFunction = mapFunction;
+		this.reduceFunction = reduceFunction;
 	}
 
 	public List<Document> getPipeline() {
@@ -207,11 +193,17 @@ public class MongoDBQueryDescriptor implements Serializable {
 	}
 
 	/**
-	 * Returns collation document which will be used in DISTINCT operation
-	 *
+	 * Returns map function in the MAP_REDUCE operation
 	 */
-	public Collation getCollation() {
-		return collation;
+	public String getMapFunction() {
+		return mapFunction;
+	}
+
+	/**
+	 * Returns reduce function in the MAP_REDUCE operation
+	 */
+	public String getReduceFunction() {
+		return reduceFunction;
 	}
 
 	@Override

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBQueryParsingResult.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBQueryParsingResult.java
@@ -30,6 +30,7 @@ public class MongoDBQueryParsingResult implements QueryParsingResult {
 	private final Document orderBy;
 	private final List<String> unwinds;
 
+
 	public MongoDBQueryParsingResult(Class<?> entityType, String collectionName, Document query, Document projection, Document orderBy, List<String> unwinds) {
 		this.entityType = entityType;
 		this.collectionName = collectionName;
@@ -70,7 +71,10 @@ public class MongoDBQueryParsingResult implements QueryParsingResult {
 			null,
 			null,
 			null,
-			unwinds
+			unwinds,
+			null,
+			null,
+			null
 		);
 	}
 

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
@@ -17,11 +17,6 @@ import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor.Operation;
 import org.hibernate.ogm.util.impl.StringHelper;
 
-import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.CollationAlternate;
-import com.mongodb.client.model.CollationCaseFirst;
-import com.mongodb.client.model.CollationMaxVariable;
-import com.mongodb.client.model.CollationStrength;
 import org.bson.Document;
 
 /**
@@ -47,10 +42,8 @@ public class MongoDBQueryDescriptorBuilder {
 	 */
 	private String distinctFieldName;
 
-	/**
-	 * Collation document
-	 */
-	private String collation;
+	private String mapFunction;
+	private String reduceFunction;
 
 	/**
 	 * Document or array of documents to insert/update for an INSERT/UPDATE query.
@@ -139,8 +132,13 @@ public class MongoDBQueryDescriptorBuilder {
 		return true;
 	}
 
-	public boolean setCollation(String collation) {
-		this.collation = collation;
+	public boolean setMapFunction(String mapFunction) {
+		this.mapFunction = mapFunction;
+		return true;
+	}
+
+	public boolean setReduceFunction(String reduceFunction) {
+		this.reduceFunction = reduceFunction;
 		return true;
 	}
 
@@ -148,10 +146,8 @@ public class MongoDBQueryDescriptorBuilder {
 		//@todo redactor the spagetti!
 		if ( operation != Operation.AGGREGATE_PIPELINE ) {
 			MongoDBQueryDescriptor descriptor = null;
-			if ( operation == Operation.DISTINCT ) {
-				descriptor = new MongoDBQueryDescriptor( collection, operation, parse( criteria ), parseCollation( collation ), distinctFieldName );
-			}
-			else if ( operation == Operation.INSERTMANY ) {
+
+			if ( operation == Operation.INSERTMANY ) {
 				// must be array
 				Object anyDocs = parseAsObject( updateOrInsert );
 				List<Document> documents = (List<Document>) parseAsObject( updateOrInsert );
@@ -164,6 +160,9 @@ public class MongoDBQueryDescriptorBuilder {
 						parse( options ),
 						null,
 						documents,
+						null,
+						null,
+						null,
 						null
 				);
 			}
@@ -181,6 +180,9 @@ public class MongoDBQueryDescriptorBuilder {
 							parse( options ),
 							null,
 							(List<Document>) anyDocs,
+							null,
+							null,
+							null,
 							null
 					);
 				}
@@ -194,6 +196,9 @@ public class MongoDBQueryDescriptorBuilder {
 							parse( orderBy ),
 							parse( options ),
 							(Document) anyDocs,
+							null,
+							null,
+							null,
 							null,
 							null
 					);
@@ -209,7 +214,10 @@ public class MongoDBQueryDescriptorBuilder {
 						parse( options ),
 						parse( updateOrInsert ),
 						null,
-						null
+						null,
+						distinctFieldName,
+						mapFunction,
+						reduceFunction
 				);
 			}
 			return descriptor;
@@ -243,50 +251,6 @@ public class MongoDBQueryDescriptorBuilder {
 		}
 		Document object = Document.parse( "{ 'json': " + json + "}" );
 		return object.get( "json" );
-	}
-
-	private static Collation parseCollation(String json) {
-		Document dbObject = ( (Document) parseAsObject( json ) );
-
-		if ( dbObject != null ) {
-			dbObject = (Document) dbObject.get( "collation" );
-			if ( dbObject != null ) {
-				Collation collation = Collation.builder()
-						.locale( (String) dbObject.get( "locale" ) )
-						.caseLevel( (Boolean) dbObject.get( "caseLevel" ) )
-						.numericOrdering( (Boolean) dbObject.get( "numericOrdering" ) )
-						.backwards( (Boolean) dbObject.get( "backwards" ) )
-						.collationCaseFirst( caseFirst( dbObject ) )
-						.collationStrength( strength( dbObject ) )
-						.collationAlternate( alternate( dbObject ) )
-						.collationMaxVariable( maxVariable( dbObject ) )
-						.build();
-
-				return collation;
-			}
-
-		}
-		return null;
-	}
-
-	private static CollationCaseFirst caseFirst(Document dbObject) {
-		String caseFirst = dbObject.getString( "caseFirst" );
-		return caseFirst == null ? null : CollationCaseFirst.fromString( caseFirst );
-	}
-
-	private static CollationStrength strength(Document dbObject) {
-		Integer strength = dbObject.getInteger( "strength" );
-		return strength == null ? null : CollationStrength.fromInt( strength );
-	}
-
-	private static CollationAlternate alternate(Document dbObject) {
-		String value = dbObject.getString( "alternate" );
-		return value == null ? null : CollationAlternate.fromString( value );
-	}
-
-	private static CollationMaxVariable maxVariable(Document dbObject) {
-		String value = dbObject.getString( "maxVariable" );
-		return value == null ? null : CollationMaxVariable.fromString( value );
 	}
 
 	private static Document operation(StackedOperation operation, String value) {

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/MongoDBQueryDescriptorSerializationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/MongoDBQueryDescriptorSerializationTest.java
@@ -40,7 +40,10 @@ public class MongoDBQueryDescriptorSerializationTest {
 				new Document(),
 				new Document(),
 				null,
-				Arrays.asList( "foo, bar" )
+				Arrays.asList( "foo, bar" ),
+				null,
+				null,
+				null
 		);
 
 		byte[] bytes = serialize( descriptor );

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionCLIQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionCLIQueryTest.java
@@ -6,22 +6,25 @@
  */
 package org.hibernate.ogm.datastore.mongodb.test.query.nativequery;
 
-import static org.fest.assertions.Assertions.assertThat;
-
+import java.util.LinkedHashMap;
 import java.util.List;
 
-import org.fest.assertions.Fail;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.ogm.utils.TestForIssue;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.mongodb.BasicDBList;
+import org.fest.assertions.Fail;
+import org.fest.assertions.MapAssert;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Test the execution of native queries on MongoDB using the {@link Session}
@@ -30,9 +33,10 @@ import com.mongodb.BasicDBList;
  */
 public class MongoDBSessionCLIQueryTest extends OgmTestCase {
 
-	private final OscarWildePoem portia = new OscarWildePoem( 1L, "Portia", "Oscar Wilde", 1881 );
-	private final OscarWildePoem athanasia = new OscarWildePoem( 2L, "Athanasia", "Oscar Wilde", 1879, "ebook" );
-	private final OscarWildePoem imperatrix = new OscarWildePoem( 3L, "Ave Imperatrix", "Oscar Wilde", 1882,"audible", "ebook", "paperback" );
+	private final OscarWildePoem portia = new OscarWildePoem( 1L, "Portia", "Oscar Wilde", 1881, 15 );
+	private final OscarWildePoem athanasia = new OscarWildePoem( 2L, "Athanasia", "Oscar Wilde", 1879, 37, (byte) 5, "ebook" );
+	private final OscarWildePoem imperatrix = new OscarWildePoem( 3L, "Ave Imperatrix", "Oscar Wilde", 1882, 48, (byte) 5, "audible", "ebook", "paperback" );
+
 
 	@Before
 	public void init() {
@@ -782,4 +786,75 @@ public class MongoDBSessionCLIQueryTest extends OgmTestCase {
 			session.clear();
 		}
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1246")
+	public void testSimpleMapReduce() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+			String nativeQuery = "db." + OscarWildePoem.TABLE_NAME + ".mapReduce('function() { emit( this._id, this.copiesSold);}','function(keyId, values) { return Array.sum(values); }')";
+			LinkedHashMap result = (LinkedHashMap) session.createNativeQuery( nativeQuery ).uniqueResult();
+			assertThat( result.size() ).isEqualTo( 3 );
+			assertThat( result ).includes( MapAssert.entry( 1l, 15.0 ), MapAssert.entry( 2l, 37.0 ), MapAssert.entry( 3l, 48.0 ) );
+			transaction.commit();
+			session.clear();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1246")
+	public void testMapReduceWithReplaceAction() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+			String nativeQuery = "db." + OscarWildePoem.TABLE_NAME + ".mapReduce('function() { emit( this.author, this.copiesSold);}','function(keyId, values) { return Array.sum(values); }',{ 'out' : { 'replace' : 'WILDE_MAP_REDUCE' }  })";
+			LinkedHashMap result = (LinkedHashMap) session.createNativeQuery( nativeQuery ).uniqueResult();
+			assertThat( result.size() ).isEqualTo( 1 );
+			assertThat( result ).includes( MapAssert.entry( "Oscar Wilde", 100.0 ) );
+			transaction.commit();
+			session.clear();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1246")
+	public void testMapReduceWithCollectionName() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+			String nativeQuery = "db." + OscarWildePoem.TABLE_NAME + ".mapReduce('function() { emit( this.author, this.copiesSold);}','function(keyId, values) { return Array.sum(values); }',{ 'out' : 'WILDE_MAP_REDUCE'  })";
+			LinkedHashMap result = (LinkedHashMap) session.createNativeQuery( nativeQuery ).uniqueResult();
+			assertThat( result.size() ).isEqualTo( 1 );
+			assertThat( result ).includes( MapAssert.entry( "Oscar Wilde", 100.0 ) );
+			transaction.commit();
+			session.clear();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1246")
+	public void testMapReduceWithQuery() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+			String nativeQuery = "db." + OscarWildePoem.TABLE_NAME + ".mapReduce('function() { emit( this.author, this.copiesSold);}','function(keyId, values) { return Array.sum(values); }',{ 'out' : 'WILDE_MAP_REDUCE', 'query' : { 'year' : {'$gt' : 1881}}} )";
+			LinkedHashMap result = (LinkedHashMap) session.createNativeQuery( nativeQuery ).uniqueResult();
+			assertThat( result.size() ).isEqualTo( 1 );
+			assertThat( result ).includes( MapAssert.entry( "Oscar Wilde", 48.0 ) );
+			transaction.commit();
+			session.clear();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "OGM-1246")
+	public void testMapReduceWithOptions() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+			String nativeQuery = "db." + OscarWildePoem.TABLE_NAME + ".mapReduce('function() { emit( this.author, this.copiesSold);}','function(keyId, values) { return Array.sum(values); }',{ 'out' : 'WILDE_MAP_REDUCE', 'query' : { 'year' : {'$gt' : 1880}}, 'limit' : 1, 'sort' : {'copiesSold' : 1 }, 'collation': { 'locale' : 'en', 'caseLevel' : false, 'caseFirst' : 'upper'} })";
+			LinkedHashMap result = (LinkedHashMap) session.createNativeQuery( nativeQuery ).uniqueResult();
+			assertThat( result.size() ).isEqualTo( 1 );
+			assertThat( result ).includes( MapAssert.entry( "Oscar Wilde", 15.0 ) );
+			transaction.commit();
+			session.clear();
+		}
+	}
+
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/OscarWildePoem.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/OscarWildePoem.java
@@ -9,7 +9,6 @@ package org.hibernate.ogm.datastore.mongodb.test.query.nativequery;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import javax.persistence.ColumnResult;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -54,26 +53,30 @@ public class OscarWildePoem {
 	private String author;
 	private byte rating;
 	private Integer year;
+	private Integer copiesSold;
 	private List<String> mediums = new ArrayList<String>();
 
 	public OscarWildePoem() {
 	}
 
-	public OscarWildePoem(Long id, String name, String author, int year, String... mediums) {
+	public OscarWildePoem(Long id, String name, String author, int year) {
+		this( id, name, author, year, 0 );
+	}
+
+	public OscarWildePoem(Long id, String name, String author, int year, int copiesSold) {
+		this( id, name, author, year, copiesSold, (byte) 0 );
+	}
+
+	public OscarWildePoem(Long id, String name, String author, int year, int copiesSold, byte rating, String... mediums) {
 		this.id = id;
 		this.name = name;
 		this.author = author;
 		this.year = year;
+		this.copiesSold = copiesSold;
+		this.rating = rating;
 		this.mediums = Arrays.asList( mediums );
 	}
 
-	public OscarWildePoem(Long id, String name, String author, int year, byte rating) {
-		this.id = id;
-		this.name = name;
-		this.author = author;
-		this.year = year;
-		this.rating = rating;
-	}
 
 	@Id
 	public Long getId() {
@@ -125,8 +128,16 @@ public class OscarWildePoem {
 		this.mediums = medium;
 	}
 
+	public Integer getCopiesSold() {
+		return copiesSold;
+	}
+
+	public void setCopiesSold(Integer copiesSold) {
+		this.copiesSold = copiesSold;
+	}
+
 	@Override
 	public String toString() {
-		return "OscarWildePoem [id=" + id + ", name=" + name + ", author=" + author + ", rating=" + rating + "]";
+		return "OscarWildePoem [id=" + id + ", name=" + name + ", author=" + author + ", rating=" + rating + ", copiesSold=" + copiesSold + "]";
 	}
 }


### PR DESCRIPTION
- Moved Collation parsing from MongoDBQueryDescriptorBuilder.java to MongoDBDialect.java in order to reuse the same in mapReduce function.

- Done some refactoring in OscarWilde.java to add few more fields to the table in order to test mapReduce.