### PR TITLE
OGM-1339 Support geospatial queries for MongoDB

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/util/impl/ArrayHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/ArrayHelper.java
@@ -74,7 +74,7 @@ public class ArrayHelper {
 	 * @param first the first array
 	 * @param second the second array
 	 * @param <T> the type of the element in the array
-	 * @return a new array created adding the element in the second array after the first one,
+	 * @return a new array created adding the element in the second array after the first one
 	 */
 	public static <T> T[] concat(T[] first, T... second) {
 		int firstLength = first.length;
@@ -110,5 +110,22 @@ public class ArrayHelper {
 			currentLength += entry.length;
 		}
 		return joined;
+	}
+
+	/**
+	 * Concats an element and an array.
+	 *
+	 * @param firstElement the first element
+	 * @param array the array
+	 * @param <T> the type of the element in the array
+	 * @return a new array created adding the element in the second array after the first element
+	 */
+	public static <T> T[] concat(T firstElement, T... array) {
+		@SuppressWarnings("unchecked")
+		T[] result = (T[]) Array.newInstance( firstElement.getClass(), 1 + array.length );
+		result[0] = firstElement;
+		System.arraycopy( array, 0, result, 1, array.length );
+
+		return result;
 	}
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/MongoDBDialect.java
@@ -10,6 +10,7 @@ import static java.lang.Boolean.FALSE;
 import static org.hibernate.ogm.datastore.document.impl.DotPatternMapHelpers.getColumnSharedPrefixOfAssociatedEntityLink;
 import static org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers.hasField;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,7 +44,6 @@ import org.hibernate.ogm.datastore.mongodb.dialect.impl.MongoHelpers;
 import org.hibernate.ogm.datastore.mongodb.impl.MongoDBDatastoreProvider;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 import org.hibernate.ogm.datastore.mongodb.options.AssociationDocumentStorageType;
 import org.hibernate.ogm.datastore.mongodb.options.impl.AssociationDocumentStorageOption;
 import org.hibernate.ogm.datastore.mongodb.options.impl.ReadPreferenceOption;
@@ -51,7 +51,19 @@ import org.hibernate.ogm.datastore.mongodb.options.impl.WriteConcernOption;
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.MongoDBQueryDescriptorBuilder;
 import org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl.NativeQueryParser;
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
 import org.hibernate.ogm.datastore.mongodb.type.impl.BinaryAsBsonBinaryGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoLineStringGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoMultiLineStringGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoMultiPointGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoMultiPolygonGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoPointGridType;
+import org.hibernate.ogm.datastore.mongodb.type.impl.GeoPolygonGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.ObjectIdGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.SerializableAsBinaryGridType;
 import org.hibernate.ogm.datastore.mongodb.type.impl.StringAsObjectIdGridType;
@@ -792,6 +804,24 @@ public class MongoDBDialect extends BaseGridDialect implements QueryableGridDial
 		else if ( type instanceof MaterializedBlobType ) {
 			MaterializedBlobType exposedType = (MaterializedBlobType) type;
 			return new SerializableAsBinaryGridType<>( exposedType.getJavaTypeDescriptor() );
+		}
+		else if ( type.getReturnedClass() == GeoPoint.class ) {
+			return GeoPointGridType.INSTANCE;
+		}
+		else if ( type.getReturnedClass() == GeoMultiPoint.class ) {
+			return GeoMultiPointGridType.INSTANCE;
+		}
+		else if ( type.getReturnedClass() == GeoLineString.class ) {
+			return GeoLineStringGridType.INSTANCE;
+		}
+		else if ( type.getReturnedClass() == GeoMultiLineString.class ) {
+			return GeoMultiLineStringGridType.INSTANCE;
+		}
+		else if ( type.getReturnedClass() == GeoPolygon.class ) {
+			return GeoPolygonGridType.INSTANCE;
+		}
+		else if ( type.getReturnedClass() == GeoMultiPolygon.class ) {
+			return GeoMultiPolygonGridType.INSTANCE;
 		}
 		return null; // all other types handled as in hibernate-ogm-core
 	}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBSchemaDefiner.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBSchemaDefiner.java
@@ -27,6 +27,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.ogm.datastore.mongodb.MongoDBDialect;
 import org.hibernate.ogm.datastore.mongodb.index.impl.MongoDBIndexSpec;
+import org.hibernate.ogm.datastore.mongodb.index.impl.MongoDBIndexType;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
 import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
 import java.lang.invoke.MethodHandles;
@@ -266,7 +267,8 @@ public class MongoDBSchemaDefiner extends BaseSchemaDefiner {
 
 		// if a text index already exists in the collection, MongoDB silently ignores the creation of the new text index
 		// so we might as well log a warning about it
-		if ( indexSpec.isTextIndex() && preexistingTextIndex != null && !preexistingTextIndex.equalsIgnoreCase( indexSpec.getIndexName() ) ) {
+		if ( MongoDBIndexType.TEXT.equals( indexSpec.getIndexType() )
+				&& preexistingTextIndex != null && !preexistingTextIndex.equalsIgnoreCase( indexSpec.getIndexName() ) ) {
 			throw log.unableToCreateTextIndex( collection.getNamespace().getCollectionName(), indexSpec.getIndexName(), preexistingTextIndex );
 		}
 

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/index/impl/MongoDBIndexSpec.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/index/impl/MongoDBIndexSpec.java
@@ -27,10 +27,12 @@ import com.mongodb.client.model.IndexOptions;
  */
 public class MongoDBIndexSpec {
 
+	private static final String INDEX_TYPE_OPTION = "_type";
+
 	/**
 	 * The MongoDB collection/table for which the index will be set
 	 */
-	private String collection;
+	private final String collection;
 
 	/**
 	 * Optional. The name of the index. If unspecified, MongoDB generates an index name
@@ -39,38 +41,40 @@ public class MongoDBIndexSpec {
 	 * Whether user specified or MongoDB generated, index names including their full namespace (i.e. database.collection)
 	 * cannot be longer than the Index Name Limit (that is 128 characters)
 	 */
-	private String indexName;
+	private final String indexName;
 
 	/**
 	 * The index keys of the index prepared for MongoDB.
 	 */
-	private Document indexKeys = new Document();
+	private final Document indexKeys = new Document();
 
 	/**
 	 * The options specific to MongoDB.
 	 */
-	private IndexOptions options;
+	private final IndexOptions options;
 
 	/**
 	 * Indicates if the index is a text index.
 	 */
-	private boolean isTextIndex = false;
+	private final MongoDBIndexType indexType;
 
 	/**
 	 * Constructor used for columns marked as unique.
 	 */
 	public MongoDBIndexSpec(String collection, String columnName, String indexName, Document options) {
-		this.options = prepareOptions( options, indexName, true );
+		this.indexType = determineIndexType( options );
+		this.options = prepareOptions( this.indexType, options, indexName, true );
 		this.collection = collection;
 		this.indexName = indexName;
-		indexKeys.put( columnName, 1 );
+		this.indexKeys.put( columnName, 1 );
 	}
 
 	/**
 	 * Constructor used for {@link UniqueKey}s.
 	 */
 	public MongoDBIndexSpec(UniqueKey uniqueKey, Document options) {
-		this.options = prepareOptions( options, uniqueKey.getName(), true );
+		this.indexType = determineIndexType( options );
+		this.options = prepareOptions( this.indexType, options, uniqueKey.getName(), true );
 		this.collection = uniqueKey.getTable().getName();
 		this.indexName = uniqueKey.getName();
 		this.addIndexKeys( uniqueKey.getColumnIterator(), uniqueKey.getColumnOrderMap() );
@@ -80,18 +84,32 @@ public class MongoDBIndexSpec {
 	 * Constructor used for {@link Index}es.
 	 */
 	public MongoDBIndexSpec(Index index, Document options) {
-		this.options = prepareOptions( options, index.getName(), false );
+		this.indexType = determineIndexType( options );
+		this.options = prepareOptions( this.indexType, options, index.getName(), false );
 		this.collection = index.getTable().getName();
 		this.indexName = index.getName();
 		// TODO OGM-1080: the columnOrderMap is not accessible for an Index
 		this.addIndexKeys( index.getColumnIterator(), Collections.<Column, String>emptyMap() );
 	}
 
+	private static MongoDBIndexType determineIndexType(Document options) {
+		MongoDBIndexType indexType = MongoDBIndexType.from( options.getString( INDEX_TYPE_OPTION ) );
+		options.remove( INDEX_TYPE_OPTION );
+
+		// legacy method for setting the text index type
+		if ( MongoDBIndexType.NORMAL.equals( indexType ) && Boolean.TRUE.equals( options.get( "text" ) ) ) {
+			options.remove( "text" );
+			return MongoDBIndexType.TEXT;
+		}
+
+		return indexType;
+	}
+
 	/**
 	 * Prepare the options by adding additional information to them.
-	 * @see <a href="https://docs.mongodb.com/manual/core/index-ttl/"> TTL Indexes</a>
+	 * @see <a href="https://docs.mongodb.com/manual/core/index-ttl/">TTL Indexes</a>
 	 */
-	private IndexOptions prepareOptions(Document options, String indexName, boolean unique) {
+	private static IndexOptions prepareOptions(MongoDBIndexType indexType, Document options, String indexName, boolean unique) {
 		IndexOptions indexOptions = new IndexOptions();
 		indexOptions.name( indexName ).unique( unique ).background( options.getBoolean( "background" , false ) );
 
@@ -111,9 +129,9 @@ public class MongoDBIndexSpec {
 
 		}
 
-		if ( Boolean.TRUE.equals( options.get( "text" ) ) ) {
+		if ( MongoDBIndexType.TEXT.equals( indexType ) ) {
 			// text is an option we take into account to mark an index as a full text index as we cannot put "text" as
-			// the order like MongoDB as ORM explicitely checks that the order is either asc or desc.
+			// the order like MongoDB as ORM explicitly checks that the order is either asc or desc.
 			// we remove the option from the Document so that we don't pass it to MongoDB
 			if ( options.containsKey( "default_language" ) ) {
 				indexOptions.defaultLanguage( options.getString( "default_language" ) );
@@ -122,7 +140,6 @@ public class MongoDBIndexSpec {
 				indexOptions.weights( (Bson) options.get( "weights" ) );
 			}
 
-			isTextIndex = true;
 			options.remove( "text" );
 		}
 		return indexOptions;
@@ -136,20 +153,20 @@ public class MongoDBIndexSpec {
 		return indexName;
 	}
 
-	public boolean isTextIndex() {
-		return isTextIndex;
+	public MongoDBIndexType getIndexType() {
+		return indexType;
 	}
 
 	private void addIndexKeys(Iterator<Column> columnIterator, Map<Column, String> columnOrderMap) {
 		while ( columnIterator.hasNext() ) {
 			Column column = columnIterator.next();
 			Object mongoDBOrder;
-			if ( isTextIndex ) {
-				mongoDBOrder = "text";
-			}
-			else {
+			if ( MongoDBIndexType.NORMAL.equals( indexType ) ) {
 				String order = columnOrderMap.get( column ) != null ? columnOrderMap.get( column ) : "asc";
 				mongoDBOrder = "asc".equals( order ) ? 1 : -1;
+			}
+			else {
+				mongoDBOrder = indexType.getType();
 			}
 
 			indexKeys.put( column.getName(), mongoDBOrder );
@@ -170,7 +187,8 @@ public class MongoDBIndexSpec {
 		sb.append( getClass().getSimpleName() );
 		sb.append( "[" );
 		sb.append( "collection: " ).append( collection ).append( ", " );
-		sb.append( "indexName: " ).append( indexName );
+		sb.append( "indexName: " ).append( indexName ).append( ", " );
+		sb.append( "indexType: " ).append( indexType );
 		sb.append( "]" );
 		return sb.toString();
 	}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/index/impl/MongoDBIndexType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/index/impl/MongoDBIndexType.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.index.impl;
+
+import org.hibernate.ogm.options.shared.IndexOption;
+import org.hibernate.ogm.util.impl.StringHelper;
+
+/**
+ * Supported MongoDB index types. Defined as a "_type" entry in {@link IndexOption}.
+ *
+ * @author Guillaume Smet
+ */
+public enum MongoDBIndexType {
+
+	NORMAL(null),
+
+	/**
+	 * Full text index.
+	 */
+	TEXT("text"),
+
+	/**
+	 * Geospatial index on a 2D sphere.
+	 */
+	TWODSPHERE("2dsphere"),
+
+	/**
+	 * Geospatial index on a 2D plan.
+	 */
+	TWOD("2d");
+
+	private String type;
+
+	private MongoDBIndexType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public static MongoDBIndexType from(String type) {
+		if ( StringHelper.isEmpty( type ) ) {
+			return NORMAL;
+		}
+		if ( TEXT.type.equals( type ) ) {
+			return TEXT;
+		}
+		else if ( TWODSPHERE.type.equals( type ) ) {
+			return TWODSPHERE;
+		}
+		else if ( TWOD.type.equals( type ) ) {
+			return TWOD;
+		}
+		throw new IllegalArgumentException( "Unsupported MongoDB index type " + type );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -131,4 +131,7 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1236, value = "The options for index %2$s of collection %1$s are not a valid JSON object.")
 	HibernateException invalidOptionsFormatForIndex(String collection, String indexName, @Cause Exception e);
 
+	@Message(id = 1237, value = "Invalid GeoJSON type %1$s. Expecting %2$s.")
+	HibernateException invalidGeoJsonType(String actualType, String expectedType);
+
 }

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/AbstractGeoJsonObject.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/AbstractGeoJsonObject.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
+import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
+
+/**
+ * Common base class for GeoJSON objects.
+ *
+ * @author Guillaume Smet
+ */
+public abstract class AbstractGeoJsonObject implements Serializable {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private String type;
+
+	protected AbstractGeoJsonObject(String type) {
+		this.type = type;
+	}
+
+	public BsonDocument toBsonDocument() {
+		BsonDocument document = new BsonDocument();
+		document.put( "type", new BsonString( type ) );
+		document.put( "coordinates", toCoordinates() );
+		return document;
+	}
+
+	protected abstract BsonArray toCoordinates();
+
+	protected static void checkType(String expectedType, Document document) {
+		String documentType = document.getString( "type" );
+		if ( !expectedType.equals( documentType ) ) {
+			throw log.invalidGeoJsonType( documentType, expectedType );
+		}
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoLineString.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoLineString.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bson.BsonArray;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON LineString in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoLineString extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "LineString";
+
+	/**
+	 * The start point of the line.
+	 */
+	private GeoPoint startPoint;
+
+	/**
+	 * The end point of the line.
+	 */
+	private GeoPoint endPoint;
+
+	/**
+	 * Instantiates a new LineString.
+	 *
+	 * @param startPoint the start point of the line
+	 * @param endPoint the end point of the line
+	 */
+	public GeoLineString(GeoPoint startPoint, GeoPoint endPoint) {
+		super( TYPE );
+		Contracts.assertNotNull( startPoint, "startPoint" );
+		Contracts.assertNotNull( endPoint, "endPoint" );
+		this.startPoint = startPoint;
+		this.endPoint = endPoint;
+	}
+
+	/**
+	 * @return the start point of the line
+	 */
+	public GeoPoint getStartPoint() {
+		return startPoint;
+	}
+
+	/**
+	 * @return the start point of the line
+	 */
+	public GeoPoint getEndPoint() {
+		return endPoint;
+	}
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray( Arrays.asList(
+				startPoint.toCoordinates(),
+				endPoint.toCoordinates()
+		) );
+
+		return coordinates;
+	}
+
+	static GeoLineString fromCoordinates(List<List<Double>> coordinates) {
+		if ( coordinates == null ) {
+			return null;
+		}
+
+		return new GeoLineString( GeoPoint.fromCoordinates( coordinates.get( 0 ) ), GeoPoint.fromCoordinates( coordinates.get( 1 ) ) );
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoLineString fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<List<Double>> coordinates = (List<List<Double>>) document.get( "coordinates" );
+
+		return fromCoordinates( coordinates );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoLineString that = (GeoLineString) obj;
+
+		if ( !that.startPoint.equals( startPoint ) ) {
+			return false;
+		}
+		if ( !that.endPoint.equals( endPoint ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int hashCode = startPoint.hashCode();
+		hashCode = hashCode * 31 + endPoint.hashCode();
+		return hashCode;
+	}
+
+	@Override
+	public String toString() {
+		return "GeoLineString [startPoint=" + startPoint + ", endPoint=" + endPoint + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiLineString.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiLineString.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bson.BsonArray;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.ArrayHelper;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON MultiLineString in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoMultiLineString extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "MultiLineString";
+
+	/**
+	 * The list of LineStrings.
+	 */
+	private List<GeoLineString> lineStrings;
+
+	/**
+	 * Instantiates a new MultiLineString.
+	 *
+	 * @param lineStrings the list of LineStrings
+	 */
+	public GeoMultiLineString(List<GeoLineString> lineStrings) {
+		super( TYPE );
+		this.lineStrings = lineStrings;
+	}
+
+	/**
+	 * Instantiates a new MultiLineString.
+	 *
+	 * @param firstLineString the first LineString
+	 * @param additionalLineStrings the additional LineStrings
+	 */
+	public GeoMultiLineString(GeoLineString firstLineString, GeoLineString... additionalLineStrings) {
+		super( TYPE );
+		Contracts.assertNotNull( firstLineString, "firstLineString" );
+		Contracts.assertNotNull( additionalLineStrings, "additionalLineStrings" );
+		this.lineStrings = new ArrayList<>( Arrays.asList( ArrayHelper.concat( firstLineString, additionalLineStrings ) ) );
+	}
+
+	/**
+	 * @return the list of LineStrings
+	 */
+	public List<GeoLineString> getLineStrings() {
+		return lineStrings;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoMultiLineString that = (GeoMultiLineString) obj;
+
+		if ( !that.lineStrings.equals( lineStrings ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray();
+
+		for ( GeoLineString geoLineString : lineStrings ) {
+			coordinates.add( geoLineString.toCoordinates() );
+		}
+
+		return coordinates;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoMultiLineString fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<List<List<Double>>> linesCoordinates = (List<List<List<Double>>>) document.get( "coordinates" );
+
+		if ( linesCoordinates == null ) {
+			return null;
+		}
+
+		List<GeoLineString> geoLineStrings = linesCoordinates.stream()
+				.map( GeoLineString::fromCoordinates )
+				.collect( Collectors.toList() );
+
+		return new GeoMultiLineString( geoLineStrings );
+	}
+
+	@Override
+	public int hashCode() {
+		return lineStrings.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "GeoMultiLineString [lineStrings=" + lineStrings + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiPoint.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiPoint.java
@@ -1,0 +1,149 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bson.BsonArray;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.ArrayHelper;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON MultiPoint in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoMultiPoint extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "MultiPoint";
+
+	/**
+	 * The list of Points.
+	 */
+	private List<GeoPoint> points;
+
+	/**
+	 * Instantiates a new MultiPoint.
+	 *
+	 * @param point the first point
+	 */
+	public GeoMultiPoint(GeoPoint point) {
+		super( TYPE );
+		Contracts.assertNotNull( point, "point" );
+		this.points.add( point );
+	}
+
+	/**
+	 * Instantiates a new MultiPoint.
+	 *
+	 * @param points the list of points
+	 */
+	public GeoMultiPoint(List<GeoPoint> points) {
+		super( TYPE );
+		Contracts.assertNotNull( points, "points" );
+		this.points = points;
+	}
+
+	/**
+	 * Instantiates a new MultiPoint.
+	 *
+	 * @param firstPoint the first point
+	 * @param additionalPoints the additional points
+	 */
+	public GeoMultiPoint(GeoPoint firstPoint, GeoPoint... additionalPoints) {
+		super( TYPE );
+		Contracts.assertNotNull( firstPoint, "firstPoint" );
+		Contracts.assertNotNull( additionalPoints, "additionalPoints" );
+		this.points = new ArrayList<>( Arrays.asList( ArrayHelper.concat( firstPoint, additionalPoints ) ) );
+	}
+
+	/**
+	 * Adds a new point.
+	 *
+	 * @param point a point
+	 * @return this for chaining
+	 */
+	public GeoMultiPoint addPoint(GeoPoint point) {
+		Contracts.assertNotNull( point, "point" );
+		this.points.add( point );
+		return this;
+	}
+
+	/**
+	 * @return the list of points
+	 */
+	public List<GeoPoint> getPoints() {
+		return points;
+	}
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray();
+
+		for ( GeoPoint geoPoint : points ) {
+			coordinates.add( geoPoint.toCoordinates() );
+		}
+
+		return coordinates;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoMultiPoint fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<List<Double>> pointsCoordinates = (List<List<Double>>) document.get( "coordinates" );
+
+		if ( pointsCoordinates == null ) {
+			return null;
+		}
+
+		List<GeoPoint> geoPoints = pointsCoordinates.stream()
+				.map( GeoPoint::fromCoordinates )
+				.collect( Collectors.toList() );
+
+		return new GeoMultiPoint( geoPoints );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoMultiPoint that = (GeoMultiPoint) obj;
+
+		if ( !that.points.equals( points ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return points.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "GeoMultiPoint [points=" + points + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiPolygon.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoMultiPolygon.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bson.BsonArray;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.ArrayHelper;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON MultiPolygon in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoMultiPolygon extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "MultiPolygon";
+
+	/**
+	 * The list of Polygon.
+	 */
+	private List<GeoPolygon> polygons;
+
+	/**
+	 * Instantiates a new MultiPolygon.
+	 *
+	 * @param polygons the list of Polygons
+	 */
+	public GeoMultiPolygon(List<GeoPolygon> polygons) {
+		super( TYPE );
+		this.polygons = polygons;
+	}
+
+	/**
+	 * Instantiates a new MultiPolygon.
+	 *
+	 * @param firstPolygon the first Polygon
+	 * @param additionalPolygons the additional Polygons
+	 */
+	public GeoMultiPolygon(GeoPolygon firstPolygon, GeoPolygon... additionalPolygons) {
+		super( TYPE );
+		Contracts.assertNotNull( firstPolygon, "firstPolygon" );
+		Contracts.assertNotNull( additionalPolygons, "additionalPolygons" );
+		this.polygons = new ArrayList<>( Arrays.asList( ArrayHelper.concat( firstPolygon, additionalPolygons ) ) );
+	}
+
+	/**
+	 * @return the list of Polygons
+	 */
+	public List<GeoPolygon> getPolygons() {
+		return polygons;
+	}
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray();
+
+		for ( GeoPolygon geoPolygon : polygons ) {
+			coordinates.add( geoPolygon.toCoordinates() );
+		}
+
+		return coordinates;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoMultiPolygon fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<List<List<List<Double>>>> polygonsCoordinates = (List<List<List<List<Double>>>>) document.get( "coordinates" );
+
+		if ( polygonsCoordinates == null ) {
+			return null;
+		}
+
+		List<GeoPolygon> geoPolygons = polygonsCoordinates.stream()
+				.map( GeoPolygon::fromCoordinates )
+				.collect( Collectors.toList() );
+
+		return new GeoMultiPolygon( geoPolygons );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoMultiPolygon that = (GeoMultiPolygon) obj;
+
+		if ( !that.polygons.equals( polygons ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return polygons.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "GeoMultiPolygon [polygons=" + polygons + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoPoint.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoPoint.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.List;
+
+import org.bson.BsonArray;
+import org.bson.BsonDouble;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON Point in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoPoint extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "Point";
+
+	/**
+	 * The longitude of the point.
+	 */
+	private double longitude;
+
+	/**
+	 * The latitude of the point.
+	 */
+	private double latitude;
+
+	/**
+	 * Instantiates a new Point.
+	 *
+	 * @param longitude the longitude of the point
+	 * @param latitude the latitude of the point
+	 */
+	public GeoPoint(double longitude, double latitude) {
+		super( TYPE );
+		Contracts.assertNotNull( longitude, "longitude" );
+		Contracts.assertNotNull( latitude, "latitude" );
+		this.longitude = longitude;
+		this.latitude = latitude;
+	}
+
+	/**
+	 * @return the longitude of the point
+	 */
+	public double getLongitude() {
+		return longitude;
+	}
+
+	/**
+	 * @return the latitude of the point
+	 */
+	public double getLatitude() {
+		return latitude;
+	}
+
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray();
+
+		coordinates.add( new BsonDouble( longitude ) );
+		coordinates.add( new BsonDouble( latitude ) );
+
+		return coordinates;
+	}
+
+	static GeoPoint fromCoordinates(List<Double> coordinates) {
+		if ( coordinates == null ) {
+			return null;
+		}
+
+		return new GeoPoint( coordinates.get( 0 ), coordinates.get( 1 ) );
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoPoint fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<Double> coordinates = (List<Double>) document.get( "coordinates" );
+
+		return fromCoordinates( coordinates );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoPoint that = (GeoPoint) obj;
+
+		if ( that.longitude != longitude ) {
+			return false;
+		}
+		if ( that.latitude != latitude ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int hashCode = Double.valueOf( longitude ).hashCode();
+		hashCode = hashCode * 31 + Double.valueOf( latitude ).hashCode();
+		return hashCode;
+	}
+
+	@Override
+	public String toString() {
+		return "GeoPoint [longitude=" + longitude + ", latitude=" + latitude + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoPolygon.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/GeoPolygon.java
@@ -1,0 +1,217 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bson.BsonArray;
+import org.bson.Document;
+import org.hibernate.ogm.util.Experimental;
+import org.hibernate.ogm.util.impl.Contracts;
+
+/**
+ * Type used to represent a GeoJSON Polygon in MongoDB and support spatial queries.
+ *
+ * @author Guillaume Smet
+ */
+@Experimental
+public class GeoPolygon extends AbstractGeoJsonObject {
+
+	private static final String TYPE = "Polygon";
+
+	private List<List<GeoPoint>> rings = new ArrayList<>( 1 );
+
+	/**
+	 * Instantiates a new Polygon.
+	 *
+	 * @param exteriorRing the exterior ring of the polygon, it cannot self-intersect
+	 */
+	public GeoPolygon(List<GeoPoint> exteriorRing) {
+		super( TYPE );
+		Contracts.assertNotNull( exteriorRing, "exteriorRing" );
+		this.rings.add( exteriorRing );
+	}
+
+	/**
+	 * Instantiates a new Polygon.
+	 *
+	 * @param firstPoint the first point of the polygon
+	 * @param secondPoint the second point of the polygon
+	 * @param thirdPoint the third point of the polygon
+	 * @param fourthPoint the third point of the polygon
+	 * @param additionalPoints the additional points of the polygon
+	 */
+	public GeoPolygon(GeoPoint firstPoint, GeoPoint secondPoint, GeoPoint thirdPoint, GeoPoint fourthPoint, GeoPoint... additionalPoints) {
+		super( TYPE );
+		Contracts.assertNotNull( firstPoint, "firstPoint" );
+		Contracts.assertNotNull( secondPoint, "secondPoint" );
+		Contracts.assertNotNull( thirdPoint, "thirdPoint" );
+		Contracts.assertNotNull( fourthPoint, "fourthPoint" );
+		Contracts.assertNotNull( additionalPoints, "additionalPoints" );
+
+		List<GeoPoint> exteriorRing = new ArrayList<>( 4 + additionalPoints.length );
+		exteriorRing.add( firstPoint );
+		exteriorRing.add( secondPoint );
+		exteriorRing.add( thirdPoint );
+		exteriorRing.add( fourthPoint );
+		exteriorRing.addAll( Arrays.asList( additionalPoints ) );
+
+		this.rings.add( exteriorRing );
+	}
+
+	/**
+	 * Adds a new hole to the polygon.
+	 *
+	 * @param hole a hole, must be contained in the exterior ring and must not overlap or
+	 * intersect another hole
+	 * @return this for chaining
+	 */
+	public GeoPolygon addHole(List<GeoPoint> hole) {
+		Contracts.assertNotNull( hole, "hole" );
+		this.rings.add( hole );
+		return this;
+	}
+
+	/**
+	 * Adds a new hole to the polygon.
+	 *
+	 * @param firstPoint the first point of the polygon
+	 * @param secondPoint the second point of the polygon
+	 * @param thirdPoint the third point of the polygon
+	 * @param fourthPoint the third point of the polygon
+	 * @param additionalPoints the additional points of the polygon
+	 */
+	public GeoPolygon addHole(GeoPoint firstPoint, GeoPoint secondPoint, GeoPoint thirdPoint, GeoPoint fourthPoint, GeoPoint... additionalPoints) {
+		Contracts.assertNotNull( firstPoint, "firstPoint" );
+		Contracts.assertNotNull( secondPoint, "secondPoint" );
+		Contracts.assertNotNull( thirdPoint, "thirdPoint" );
+		Contracts.assertNotNull( fourthPoint, "fourthPoint" );
+		Contracts.assertNotNull( additionalPoints, "additionalPoints" );
+
+		List<GeoPoint> hole = new ArrayList<>( 4 + additionalPoints.length );
+		hole.add( firstPoint );
+		hole.add( secondPoint );
+		hole.add( thirdPoint );
+		hole.add( fourthPoint );
+		hole.addAll( Arrays.asList( additionalPoints ) );
+
+		this.rings.add( hole );
+
+		return this;
+	}
+
+	/**
+	 * Adds new holes to the polygon.
+	 *
+	 * @param holes holes, must be contained in the exterior ring and must not overlap or
+	 * intersect another hole
+	 * @return this for chaining
+	 */
+	public GeoPolygon addHoles(List<List<GeoPoint>> holes) {
+		Contracts.assertNotNull( holes, "holes" );
+		this.rings.addAll( holes );
+		return this;
+	}
+
+	/**
+	 * Returns the external ring of the polygon.
+	 *
+	 * @return the external ring
+	 */
+	public List<GeoPoint> getExternalRing() {
+		return rings.get( 0 );
+	}
+
+	/**
+	 * @return the rings of the polygon
+	 */
+	public List<List<GeoPoint>> getRings() {
+		return rings;
+	}
+
+	@Override
+	protected BsonArray toCoordinates() {
+		BsonArray coordinates = new BsonArray();
+		for ( List<GeoPoint> ring : rings ) {
+			BsonArray ringCoordinates = new BsonArray();
+			for ( GeoPoint geoPoint : ring ) {
+				ringCoordinates.add( geoPoint.toCoordinates() );
+			}
+			coordinates.add( ringCoordinates );
+		}
+		return coordinates;
+	}
+
+	static GeoPolygon fromCoordinates(List<List<List<Double>>> coordinates) {
+		if ( coordinates == null ) {
+			return null;
+		}
+
+		List<List<GeoPoint>> rings = new ArrayList<>( coordinates.size() );
+
+		for ( List<List<Double>> ringCoordinates : coordinates ) {
+			List<GeoPoint> ring = ringCoordinates.stream()
+					.map( GeoPoint::fromCoordinates )
+					.collect( Collectors.toList() );
+			rings.add( ring );
+		}
+
+		GeoPolygon geoPolygon = new GeoPolygon( rings.get( 0 ) );
+		geoPolygon.addHoles( rings.subList( 1, rings.size() ) );
+
+		return geoPolygon;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static GeoPolygon fromDocument(Document document) {
+		if ( document == null ) {
+			return null;
+		}
+
+		checkType( TYPE, document );
+
+		List<List<List<Double>>> coordinates = (List<List<List<Double>>>) document.get( "coordinates" );
+
+		if ( coordinates == null ) {
+			return null;
+		}
+
+		return fromCoordinates( coordinates );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+
+		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+
+		GeoPolygon that = (GeoPolygon) obj;
+
+		if ( !that.rings.equals( rings ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return rings.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "GeoPolygon [rings=" + rings + "]";
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/AbstractGeoJsonObjectGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/AbstractGeoJsonObjectGridTypeDescriptor.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import java.util.function.Function;
+
+import org.bson.Document;
+import org.hibernate.ogm.datastore.mongodb.type.AbstractGeoJsonObject;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.type.descriptor.impl.BasicGridBinder;
+import org.hibernate.ogm.type.descriptor.impl.GridTypeDescriptor;
+import org.hibernate.ogm.type.descriptor.impl.GridValueBinder;
+import org.hibernate.ogm.type.descriptor.impl.GridValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
+/**
+ * Base grid type descriptor for GeoJSON objects.
+ *
+ * @author Guillaume Smet
+ */
+class AbstractGeoJsonObjectGridTypeDescriptor<T extends AbstractGeoJsonObject> implements GridTypeDescriptor {
+
+	private final Class<T> geoObjectClass;
+
+	private final Function<Document, T> geoObjectSupplier;
+
+	protected AbstractGeoJsonObjectGridTypeDescriptor(Class<T> geoObjectClass, Function<Document, T> geoObjectSupplier) {
+		this.geoObjectClass = geoObjectClass;
+		this.geoObjectSupplier = geoObjectSupplier;
+	}
+
+	@Override
+	public <X> GridValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new BasicGridBinder<X>( javaTypeDescriptor, this ) {
+
+			@Override
+			protected void doBind(Tuple resultset, X value, String[] names, WrapperOptions options) {
+				T geoObject = javaTypeDescriptor.unwrap( value, geoObjectClass, options );
+
+				resultset.put( names[0], geoObject.toBsonDocument() );
+			}
+		};
+	}
+
+	@Override
+	public <X> GridValueExtractor<X> getExtractor(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new GridValueExtractor<X>() {
+
+			@Override
+			public X extract(Tuple resultset, String name) {
+				Document document = (Document) resultset.get( name );
+
+				if ( document == null ) {
+					return null;
+				}
+
+				return javaTypeDescriptor.wrap( geoObjectSupplier.apply( document ), null );
+			}
+		};
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/AbstractGeoJsonObjectTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/AbstractGeoJsonObjectTypeDescriptor.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+import org.hibernate.ogm.datastore.mongodb.type.AbstractGeoJsonObject;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+
+/**
+ * Base type descriptor for GeoJSON objects.
+ *
+ * @author Guillaume Smet
+ */
+abstract class AbstractGeoJsonObjectTypeDescriptor<T extends AbstractGeoJsonObject> extends AbstractTypeDescriptor<T> {
+
+	protected AbstractGeoJsonObjectTypeDescriptor(Class<T> type) {
+		super( type );
+	}
+
+	@Override
+	public String toString(T value) {
+		return value == null ? null : value.toString();
+	}
+
+	@Override
+	public T fromString(String string) {
+		throw new UnsupportedOperationException( "Converting a string to a " + getJavaTypeClass().getSimpleName() + " is not supported." );
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Override
+	public <X> X unwrap(T value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+		if ( getJavaTypeClass().isAssignableFrom( type ) ) {
+			return (X) value;
+		}
+		throw unknownUnwrap( type );
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <X> T wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+		if ( getJavaTypeClass().isInstance( value ) ) {
+			return (T) value;
+		}
+		throw unknownWrap( value.getClass() );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoLineStringGridType extends AbstractGenericBasicType<GeoLineString>  {
+
+	public static final GeoLineStringGridType INSTANCE = new GeoLineStringGridType();
+
+	public GeoLineStringGridType() {
+		super( GeoLineStringGridTypeDescriptor.INSTANCE, GeoLineStringTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geolinestring";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+
+/**
+ * Persists {@link GeoLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoLineStringGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoLineString> {
+
+	public static final GeoLineStringGridTypeDescriptor INSTANCE = new GeoLineStringGridTypeDescriptor();
+
+	private GeoLineStringGridTypeDescriptor() {
+		super( GeoLineString.class, GeoLineString::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoLineStringTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+
+/**
+ * Persists {@link GeoLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoLineStringTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoLineString> {
+
+	public static final GeoLineStringTypeDescriptor INSTANCE = new GeoLineStringTypeDescriptor();
+
+	public GeoLineStringTypeDescriptor() {
+		super( GeoLineString.class );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoMultiLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiLineStringGridType extends AbstractGenericBasicType<GeoMultiLineString>  {
+
+	public static final GeoMultiLineStringGridType INSTANCE = new GeoMultiLineStringGridType();
+
+	public GeoMultiLineStringGridType() {
+		super( GeoMultiLineStringGridTypeDescriptor.INSTANCE, GeoMultiLineStringTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geomultilinestring";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+
+/**
+ * Persists {@link GeoMultiLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiLineStringGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoMultiLineString> {
+
+	public static final GeoMultiLineStringGridTypeDescriptor INSTANCE = new GeoMultiLineStringGridTypeDescriptor();
+
+	private GeoMultiLineStringGridTypeDescriptor() {
+		super( GeoMultiLineString.class, GeoMultiLineString::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiLineStringTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+
+/**
+ * Persists {@link GeoMultiLineString} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiLineStringTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoMultiLineString> {
+
+	public static final GeoMultiLineStringTypeDescriptor INSTANCE = new GeoMultiLineStringTypeDescriptor();
+
+	public GeoMultiLineStringTypeDescriptor() {
+		super( GeoMultiLineString.class );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoMultiPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPointGridType extends AbstractGenericBasicType<GeoMultiPoint>  {
+
+	public static final GeoMultiPointGridType INSTANCE = new GeoMultiPointGridType();
+
+	public GeoMultiPointGridType() {
+		super( GeoMultiPointGridTypeDescriptor.INSTANCE, GeoMultiPointTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geomultipoint";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+
+/**
+ * Persists {@link GeoMultiPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPointGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoMultiPoint> {
+
+	public static final GeoMultiPointGridTypeDescriptor INSTANCE = new GeoMultiPointGridTypeDescriptor();
+
+	private GeoMultiPointGridTypeDescriptor() {
+		super( GeoMultiPoint.class, GeoMultiPoint::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPointTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+
+/**
+ * Persists {@link GeoMultiPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPointTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoMultiPoint> {
+
+	public static final GeoMultiPointTypeDescriptor INSTANCE = new GeoMultiPointTypeDescriptor();
+
+	public GeoMultiPointTypeDescriptor() {
+		super( GeoMultiPoint.class );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoMultiPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPolygonGridType extends AbstractGenericBasicType<GeoMultiPolygon>  {
+
+	public static final GeoMultiPolygonGridType INSTANCE = new GeoMultiPolygonGridType();
+
+	public GeoMultiPolygonGridType() {
+		super( GeoMultiPolygonGridTypeDescriptor.INSTANCE, GeoMultiPolygonTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geomultipolygon";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+
+/**
+ * Persists {@link GeoMultiPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPolygonGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoMultiPolygon> {
+
+	public static final GeoMultiPolygonGridTypeDescriptor INSTANCE = new GeoMultiPolygonGridTypeDescriptor();
+
+	private GeoMultiPolygonGridTypeDescriptor() {
+		super( GeoMultiPolygon.class, GeoMultiPolygon::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoMultiPolygonTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+
+/**
+ * Persists {@link GeoMultiPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoMultiPolygonTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoMultiPolygon> {
+
+	public static final GeoMultiPolygonTypeDescriptor INSTANCE = new GeoMultiPolygonTypeDescriptor();
+
+	public GeoMultiPolygonTypeDescriptor() {
+		super( GeoMultiPolygon.class );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPointGridType extends AbstractGenericBasicType<GeoPoint>  {
+
+	public static final GeoPointGridType INSTANCE = new GeoPointGridType();
+
+	public GeoPointGridType() {
+		super( GeoPointGridTypeDescriptor.INSTANCE, GeoPointTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geopoint";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+
+/**
+ * Persists {@link GeoPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPointGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoPoint> {
+
+	public static final GeoPointGridTypeDescriptor INSTANCE = new GeoPointGridTypeDescriptor();
+
+	private GeoPointGridTypeDescriptor() {
+		super( GeoPoint.class, GeoPoint::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPointTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+
+/**
+ * Persists {@link GeoPoint} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPointTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoPoint> {
+
+	public static final GeoPointTypeDescriptor INSTANCE = new GeoPointTypeDescriptor();
+
+	public GeoPointTypeDescriptor() {
+		super( GeoPoint.class );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonGridType.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonGridType.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
+import org.hibernate.ogm.type.impl.AbstractGenericBasicType;
+
+/**
+ * Persists {@link GeoPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPolygonGridType extends AbstractGenericBasicType<GeoPolygon>  {
+
+	public static final GeoPolygonGridType INSTANCE = new GeoPolygonGridType();
+
+	public GeoPolygonGridType() {
+		super( GeoPolygonGridTypeDescriptor.INSTANCE, GeoPolygonTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	public String getName() {
+		return "geopolygon";
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		return 1;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonGridTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonGridTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
+
+/**
+ * Persists {@link GeoPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPolygonGridTypeDescriptor extends AbstractGeoJsonObjectGridTypeDescriptor<GeoPolygon> {
+
+	public static final GeoPolygonGridTypeDescriptor INSTANCE = new GeoPolygonGridTypeDescriptor();
+
+	private GeoPolygonGridTypeDescriptor() {
+		super( GeoPolygon.class, GeoPolygon::fromDocument );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonTypeDescriptor.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/type/impl/GeoPolygonTypeDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.type.impl;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
+
+/**
+ * Persists {@link GeoPolygon} in the format expected by MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class GeoPolygonTypeDescriptor extends AbstractGeoJsonObjectTypeDescriptor<GeoPolygon> {
+
+	public static final GeoPolygonTypeDescriptor INSTANCE = new GeoPolygonTypeDescriptor();
+
+	public GeoPolygonTypeDescriptor() {
+		super( GeoPolygon.class );
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/MongoDBIndexTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/MongoDBIndexTest.java
@@ -25,13 +25,11 @@ import org.junit.Test;
  */
 public class MongoDBIndexTest extends OgmTestCase {
 
-	private static final String COLLECTION_NAME = "T_POEM";
-
 	@Test
 	public void testSuccessfulIndexCreation() throws Exception {
 		OgmSession session = openSession();
 
-		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), COLLECTION_NAME );
+		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), Poem.COLLECTION_NAME );
 		assertThat( indexMap.size() ).isEqualTo( 6 );
 
 		assertJsonEquals( "{ 'v' : 2 , 'key' : { 'author' : 1} , 'name' : 'author_idx' , 'ns' : 'ogm_test_database.T_POEM' , 'background' : true , 'partialFilterExpression' : { 'author' : 'Verlaine'}}",
@@ -51,7 +49,7 @@ public class MongoDBIndexTest extends OgmTestCase {
 	public void testSuccessfulTextIndexCreation() throws Exception {
 		OgmSession session = openSession();
 
-		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), COLLECTION_NAME );
+		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), Poem.COLLECTION_NAME );
 		assertThat( indexMap.size() ).isEqualTo( 6 );
 
 		assertJsonEquals( "{ 'v' : 2 , 'key' : { '_fts' : 'text' , '_ftsx' : 1} , 'name' : 'author_name_text_idx' , 'ns' : 'ogm_test_database.T_POEM' , 'weights' : { 'author' : 2, 'name' : 5} , 'default_language' : 'fr' , 'language_override' : 'language' , 'textIndexVersion' : 3}",
@@ -60,8 +58,34 @@ public class MongoDBIndexTest extends OgmTestCase {
 		session.close();
 	}
 
+	@Test
+	public void testSuccessfulTextIndexWithTypeCreation() throws Exception {
+		OgmSession session = openSession();
+
+		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), OscarWildePoem.COLLECTION_NAME );
+		assertThat( indexMap.size() ).isEqualTo( 3 );
+
+		assertJsonEquals( "{ 'v' : 2 , 'key' : { '_fts' : 'text' , '_ftsx' : 1} , 'name' : 'name_text_idx' , 'ns' : 'ogm_test_database.T_OSCAR_WILDE_POEM', 'default_language' : 'fr' , 'language_override' : 'language' , weights : { name: 5 } , 'textIndexVersion' : 3}",
+				indexMap.get( "name_text_idx" ).toJson() );
+
+		session.close();
+	}
+
+	@Test
+	public void testSuccessfulSpatialIndexCreation() throws Exception {
+		OgmSession session = openSession();
+
+		Map<String, Document> indexMap = getIndexes( session.getSessionFactory(), Restaurant.COLLECTION_NAME );
+		assertThat( indexMap.size() ).isEqualTo( 2 );
+
+		assertJsonEquals( "{ 'v' : 2 , 'key' : { 'location' : '2dsphere'} , 'name' : 'location_spatial_idx' , 'ns' : 'ogm_test_database.T_RESTAURANT' , 2dsphereIndexVersion=3}",
+				indexMap.get( "location_spatial_idx" ).toJson() );
+
+		session.close();
+	}
+
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Poem.class };
+		return new Class<?>[] { Poem.class, OscarWildePoem.class, Restaurant.class };
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/OscarWildePoem.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/OscarWildePoem.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.index;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.options.shared.IndexOption;
+import org.hibernate.ogm.options.shared.IndexOptions;
+
+/**
+ * @author Guillaume Smet
+ */
+@Entity
+@Table(name = OscarWildePoem.COLLECTION_NAME, indexes = {
+		@Index(columnList = "name DESC", name = "name_idx"),
+		@Index(columnList = "name", name = "name_text_idx")
+} )
+@IndexOptions({
+		@IndexOption(forIndex = "name_text_idx", options = "{ _type: 'text', default_language : 'fr', weights : { name: 5 } }"),
+})
+public class OscarWildePoem {
+
+	public static final String COLLECTION_NAME = "T_OSCAR_WILDE_POEM";
+
+	private String id;
+
+	private String name;
+
+	OscarWildePoem() {
+	}
+
+	public OscarWildePoem(String id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/Poem.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/Poem.java
@@ -19,7 +19,7 @@ import org.hibernate.ogm.options.shared.IndexOptions;
  * @author Guillaume Smet
  */
 @Entity
-@Table(name = "T_POEM", indexes = {
+@Table(name = Poem.COLLECTION_NAME, indexes = {
 		@Index(columnList = "author ASC", name = "author_idx"),
 		@Index(columnList = "name DESC", name = "name_idx"),
 		@Index(columnList = "author, name", name = "author_name_idx", unique = true),
@@ -35,7 +35,10 @@ import org.hibernate.ogm.options.shared.IndexOptions;
 })
 public class Poem {
 
+	public static final String COLLECTION_NAME = "T_POEM";
+
 	private String id;
+
 	private String name;
 
 	private String author;

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/Restaurant.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/index/Restaurant.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.index;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.options.shared.IndexOption;
+import org.hibernate.ogm.options.shared.IndexOptions;
+
+@Entity
+@Table(name = Restaurant.COLLECTION_NAME, indexes = {
+		@Index(columnList = "location", name = "location_spatial_idx")
+})
+@IndexOptions(
+		@IndexOption(forIndex = "location_spatial_idx", options = "{ _type: '2dsphere' }")
+)
+public class Restaurant {
+
+	public static final String COLLECTION_NAME = "T_RESTAURANT";
+
+	@Id
+	private Long id;
+
+	private String name;
+
+	private GeoPoint location;
+
+	public Restaurant() {
+	}
+
+	public Restaurant(Long id, String name, GeoPoint location) {
+		this.id = id;
+		this.name = name;
+		this.location = location;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public GeoPoint getLocation() {
+		return location;
+	}
+
+	public void setLocation(GeoPoint location) {
+		this.location = location;
+	}
+
+	@Override
+	public String toString() {
+		return "Restaurant [id=" + id + ", name=" + name + ", location=" + location + "]";
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/GeoObject.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/GeoObject.java
@@ -1,0 +1,138 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.spatial;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
+import org.hibernate.ogm.options.shared.IndexOption;
+import org.hibernate.ogm.options.shared.IndexOptions;
+
+@Entity
+@Table(name = GeoObject.COLLECTION_NAME, indexes = {
+		@Index(columnList = "point", name = "point_spatial_idx"),
+		@Index(columnList = "multiPoint", name = "multiPoint_spatial_idx"),
+		@Index(columnList = "lineString", name = "lineString_spatial_idx"),
+		@Index(columnList = "multiLineString", name = "multiLineString_spatial_idx"),
+		@Index(columnList = "polygon", name = "polygon_spatial_idx"),
+		@Index(columnList = "multiPolygon", name = "multiPolygon_spatial_idx")
+})
+@IndexOptions({
+		@IndexOption(forIndex = "point_spatial_idx", options = "{ _type: '2dsphere' }"),
+		@IndexOption(forIndex = "multiPoint_spatial_idx", options = "{ _type: '2dsphere' }"),
+		@IndexOption(forIndex = "lineString_spatial_idx", options = "{ _type: '2dsphere' }"),
+		@IndexOption(forIndex = "multiLineString_spatial_idx", options = "{ _type: '2dsphere' }"),
+		@IndexOption(forIndex = "polygon_spatial_idx", options = "{ _type: '2dsphere' }"),
+		@IndexOption(forIndex = "multiPolygon_spatial_idx", options = "{ _type: '2dsphere' }")
+})
+public class GeoObject {
+
+	public static final String COLLECTION_NAME = "T_GEO_OBJECT";
+
+	@Id
+	private Long id;
+
+	private GeoPoint point;
+
+	private GeoMultiPoint multiPoint;
+
+	private GeoLineString lineString;
+
+	private GeoMultiLineString multiLineString;
+
+	private GeoPolygon polygon;
+
+	private GeoMultiPolygon multiPolygon;
+
+	public GeoObject() {
+	}
+
+	public GeoObject(Long id,
+			GeoPoint point,
+			GeoMultiPoint multiPoint,
+			GeoLineString lineString,
+			GeoMultiLineString multiLineString,
+			GeoPolygon polygon,
+			GeoMultiPolygon multiPolygon) {
+		this.id = id;
+		this.point = point;
+		this.multiPoint = multiPoint;
+		this.lineString = lineString;
+		this.multiLineString = multiLineString;
+		this.polygon = polygon;
+		this.multiPolygon = multiPolygon;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public GeoPoint getPoint() {
+		return point;
+	}
+
+	public void setPoint(GeoPoint point) {
+		this.point = point;
+	}
+
+	public GeoMultiPoint getMultiPoint() {
+		return multiPoint;
+	}
+
+	public void setMultiPoint(GeoMultiPoint multiPoint) {
+		this.multiPoint = multiPoint;
+	}
+
+	public GeoLineString getLineString() {
+		return lineString;
+	}
+
+	public void setLineString(GeoLineString lineString) {
+		this.lineString = lineString;
+	}
+
+	public GeoMultiLineString getMultiLineString() {
+		return multiLineString;
+	}
+
+	public void setMultiLineString(GeoMultiLineString multiLineString) {
+		this.multiLineString = multiLineString;
+	}
+
+	public GeoPolygon getPolygon() {
+		return polygon;
+	}
+
+	public void setPolygon(GeoPolygon polygon) {
+		this.polygon = polygon;
+	}
+
+	public GeoMultiPolygon getMultiPolygon() {
+		return multiPolygon;
+	}
+
+	public void setMultiPolygon(GeoMultiPolygon multiPolygon) {
+		this.multiPolygon = multiPolygon;
+	}
+
+	@Override
+	public String toString() {
+		return "GeoObject [id=" + id + "]";
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/MongoDBGeoObjectTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/MongoDBGeoObjectTest.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.spatial;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.datastore.mongodb.type.GeoLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiLineString;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoMultiPolygon;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPolygon;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the GeoJSON objects support for MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class MongoDBGeoObjectTest extends OgmTestCase {
+
+	private static final GeoPolygon BOUNDING_BOX = new GeoPolygon(
+			new GeoPoint( 4.814922, 45.7753612 ),
+			new GeoPoint( 4.8160825, 45.7327172 ),
+			new GeoPoint( 4.9281299, 45.7211302 ),
+			new GeoPoint( 4.8706127, 45.786724 ),
+			new GeoPoint( 4.814922, 45.7753612 )
+	);
+
+	private static final GeoPoint OURSON_QUI_BOIT = new GeoPoint( 4.835195, 45.7706477 );
+	private static final GeoPoint CHEZ_MARGOTTE = new GeoPoint( 4.8510299, 45.7530374 );
+	private static final GeoPoint IMOUTO = new GeoPoint( 4.8386221, 45.7541719 );
+	private static final GeoPoint PENJAB = new GeoPoint( 4.826229, 45.7611617 );
+	private static final GeoPoint ARSENIC = new GeoPoint( 4.8424062, 45.7591419 );
+
+	private static final GeoMultiPoint MULTI_POINT = new GeoMultiPoint( OURSON_QUI_BOIT, CHEZ_MARGOTTE, ARSENIC );
+
+	private static final GeoLineString LINE_STRING = new GeoLineString( OURSON_QUI_BOIT, CHEZ_MARGOTTE );
+	private static final GeoMultiLineString MULTI_LINE_STRING = new GeoMultiLineString(
+			LINE_STRING,
+			new GeoLineString( IMOUTO, PENJAB )
+	);
+
+	private static final GeoPolygon POLYGON = new GeoPolygon( OURSON_QUI_BOIT, PENJAB, IMOUTO, OURSON_QUI_BOIT );
+	private static final GeoMultiPolygon MULTI_POLYGON = new GeoMultiPolygon(
+			POLYGON,
+			new GeoPolygon( ARSENIC, CHEZ_MARGOTTE, IMOUTO, ARSENIC )
+	);
+
+	private final GeoObject geoObject = new GeoObject( 1L, OURSON_QUI_BOIT, MULTI_POINT, LINE_STRING, MULTI_LINE_STRING, POLYGON, MULTI_POLYGON );
+
+	@Before
+	public void init() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.persist( geoObject );
+			tx.commit();
+		}
+	}
+
+	@After
+	public void tearDown() throws InterruptedException {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			delete( session, geoObject );
+			tx.commit();
+		}
+	}
+
+	private void delete(final Session session, final GeoObject geoObject) {
+		Object entity = session.get( GeoObject.class, geoObject.getId() );
+		if ( entity != null ) {
+			session.delete( entity );
+		}
+	}
+
+	@Test
+	public void testBoundingBox() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			checkBoundingBoxResultForField( session, "point" );
+			checkBoundingBoxResultForField( session, "multiPoint" );
+			checkBoundingBoxResultForField( session, "lineString" );
+			checkBoundingBoxResultForField( session, "multiLineString" );
+			checkBoundingBoxResultForField( session, "polygon" );
+			checkBoundingBoxResultForField( session, "multiPolygon" );
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void checkBoundingBoxResultForField(OgmSession session, String field) {
+		Transaction transaction = session.beginTransaction();
+
+		Query query = session
+				.createNativeQuery( "{ " + field + ": { $geoWithin: { $geometry: " + BOUNDING_BOX.toBsonDocument() + " } } }" )
+				.addEntity( GeoObject.class );
+		List<GeoObject> result = query.list();
+
+		assertThat( result ).hasSize( 1 );
+
+		GeoObject geoObject = result.get( 0 );
+		assertThat( geoObject.getId() ).describedAs( "id" ).isEqualTo( 1L );
+		assertThat( geoObject.getPoint() ).describedAs( "point" ).isEqualTo( OURSON_QUI_BOIT );
+		assertThat( geoObject.getMultiPoint() ).describedAs( "multiPoint" ).isEqualTo( MULTI_POINT );
+		assertThat( geoObject.getLineString() ).describedAs( "lineString" ).isEqualTo( LINE_STRING );
+		assertThat( geoObject.getMultiLineString() ).describedAs( "multiLineString" ).isEqualTo( MULTI_LINE_STRING );
+		assertThat( geoObject.getPolygon() ).describedAs( "polygon" ).isEqualTo( POLYGON );
+		assertThat( geoObject.getMultiPolygon() ).describedAs( "multiPolygon" ).isEqualTo( MULTI_POLYGON );
+
+		transaction.commit();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ GeoObject.class };
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/MongoDBSpatialQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/MongoDBSpatialQueryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.spatial;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Demonstrate the spatial support for MongoDB.
+ *
+ * @author Guillaume Smet
+ */
+public class MongoDBSpatialQueryTest extends OgmTestCase {
+
+	private final Restaurant ourson = new Restaurant( 1L, "L'ourson qui boit", new GeoPoint( 4.835195, 45.7706477 ) );
+	private final Restaurant margotte = new Restaurant( 2L, "Chez Margotte", new GeoPoint( 4.8510299, 45.7530374 ) );
+	private final Restaurant imouto = new Restaurant( 3L, "Imouto", new GeoPoint( 4.8386221, 45.7541719 ) );
+
+	@Before
+	public void init() {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.persist( ourson );
+			session.persist( margotte );
+			session.persist( imouto );
+			tx.commit();
+		}
+	}
+
+	@After
+	public void tearDown() throws InterruptedException {
+		try ( Session session = openSession() ) {
+			Transaction tx = session.beginTransaction();
+			delete( session, ourson );
+			delete( session, margotte );
+			delete( session, imouto );
+			tx.commit();
+		}
+	}
+
+	private void delete(final Session session, final Restaurant restaurant) {
+		Object entity = session.get( Restaurant.class, restaurant.getId() );
+		if ( entity != null ) {
+			session.delete( entity );
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSpatialQuery() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Transaction transaction = session.beginTransaction();
+
+			Query query = session
+					.createNativeQuery( "{ location: { $near: { $geometry: { type: 'Point', coordinates: [4.8520035, 45.7498209] }, $maxDistance: 500 } } }" )
+					.addEntity( Restaurant.class );
+			List<Restaurant> result = query.list();
+
+			assertThat( result ).onProperty( "id" ).containsExactly( 2L );
+
+			query = session
+					.createNativeQuery( "{ location: { $near: { $geometry: { type: 'Point', coordinates: [4.8520035, 45.7498209] }, $maxDistance: 2000 } } }" )
+					.addEntity( Restaurant.class );
+			result = query.list();
+
+			assertThat( result ).onProperty( "id" ).containsExactly( 2L, 3L );
+
+			transaction.commit();
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Restaurant.class };
+	}
+}

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/Restaurant.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/spatial/Restaurant.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.spatial;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+import org.hibernate.ogm.datastore.mongodb.type.GeoPoint;
+import org.hibernate.ogm.options.shared.IndexOption;
+import org.hibernate.ogm.options.shared.IndexOptions;
+
+@Entity
+@Table(name = Restaurant.COLLECTION_NAME, indexes = {
+		@Index(columnList = "location", name = "location_spatial_idx")
+})
+@IndexOptions(
+		@IndexOption(forIndex = "location_spatial_idx", options = "{ _type: '2dsphere' }")
+)
+public class Restaurant {
+
+	public static final String COLLECTION_NAME = "T_RESTAURANT";
+
+	@Id
+	private Long id;
+
+	private String name;
+
+	private GeoPoint location;
+
+	public Restaurant() {
+	}
+
+	public Restaurant(Long id, String name, GeoPoint location) {
+		this.id = id;
+		this.name = name;
+		this.location = location;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public GeoPoint getLocation() {
+		return location;
+	}
+
+	public void setLocation(GeoPoint location) {
+		this.location = location;
+	}
+
+	@Override
+	public String toString() {
+		return "Restaurant [id=" + id + ", name=" + name + ", location=" + location + "]";
+	}
+}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/OGM-1339

@DavideD so here is my attempt at supporting geospatial queries for MongoDB. I added a `GeoPoint` type that end users can use for that.

I'm not sure it's something we should do but I think providing an easy way to have spatial queries in their applications could be appealing to users.

We could also try to support more types: https://docs.mongodb.com/manual/reference/geojson/ . It shouldn't be too hard.

Another possibility could be to allow an arbitrary object to be serialized as BSON to be stored in MongoDB and unserialized to a POJO. This project might be useful for that: https://github.com/michel-kraemer/bson4jackson . But it will probably be a bit fragile and defeat the purpose of using a JPA mapping.

The patch shouldn't be committed as is. Documentation is missing but I wanted to have a preliminary feedback before writing it.

Btw, I changed a bit how the type of the index is defined to be more generic. It still supports the `text: true` syntax but it's now recommended to use `_type: 'text'` or `_type: '2dsphere'`. I used an underscore to avoid conflicts with the MongoDB options.