### PR TITLE
OGM-1301 Improve error reporting of the MongoDB (#20)

### DIFF
--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
@@ -36,8 +36,8 @@ public class MongoDBQueryDescriptorBuilder {
 	 * Helper fields for recording the states of the parser
 	 */
 	private boolean isCliQuery;
-	private String invalidJsonInPrefix;
-	private boolean everyParameterIsValid;
+	private String invalidJsonParameter;
+	private boolean areParametersValid;
 	private String operationName;
 	private boolean isQueryValid;
 
@@ -122,13 +122,13 @@ public class MongoDBQueryDescriptorBuilder {
 		return true;
 	}
 
-	public boolean setInvalidJsonInPrefix(String invalidJsonInPrefix) {
-		this.invalidJsonInPrefix = invalidJsonInPrefix;
+	public boolean setInvalidJsonParameter(String invalidJsonParameter) {
+		this.invalidJsonParameter = invalidJsonParameter;
 		return true;
 	}
 
-	public boolean setEveryParameterIsValid(boolean everyParameterIsValid) {
-		this.everyParameterIsValid = everyParameterIsValid;
+	public boolean setParametersValid(boolean areParametersValid) {
+		this.areParametersValid = areParametersValid;
 		return true;
 	}
 
@@ -188,34 +188,36 @@ public class MongoDBQueryDescriptorBuilder {
 			if ( isCliQuery ) {
 				// db ???
 				if ( collection == null ) {
-					throw new NativeQueryParseException( "Cli query should match the format db.collection.oper()" );
+					throw new NativeQueryParseException( "Cli query should match the format db.collection.operation(<arguments>)" );
 				}
 				// db . collection ???
 				if ( operation == null && operationName == null ) {
-					throw new NativeQueryParseException( "Cli query should match the format db.collection.oper()" );
+					throw new NativeQueryParseException( "Cli query should match the format db.collection.operation(<arguments>)" );
 				}
 				// db . collection . UNSUPPORTED
 				if ( operation == null ) {
 					throw new NativeQueryParseException( "Operation '" + operationName + "' is unsupported" );
 				}
 				// db . collection . operation ( ???
-				if ( invalidJsonInPrefix != null ) {
+				if ( invalidJsonParameter != null ) {
 					try {
-						Document.parse( invalidJsonInPrefix );
+						Document.parse( invalidJsonParameter );
 					}
 					catch (JsonParseException e ) {
 						throw new NativeQueryParseException( e );
 					}
 				}
 				// db . collection . operation ( ???
-				if ( !everyParameterIsValid ) {
+				if ( !areParametersValid ) {
 					throw new NativeQueryParseException( "Parameters are invalid for " + operationName );
 				}
-				throw new NativeQueryParseException( "Missing ')'" );
+				else {
+					throw new NativeQueryParseException( "Missing ')'" );
+				}
 			}
 			// the input is not a json object: might be error in { ... } or does not start with '{'
 			try {
-				Document.parse( invalidJsonInPrefix );
+				Document.parse( invalidJsonParameter );
 			}
 			catch (JsonParseException e ) {
 				throw new NativeQueryParseException( e );

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/MongoDBQueryDescriptorBuilder.java
@@ -18,6 +18,7 @@ import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor.Ope
 import org.hibernate.ogm.util.impl.StringHelper;
 
 import org.bson.Document;
+import org.bson.json.JsonParseException;
 
 /**
  * Builder for {@link MongoDBQueryDescriptor}s.
@@ -30,6 +31,16 @@ public class MongoDBQueryDescriptorBuilder {
 
 	private String collection;
 	private Operation operation;
+
+	/**
+	 * Helper fields for recording the states of the parser
+	 */
+	private boolean isCliQuery;
+	private String invalidJsonInPrefix;
+	private boolean everyParameterIsValid;
+	private String operationName;
+	private boolean isQueryValid;
+
 	/**
 	 * Overloaded to be the 'document' for a FINDANDMODIFY query (which is a kind of criteria),
 	 */
@@ -102,6 +113,35 @@ public class MongoDBQueryDescriptorBuilder {
 		return true;
 	}
 
+	public boolean isCliQuery() {
+		return isCliQuery;
+	}
+
+	public boolean setCliQuery(boolean isCliQuery) {
+		this.isCliQuery = isCliQuery;
+		return true;
+	}
+
+	public boolean setInvalidJsonInPrefix(String invalidJsonInPrefix) {
+		this.invalidJsonInPrefix = invalidJsonInPrefix;
+		return true;
+	}
+
+	public boolean setEveryParameterIsValid(boolean everyParameterIsValid) {
+		this.everyParameterIsValid = everyParameterIsValid;
+		return true;
+	}
+
+	public boolean setOperationName(String operationName) {
+		this.operationName = operationName;
+		return true;
+	}
+
+	public boolean setQueryValid(boolean isQueryValid) {
+		this.isQueryValid = isQueryValid;
+		return true;
+	}
+
 	public boolean setCriteria(String criteria) {
 		this.criteria = criteria;
 		return true;
@@ -142,7 +182,46 @@ public class MongoDBQueryDescriptorBuilder {
 		return true;
 	}
 
-	public MongoDBQueryDescriptor build() {
+	public MongoDBQueryDescriptor build() throws NativeQueryParseException {
+		if ( !isQueryValid ) {
+			// the input is CLI query: it starts with 'db'
+			if ( isCliQuery ) {
+				// db ???
+				if ( collection == null ) {
+					throw new NativeQueryParseException( "Cli query should match the format db.collection.oper()" );
+				}
+				// db . collection ???
+				if ( operation == null && operationName == null ) {
+					throw new NativeQueryParseException( "Cli query should match the format db.collection.oper()" );
+				}
+				// db . collection . UNSUPPORTED
+				if ( operation == null ) {
+					throw new NativeQueryParseException( "Operation '" + operationName + "' is unsupported" );
+				}
+				// db . collection . operation ( ???
+				if ( invalidJsonInPrefix != null ) {
+					try {
+						Document.parse( invalidJsonInPrefix );
+					}
+					catch (JsonParseException e ) {
+						throw new NativeQueryParseException( e );
+					}
+				}
+				// db . collection . operation ( ???
+				if ( !everyParameterIsValid ) {
+					throw new NativeQueryParseException( "Parameters are invalid for " + operationName );
+				}
+				throw new NativeQueryParseException( "Missing ')'" );
+			}
+			// the input is not a json object: might be error in { ... } or does not start with '{'
+			try {
+				Document.parse( invalidJsonInPrefix );
+			}
+			catch (JsonParseException e ) {
+				throw new NativeQueryParseException( e );
+			}
+		}
+
 		//@todo refactor the spaghetti!
 		if ( operation != Operation.AGGREGATE_PIPELINE ) {
 			MongoDBQueryDescriptor descriptor = null;

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParseException.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParseException.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl;
+
+/**
+ *  An exception thrown by {@link MongoDBQueryDescriptorBuilder}
+ *  if the input is not correct.
+ */
+public class NativeQueryParseException extends RuntimeException {
+	public NativeQueryParseException(String message) {
+		super( message );
+	}
+
+	public NativeQueryParseException(Exception e) {
+		super( e );
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
@@ -534,8 +534,9 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 			return String( string );
 		}
 	}
+
 	String readStringFromJson(String json) {
-		try (JsonReader jsonReader = new JsonReader(json) ){
+		try ( JsonReader jsonReader = new JsonReader( json ) ) {
 			return jsonReader.readString();
 		}
 	}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/nativequery/impl/NativeQueryParser.java
@@ -8,13 +8,13 @@ package org.hibernate.ogm.datastore.mongodb.query.parsing.nativequery.impl;
 
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor.Operation;
 
+import com.mongodb.util.JSON;
+import org.bson.json.JsonReader;
 import org.parboiled.BaseParser;
 import org.parboiled.Rule;
 import org.parboiled.annotations.BuildParseTree;
 import org.parboiled.annotations.SuppressNode;
 import org.parboiled.annotations.SuppressSubnodes;
-
-import com.mongodb.util.JSON;
 
 /**
  * A parser for MongoDB queries which can be given in one of the following representations:
@@ -356,7 +356,7 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 				"distinct ",
 				builder.setOperation( Operation.DISTINCT ),
 				"( ",
-				Sequence( JsonString(), builder.setDistinctFieldName( JSON.parse( match() ).toString() ) ),
+				Sequence( JsonString(), builder.setDistinctFieldName( readStringFromJson( match() ) ) ),
 				Optional( Sequence( ", ", JsonObject(), builder.setCriteria( match() ) ) ),
 				Optional( Sequence( ", ", JsonObject(), builder.setOptions( match() ) ) ),
 				builder.setEveryParameterIsValid( true ),
@@ -369,8 +369,8 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 				"mapReduce ",
 				builder.setOperation( Operation.MAP_REDUCE ),
 				"( ",
-				Sequence( JsonString(), builder.setMapFunction( JSON.parse( match() ).toString() ) ),
-				Sequence( ", ", JsonString(), builder.setReduceFunction( JSON.parse( match() ).toString() ) ),
+				Sequence( JsonString(), builder.setMapFunction( readStringFromJson( match() ) ) ),
+				Sequence( ", ", JsonString(), builder.setReduceFunction( readStringFromJson( match() ) ) ),
 				Optional( Sequence( ", ", JsonObject(), builder.setOptions( match() ) ) ),
 				builder.setEveryParameterIsValid( true ),
 				") "
@@ -532,6 +532,11 @@ public class NativeQueryParser extends BaseParser<MongoDBQueryDescriptorBuilder>
 		}
 		else {
 			return String( string );
+		}
+	}
+	String readStringFromJson(String json) {
+		try (JsonReader jsonReader = new JsonReader(json) ){
+			return jsonReader.readString();
 		}
 	}
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/nativequery/NativeQueryParserTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/parsing/nativequery/NativeQueryParserTest.java
@@ -869,7 +869,7 @@ public class NativeQueryParserTest {
 			Assert.fail( "An exception was expected" );
 		}
 		catch (Exception e) {
-			assertThat( e ).isInstanceOf( NativeQueryParseException.class ).hasMessage( "Cli query should match the format db.collection.oper()" );
+			assertThat( e ).isInstanceOf( NativeQueryParseException.class ).hasMessage( "Cli query should match the format db.collection.operation(<arguments>)" );
 		}
 	}
 
@@ -884,7 +884,7 @@ public class NativeQueryParserTest {
 			Assert.fail( "An exception was expected" );
 		}
 		catch (Exception e) {
-			assertThat( e ).isInstanceOf( NativeQueryParseException.class ).hasMessage( "Cli query should match the format db.collection.oper()" );
+			assertThat( e ).isInstanceOf( NativeQueryParseException.class ).hasMessage( "Cli query should match the format db.collection.operation(<arguments>)" );
 		}
 	}
 
@@ -951,7 +951,7 @@ public class NativeQueryParserTest {
 	}
 
 	@Test
-	public void shouldRecognizeMissingDBPart() { // ????
+	public void shouldRecognizeMissingDBPart() {
 		try {
 			NativeQueryParser parser = Parboiled.createParser( NativeQueryParser.class );
 			ParsingResult<MongoDBQueryDescriptorBuilder> run = new BasicParseRunner<MongoDBQueryDescriptorBuilder>( parser.Query() )


### PR DESCRIPTION
This is a version based on @gsmet's ideas from https://hibernate.atlassian.net/browse/OGM-1301 (I've written another [version](https://github.com/hibernate/hibernate-ogm/pull/908) but I think this is one is a little better).

Basically now when the parser hits some rules it updates the state of the builder so if the input is not valid the builder is able to produce adequate errors/suggestions. If the parser fails the rule it might also capture the input and put it in the state.

Some details and tricks for this version:
- Invoking `build` method might result in `NativeQueryParseErrror` which contains error messages or wraps JsonParseException.
- `CriteriaOnlyFindQuery` is more restrictive: now it does not match anything and can fail. However the `Query` rule behaves as before: it matches everything and stores the builder in the result stack (this is done by optionally trying the query rules and pushing the builder after).
- When the parser hits the `JsonObject` rule it stores the string if matching has failed. (this is done with `rule / ( action FAIL)`, this almost the same as something used in [peg](http://piumarta.com/software/peg/peg.1.html)  tool `exp ~ { action }`)

(about the stateless parser suggestion in the previous pull request: I think it would be easy to implement this by simply pushing the new builder to the value stack when the `Query` rule is invoked and every time we need the builder call the `peek()` method of the value stack but I'm not sure it is the best way)