### PR TITLE
OGM-571 Create-drop schema option

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/datastore/spi/BaseSchemaDefiner.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/spi/BaseSchemaDefiner.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.ogm.datastore.spi;
 
-
 /**
  * Default implementation of {@link SchemaDefiner}. Specific implementations can override those hooks they're
  * interested in. Also provides utility methods useful for implementors.
@@ -16,12 +15,18 @@ package org.hibernate.ogm.datastore.spi;
 public class BaseSchemaDefiner implements SchemaDefiner {
 
 	@Override
-	public void validateMapping(SchemaDefinitionContext context) {
-		// No-op
+	public void initializeSchema(SchemaDefinitionContext context) {
 	}
 
 	@Override
-	public void initializeSchema(SchemaDefinitionContext context) {
-		// No-op
+	public void createSchema(SchemaDefinitionContext context) {
+	}
+
+	@Override
+	public void validateSchema(SchemaDefinitionContext context) {
+	}
+
+	@Override
+	public void dropSchema(SchemaDefinitionContext context) {
 	}
 }

--- a/core/src/main/java/org/hibernate/ogm/datastore/spi/SchemaDefiner.java
+++ b/core/src/main/java/org/hibernate/ogm/datastore/spi/SchemaDefiner.java
@@ -39,19 +39,17 @@ import org.hibernate.service.spi.ServiceRegistryAwareService;
 public interface SchemaDefiner extends Service {
 
 	/**
-	 * Validates the mapped objects such as entities, id generators etc. against any specific requirements of the
-	 * current datastore.
-	 *
-	 * @param context Provides access to metadata describing the schema to be validated
-	 */
-	void validateMapping(SchemaDefinitionContext context);
-
-	/**
 	 * Initializes the schema in the datastore.
 	 *
 	 * @param context Provides access to metadata describing the schema to be initialized
 	 */
 	void initializeSchema(SchemaDefinitionContext context);
+
+	void createSchema(SchemaDefinitionContext context);
+
+	void validateSchema(SchemaDefinitionContext context);
+
+	void dropSchema(SchemaDefinitionContext context);
 
 	/**
 	 * Provides contextual information about the schema objects to be created. Schema initialization should primarily be

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaCreator.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaCreator.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner.SchemaDefinitionContext;
+import org.hibernate.ogm.service.impl.DefaultSchemaInitializationContext;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaCreator;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+/**
+ * @author Davide D'Alto
+ */
+class NoSqlSchemaCreator extends SchemaAction implements SchemaCreator {
+
+	private final SessionFactoryImplementor factory;
+
+	public NoSqlSchemaCreator(SessionFactoryImplementor factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public void doCreation(Metadata metadata, ExecutionOptions options, SourceDescriptor sourceDescriptor, TargetDescriptor targetDescriptor) {
+		validate( sourceDescriptor, targetDescriptor );
+
+		SchemaDefinitionContext context = new DefaultSchemaInitializationContext( metadata.getDatabase(), factory );
+		SchemaDefiner schemaInitializer = createSchemaInitializer( factory, metadata );
+		schemaInitializer.createSchema( context );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaDropper.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaDropper.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner.SchemaDefinitionContext;
+import org.hibernate.ogm.service.impl.DefaultSchemaInitializationContext;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.spi.DelayedDropAction;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaDropper;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+/**
+ * @author Davide D'Alto
+ */
+class NoSqlSchemaDropper extends SchemaAction implements SchemaDropper {
+
+	private final SessionFactoryImplementor factory;
+
+	public NoSqlSchemaDropper(SessionFactoryImplementor factory) {
+		this.factory = factory;
+	}
+
+	public NoSqlSchemaDropper(SessionFactoryImplementor factory, NoSqlSchemaManagementTool tool) {
+		this.factory = factory;
+	}
+
+	@Override
+	public void doDrop(Metadata metadata, ExecutionOptions options, SourceDescriptor sourceDescriptor, TargetDescriptor targetDescriptor) {
+		validate( sourceDescriptor, targetDescriptor );
+
+		SchemaDefinitionContext context = new DefaultSchemaInitializationContext( metadata.getDatabase(), factory );
+		SchemaDefiner schemaDefiner = createSchemaInitializer( factory, metadata );
+		schemaDefiner.dropSchema( context );
+	}
+
+	@Override
+	public DelayedDropAction buildDelayedAction(Metadata metadata, ExecutionOptions options, SourceDescriptor sourceDescriptor) {
+		SchemaDefinitionContext context = new DefaultSchemaInitializationContext( metadata.getDatabase(), factory );
+		return new DropAction( context );
+	}
+
+	private static class DropAction implements DelayedDropAction {
+
+		private SchemaDefinitionContext context;
+
+		public DropAction(SchemaDefinitionContext context) {
+			this.context = context;
+		}
+
+		@Override
+		public void perform(ServiceRegistry serviceRegistry) {
+			SchemaDefiner schemaDefiner = serviceRegistry.getService( SchemaDefiner.class );
+			schemaDefiner.dropSchema( context );
+		}
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaManagementTool.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaManagementTool.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import java.util.Map;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.tool.schema.spi.SchemaCreator;
+import org.hibernate.tool.schema.spi.SchemaDropper;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+import org.hibernate.tool.schema.spi.SchemaMigrator;
+import org.hibernate.tool.schema.spi.SchemaValidator;
+
+/**
+ * A {@link SchemaManagementTool} for NoSql datastores in OGM.
+ *
+ * @author Gunnar Morling
+ */
+
+/*
+ * Note: For now we ignore given {@link Target}s due to the way they are used in ORM's {@link SchemaDefiner}: Instead of
+ * passing the actual targets (for denoting stout/file/database), a helper target is used for collecting all SQL
+ * commands there. As long as that's the case we cannot really derive the intended export target from that. {@code
+ * SchemaExport} is in a transitional state as per Steve, so we should be able to do the right thing down the road. For
+ * now, only DB export will be supported, but no file exports (if feasible with given stores anyways, e.g. for MongoDB
+ * it will be hard to come up with sensible file exports; We could create JavaScript commands representing "DDL", but
+ * it'd be tough to re-import and execute them later on).
+ */
+public class NoSqlSchemaManagementTool implements SchemaManagementTool {
+
+	private final SessionFactoryImplementor factory;
+
+	public NoSqlSchemaManagementTool(SessionFactoryImplementor sessionFactory) {
+		this.factory = sessionFactory;
+	}
+
+	@Override
+	public SchemaCreator getSchemaCreator(Map options) {
+		return new NoSqlSchemaCreator( factory );
+	}
+
+	@Override
+	public SchemaDropper getSchemaDropper(Map options) {
+		return new NoSqlSchemaDropper( factory );
+	}
+
+	@Override
+	public SchemaMigrator getSchemaMigrator(Map options) {
+		throw new UnsupportedOperationException( "Schema migration is not supported yet" );
+	}
+
+	@Override
+	public SchemaValidator getSchemaValidator(Map options) {
+		return new NoSqlSchemaValidator( factory );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaManagementToolInitiator.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaManagementToolInitiator.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.spi.SessionFactoryServiceInitiator;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+
+/**
+ * @author Gunnar Morling
+ */
+public class NoSqlSchemaManagementToolInitiator implements SessionFactoryServiceInitiator<SchemaManagementTool> {
+
+	public static final NoSqlSchemaManagementToolInitiator INSTANCE = new NoSqlSchemaManagementToolInitiator();
+
+	@Override
+	public SchemaManagementTool initiateService(SessionFactoryImplementor sessionFactory, SessionFactoryOptions sessionFactoryOptions,
+			ServiceRegistryImplementor registry) {
+
+		final Object setting = registry.getService( ConfigurationService.class ).getSettings().get( AvailableSettings.SCHEMA_MANAGEMENT_TOOL );
+		SchemaManagementTool tool = registry.getService( StrategySelector.class ).resolveStrategy( SchemaManagementTool.class, setting );
+		if ( tool == null ) {
+			tool = new NoSqlSchemaManagementTool( sessionFactory );
+		}
+
+		return tool;
+	}
+
+	@Override
+	public Class<SchemaManagementTool> getServiceInitiated() {
+		return SchemaManagementTool.class;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaValidator.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/NoSqlSchemaValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner.SchemaDefinitionContext;
+import org.hibernate.ogm.service.impl.DefaultSchemaInitializationContext;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaValidator;
+
+/**
+ * @author Davide D'Alto
+ */
+public class NoSqlSchemaValidator extends SchemaAction implements SchemaValidator {
+
+	private final SessionFactoryImplementor factory;
+
+	public NoSqlSchemaValidator(SessionFactoryImplementor factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public void doValidation(Metadata metadata, ExecutionOptions options) {
+		SchemaDefinitionContext context = new DefaultSchemaInitializationContext( metadata.getDatabase(), factory );
+		SchemaDefiner schemaInitializer = createSchemaInitializer( factory, metadata );
+		schemaInitializer.validateSchema( context );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/schema/impl/SchemaAction.java
+++ b/core/src/main/java/org/hibernate/ogm/schema/impl/SchemaAction.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.schema.impl;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.ogm.datastore.spi.SchemaDefiner;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.tool.schema.SourceType;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+/**
+ * A common base class for the operations to execute on a schema.
+ *
+ * @author Davide D'Alto
+ */
+abstract class SchemaAction {
+
+	SchemaDefiner createSchemaInitializer(SessionFactoryImplementor factory, Metadata metadata) {
+		ServiceRegistryImplementor registry = factory.getServiceRegistry();
+		SchemaDefiner schemaInitializer = registry.getService( SchemaDefiner.class );
+		return schemaInitializer;
+	}
+
+	void validate(SourceDescriptor sourceDescriptor, TargetDescriptor targetDescriptor) {
+		if ( sourceDescriptor.getSourceType() != SourceType.METADATA ) {
+			throw new UnsupportedOperationException( "Import scripts for schema creation are not supported at this point by Hibernate OGM" );
+		}
+
+		if ( targetDescriptor.getTargetTypes().contains( TargetType.SCRIPT ) ) {
+			throw new UnsupportedOperationException( "Only schema export to the datastore is supported at this point by Hibernate OGM" );
+		}
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/service/impl/OgmSessionFactoryServiceInitiators.java
+++ b/core/src/main/java/org/hibernate/ogm/service/impl/OgmSessionFactoryServiceInitiators.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.ogm.datastore.impl.SchemaDefinerInitiator;
+import org.hibernate.ogm.schema.impl.NoSqlSchemaManagementToolInitiator;
 import org.hibernate.ogm.type.impl.TypeTranslatorInitiator;
 import org.hibernate.service.spi.SessionFactoryServiceInitiator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
@@ -27,6 +28,7 @@ public class OgmSessionFactoryServiceInitiators {
 			QueryParserServicesInitiator.INSTANCE,
 			SchemaDefinerInitiator.INSTANCE,
 			NativeNoSqlQueryInterpreterInitiator.INSTANCE,
-			TypeTranslatorInitiator.INSTANCE
+			TypeTranslatorInitiator.INSTANCE,
+			NoSqlSchemaManagementToolInitiator.INSTANCE
 	) );
 }

--- a/core/src/main/java/org/hibernate/ogm/service/impl/SchemaDefiningObserver.java
+++ b/core/src/main/java/org/hibernate/ogm/service/impl/SchemaDefiningObserver.java
@@ -38,7 +38,6 @@ public class SchemaDefiningObserver implements SessionFactoryObserver {
 				sessionFactoryImplementor
 		);
 
-		schemaInitializer.validateMapping( context );
 		schemaInitializer.initializeSchema( context );
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredProgrammaticallyTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/associations/storageconfiguration/AssociationStorageConfiguredProgrammaticallyTest.java
@@ -211,25 +211,29 @@ public class AssociationStorageConfiguredProgrammaticallyTest extends Associatio
 	@After
 	public void removeCloudAndSnowflakes() {
 		if ( sessions != null ) {
-			try ( Session session = sessions.openSession() ) {
-				Transaction transaction = session.beginTransaction();
+			try {
+				try ( Session session = sessions.openSession() ) {
+					Transaction transaction = session.beginTransaction();
 
-				if ( cloud != null ) {
-					Cloud cloudToDelete = (Cloud) session.get( Cloud.class, cloud.getId() );
-					for ( SnowFlake current : cloudToDelete.getProducedSnowFlakes() ) {
-						session.delete( current );
+					if ( cloud != null ) {
+						Cloud cloudToDelete = (Cloud) session.get( Cloud.class, cloud.getId() );
+						for ( SnowFlake current : cloudToDelete.getProducedSnowFlakes() ) {
+							session.delete( current );
+						}
+						for ( SnowFlake current : cloudToDelete.getBackupSnowFlakes() ) {
+							session.delete( current );
+						}
+						session.delete( cloudToDelete );
 					}
-					for ( SnowFlake current : cloudToDelete.getBackupSnowFlakes() ) {
-						session.delete( current );
-					}
-					session.delete( cloudToDelete );
+
+					transaction.commit();
 				}
-
-				transaction.commit();
+				assertThat( TestHelper.getNumberOfEntities( sessions ) ).isEqualTo( 0 );
+				assertThat( TestHelper.getNumberOfAssociations( sessions ) ).isEqualTo( 0 );
 			}
-
-			assertThat( TestHelper.getNumberOfEntities( sessions ) ).isEqualTo( 0 );
-			assertThat( TestHelper.getNumberOfAssociations( sessions ) ).isEqualTo( 0 );
+			finally {
+				sessions.close();
+			}
 		}
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAStandaloneORMAndOGMTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/jpa/JPAStandaloneORMAndOGMTest.java
@@ -6,9 +6,12 @@
  */
 package org.hibernate.ogm.backendtck.jpa;
 
+import java.util.Map;
+
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.ogm.utils.PackagingRule;
 import org.hibernate.ogm.utils.TestHelper;
 import org.junit.Rule;
@@ -25,12 +28,13 @@ public class JPAStandaloneORMAndOGMTest {
 	@Test
 	//Test for OGM-416 (avoid StackOverFlow when both an OGM and ORM PU are used
 	public void testJTAStandaloneNoOgm() throws Exception {
-		EntityManagerFactory emf = Persistence.createEntityManagerFactory(
-				"ogm", TestHelper.getDefaultTestSettings()
-		);
+		Map<String, String> settings = TestHelper.getDefaultTestSettings();
+		settings.put( AvailableSettings.HBM2DDL_AUTO, "none"  );
+
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory( "ogm", settings );
 		emf.close();
-		emf = Persistence.createEntityManagerFactory( "no-ogm" );
+
+		emf = Persistence.createEntityManagerFactory( "no-ogm", settings );
 		emf.close();
 	}
-
 }

--- a/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/OgmTestRunner.java
@@ -115,6 +115,7 @@ public class OgmTestRunner extends SkippableTestRunner {
 		if ( isTestScopedSessionFactoryRequired() ) {
 			testScopedSessionFactory = buildSessionFactory();
 			injectSessionFactory( null, testScopedFactoryFields, testScopedSessionFactory );
+			TestHelper.prepareDatabase( testScopedSessionFactory );
 		}
 
 		try {
@@ -134,6 +135,7 @@ public class OgmTestRunner extends SkippableTestRunner {
 		// create test method scoped SF if required; it will be injected in createTest()
 		if ( isTestMethodScopedSessionFactoryRequired( method ) ) {
 			testMethodScopedSessionFactory = buildSessionFactory();
+			TestHelper.prepareDatabase( testScopedSessionFactory );
 		}
 
 		try {

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.utils;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -43,7 +44,6 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.options.navigation.GlobalContext;
 import org.hibernate.ogm.util.impl.Log;
 import org.hibernate.ogm.util.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.sun.tools.javac.util.ServiceLoader;

--- a/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/TestHelper.java
@@ -239,8 +239,8 @@ public class TestHelper {
 	public static Map<String, String> getDefaultTestSettings() {
 		Map<String, String> settings = new HashMap<>();
 		settings.put( OgmProperties.ENABLED, "true" );
-		settings.put( Environment.HBM2DDL_AUTO, "none" );
 		settings.put( "hibernate.search.default.directory_provider", "ram" );
+		settings.put( Environment.HBM2DDL_AUTO, "create-drop" );
 		settings.putAll( HELPER.getAdditionalConfigurationProperties() );
 		return settings;
 	}
@@ -293,6 +293,7 @@ public class TestHelper {
 	public static <D extends DatastoreConfiguration<G>, G extends GlobalContext<?, ?>> G configureOptionsFor(Map<String, Object> settings, Class<D> datastoreType) {
 		ConfigurableImpl configurable = new ConfigurableImpl();
 		settings.put( InternalProperties.OGM_OPTION_CONTEXT, configurable.getContext() );
+		settings.put( Environment.HBM2DDL_AUTO, "create-drop" );
 		return configurable.configureOptionsFor( datastoreType );
 	}
 

--- a/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestRunner.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/jpa/OgmJpaTestRunner.java
@@ -147,6 +147,7 @@ public class OgmJpaTestRunner extends SkippableTestRunner {
 		// create test method scoped SF if required; it will be injected in createTest()
 		if ( isTestMethodScopedEntityManagerFactoryRequired( method ) ) {
 			testMethodScopedEntityManagerFactory = buildEntityManagerFactory();
+			TestHelper.prepareDatabase( testScopedEntityManagerFactory );
 		}
 
 		try {
@@ -155,6 +156,7 @@ public class OgmJpaTestRunner extends SkippableTestRunner {
 		finally {
 			if ( testMethodScopedEntityManagerFactory != null ) {
 				cleanUpPendingTransactionIfRequired( testMethodScopedEntityManagerFactory );
+				TestHelper.dropSchemaAndDatabase( testScopedEntityManagerFactory );
 				testMethodScopedEntityManagerFactory.close();
 			}
 		}

--- a/core/src/test/resources/hibernate.properties
+++ b/core/src/test/resources/hibernate.properties
@@ -8,3 +8,4 @@
 #@author Emmanuel Bernard
 hibernate.search.lucene_version=LUCENE_CURRENT
 hibernate.ogm.datastore.provider=map
+javax.persistence.schema-generation.database.action=create-drop

--- a/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
@@ -210,11 +210,11 @@ The following two strategies exist (values of the `org.hibernate.ogm.datastore.k
 
 +
 Defaults to `CACHE_PER_TABLE`. It is the recommended strategy as it makes it easier to target a specific cache for a given entity.
-`hibernate.ogm.datastore.create_database`::
-If set to `true` Hibernate OGM will create any missing Cache definitions on the Infinispan Server.
+`javax.persistence.schema-generation.database.action`::
+If set to `create`, `create-drop` or `create-only` Hibernate OGM will create any missing Cache definitions on the Infinispan Server.
 This requires the Infinispan Server configuration to have a default configuration defined, as this will be copied to the newly defined caches.
-If set to `false` an exception is thrown when a Cache is expected but not explicitly configured on the server.
-Defaults to `false`.
+If set to `none` or `validate` an exception is thrown when a Cache is expected but not explicitly configured on the server.
+Defaults to `none`.
 
 [NOTE]
 ====

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteConfiguration.java
@@ -19,7 +19,6 @@ import java.util.Properties;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.internal.util.collections.ArrayHelper;
-import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties;
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.OgmProtoStreamMarshaller;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
@@ -104,8 +103,6 @@ public class InfinispanRemoteConfiguration {
 
 	private Properties clientProperties;
 
-	private boolean createCachesEnabled;
-
 	/**
 	 * The location of the configuration file.
 	 *
@@ -135,10 +132,6 @@ public class InfinispanRemoteConfiguration {
 
 	public String getSchemaPackageName() {
 		return schemaPackageName;
-	}
-
-	public boolean isCreateCachesEnabled() {
-		return createCachesEnabled;
 	}
 
 	/**
@@ -171,11 +164,6 @@ public class InfinispanRemoteConfiguration {
 		this.schemaPackageName = propertyReader
 				.property( InfinispanRemoteProperties.SCHEMA_PACKAGE_NAME, String.class )
 				.withDefault( InfinispanRemoteProperties.DEFAULT_SCHEMA_PACKAGE_NAME )
-				.getValue();
-
-		this.createCachesEnabled = propertyReader
-				.property( OgmProperties.CREATE_DATABASE, boolean.class )
-				.withDefault( false )
 				.getValue();
 
 		log.tracef( "Initializing Infinispan Hot Rod client from configuration file at '%1$s'", configurationResource );

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/CacheNotDefinedTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/CacheNotDefinedTest.java
@@ -15,11 +15,13 @@ import javax.persistence.Table;
 
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteProperties;
 import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
 import org.hibernate.ogm.utils.TestForIssue;
 import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.tool.schema.Action;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -63,7 +65,7 @@ public class CacheNotDefinedTest {
 		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_remote" );
 		settings.put( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, "hotrod-client-testingconfiguration.properties" );
 		// This is the important option
-		settings.put( OgmProperties.CREATE_DATABASE, false );
+		settings.put( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.VALIDATE );
 
 		try ( SessionFactory sessionFactory = TestHelper.getDefaultTestSessionFactory( settings, entities ) ) {
 			Assert.fail( "This should have refused to boot because the caches don't exist" );

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/ProtoBufSchemaTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/initialize/ProtoBufSchemaTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.backendtck.associations.collection.unidirectional.Cloud;
 import org.hibernate.ogm.backendtck.associations.collection.unidirectional.SnowFlake;
 import org.hibernate.ogm.backendtck.id.Actor;
@@ -30,6 +31,7 @@ import org.hibernate.ogm.datastore.infinispanremote.schema.spi.ProvidedSchemaOve
 import org.hibernate.ogm.datastore.infinispanremote.schema.spi.SchemaOverride;
 import org.hibernate.ogm.datastore.infinispanremote.utils.RemoteHotRodServerRule;
 import org.hibernate.ogm.utils.TestHelper;
+import org.hibernate.tool.schema.Action;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -108,7 +110,7 @@ public class ProtoBufSchemaTest {
 		Map<String, Object> settings = new HashMap<>();
 		settings.put( OgmProperties.DATASTORE_PROVIDER, "infinispan_remote" );
 		settings.put( InfinispanRemoteProperties.CONFIGURATION_RESOURCE_NAME, "hotrod-client-testingconfiguration.properties" );
-		settings.put( OgmProperties.CREATE_DATABASE, true );
+		settings.put( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION, Action.CREATE_DROP );
 		return settings;
 	}
 

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/utils/InfinispanRemoteTestHelper.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.datastore.document.options.AssociationStorageType;
 import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDataStoreConfiguration;
 import org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect;
@@ -71,7 +71,7 @@ public class InfinispanRemoteTestHelper extends BaseGridDialectTestHelper implem
 
 	@Override
 	public Map<String, String> getAdditionalConfigurationProperties() {
-		return Collections.singletonMap( OgmProperties.CREATE_DATABASE, "true" );
+		return Collections.singletonMap( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION, "create-drop" );
 	}
 
 	@Override

--- a/infinispan-remote/src/test/resources/hibernate.properties
+++ b/infinispan-remote/src/test/resources/hibernate.properties
@@ -4,7 +4,7 @@
 # License: GNU Lesser General Public License (LGPL), version 2.1 or later
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
+javax.persistence.schema-generation.database.action=create-drop
 hibernate.search.lucene_version=LUCENE_CURRENT
 hibernate.ogm.datastore.provider=infinispan_remote
 hibernate.ogm.infinispan_remote.configuration_resource_name=hotrod-client-testingconfiguration.properties
-hibernate.ogm.create_database=true

--- a/infinispan/src/test/resources/hibernate.properties
+++ b/infinispan/src/test/resources/hibernate.properties
@@ -6,6 +6,7 @@
 #
 
 #@author Emmanuel Bernard
+javax.persistence.schema-generation.database.action=create-drop
 hibernate.search.lucene_version=LUCENE_CURRENT
 hibernate.ogm.datastore.provider=infinispan
 hibernate.ogm.infinispan.configuration_resource_name=infinispan-local.xml

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/InfinispanModuleMemberRegistrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.test.integration.infinispan;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.test.integration.testcase.ModuleMemberRegistrationScenario;
 import org.hibernate.ogm.test.integration.testcase.util.ModuleMemberRegistrationDeployment;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,6 +41,7 @@ public class InfinispanModuleMemberRegistrationIT extends ModuleMemberRegistrati
 				.name( "primary" )
 				.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
 				.getOrCreateProperties()
+				.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 				.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_embedded" ).up()
 				.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispan/SearchIntegrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.test.integration.infinispan;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.test.integration.testcase.MagiccardsDatabaseScenario;
 import org.hibernate.ogm.test.integration.testcase.controller.MagicCardsCollectionBean;
 import org.hibernate.ogm.test.integration.testcase.model.MagicCard;
@@ -46,6 +47,7 @@ public class SearchIntegrationIT extends MagiccardsDatabaseScenario {
 					.name( "primary" )
 					.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
 					.getOrCreateProperties()
+						.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 						.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_embedded" ).up()
 						.createProperty().name( "hibernate.ogm.infinispan.configuration_resourcename" ).value( "infinispan.xml" ).up()

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodSearchIntegrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/infinispanremote/HotRodSearchIntegrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.test.integration.infinispanremote;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.test.integration.testcase.MagiccardsDatabaseScenario;
 import org.hibernate.ogm.test.integration.testcase.controller.MagicCardsCollectionBean;
 import org.hibernate.ogm.test.integration.testcase.model.MagicCard;
@@ -48,6 +49,7 @@ public class HotRodSearchIntegrationIT extends MagiccardsDatabaseScenario {
 					.name( "primary" )
 					.provider( "org.hibernate.ogm.jpa.HibernateOgmPersistence" )
 					.getOrCreateProperties()
+						.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 						.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 						.createProperty().name( "hibernate.ogm.datastore.provider" ).value( "infinispan_remote" ).up()
 						.createProperty().name( "hibernate.ogm.infinispan_remote.configuration_resource_name" ).value( "hotrod-client-configuration.properties" ).up()

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/mongodb/MongoDBModuleMemberRegistrationIT.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.compensation.ErrorHandler.RollbackContext;
 import org.hibernate.ogm.compensation.operation.CreateTuple;
@@ -90,6 +91,7 @@ public class MongoDBModuleMemberRegistrationIT extends ModuleMemberRegistrationS
 			propertiesContext.createProperty().name( OgmProperties.PASSWORD ).value( password );
 		}
 		return propertiesContext
+					.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 					.createProperty().name( OgmProperties.DATASTORE_PROVIDER ).value( MongoDB.DATASTORE_PROVIDER_NAME ).up()
 					.createProperty().name( OgmProperties.DATABASE ).value( "ogm_test_database" ).up()
 					.createProperty().name( OgmProperties.CREATE_DATABASE ).value( "true" ).up()

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jJtaModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jJtaModuleMemberRegistrationIT.java
@@ -9,6 +9,7 @@ package org.hibernate.ogm.test.integration.neo4j.embedded;
 import java.io.File;
 import java.io.InputStream;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.datastore.neo4j.Neo4j;
 import org.hibernate.ogm.datastore.neo4j.Neo4jProperties;
 import org.hibernate.ogm.jpa.HibernateOgmPersistence;
@@ -52,6 +53,7 @@ public class EmbeddedNeo4jJtaModuleMemberRegistrationIT extends Neo4jModuleMembe
 				.provider( HibernateOgmPersistence.class.getName() )
 				.getOrCreateProperties();
 		PersistenceDescriptor persistenceDescriptor = propertiesContext
+				.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 				.createProperty().name( Neo4jProperties.DATASTORE_PROVIDER ).value( Neo4j.EMBEDDED_DATASTORE_PROVIDER_NAME ).up()
 				.createProperty()
 				.name( Neo4jProperties.DATABASE_PATH )

--- a/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT.java
+++ b/integrationtest/src/test/java/org/hibernate/ogm/test/integration/neo4j/embedded/EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.test.integration.neo4j.embedded;
 
+import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.ogm.datastore.neo4j.Neo4j;
 import org.hibernate.ogm.datastore.neo4j.Neo4jProperties;
 import org.hibernate.ogm.jpa.HibernateOgmPersistence;
@@ -49,6 +50,7 @@ public class EmbeddedNeo4jResourceLocalModuleMemberRegistrationIT extends Neo4jM
 				.provider( HibernateOgmPersistence.class.getName() )
 				.getOrCreateProperties();
 		PersistenceDescriptor persistenceDescriptor = propertiesContext
+				.createProperty().name( AvailableSettings.SCHEMA_GEN_DATABASE_ACTION ).value( "create-drop" ).up()
 				.createProperty().name( Neo4jProperties.DATASTORE_PROVIDER ).value( Neo4j.EMBEDDED_DATASTORE_PROVIDER_NAME ).up()
 				.createProperty().name( Neo4jProperties.DATABASE_PATH ).value( EmbeddedNeo4jJtaModuleMemberRegistrationIT.neo4jFolder() ).up()
 				.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBClientBuilder.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBClientBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.ogm.cfg.spi.Hosts;
+import org.hibernate.ogm.datastore.mongodb.configuration.impl.MongoDBConfiguration;
+import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
+import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+
+/**
+ * Builds the {@link MongoClient} given the {@link MongoDBConfiguration}.
+ *
+ * @author Davide D'Alto
+ *
+ */
+public class MongoDBClientBuilder {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final MongoDBConfiguration config;
+
+	public MongoDBClientBuilder(MongoDBConfiguration config) {
+		this.config = config;
+	}
+
+	public MongoClient build() {
+		MongoClientOptions clientOptions = config.buildOptions();
+		List<MongoCredential> credentials = config.buildCredentials();
+		log.connectingToMongo( config.getHosts().toString(), clientOptions.getConnectTimeout() );
+		try {
+			List<ServerAddress> serverAddresses = new ArrayList<>( config.getHosts().size() );
+			for ( Hosts.HostAndPort hostAndPort : config.getHosts() ) {
+				serverAddresses.add( new ServerAddress( hostAndPort.getHost(), hostAndPort.getPort() ) );
+			}
+			return credentials == null
+					? new MongoClient( serverAddresses, clientOptions )
+					: new MongoClient( serverAddresses, credentials, clientOptions );
+		}
+		catch (RuntimeException e) {
+			throw log.unableToInitializeMongoDB( e );
+		}
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBSchemaDefiner.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBSchemaDefiner.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.bson.Document;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.NamingHelper;
 import org.hibernate.boot.model.relational.Database;
@@ -50,7 +51,6 @@ import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-import org.bson.Document;
 
 /**
  * Performs sanity checks of the mapped objects.

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -13,7 +13,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
-import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.jboss.logging.annotations.Cause;
@@ -65,7 +65,8 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1218, value = "Cannot use primary key column name '%s' for id generator, going to use '%s' instead")
 	void cannotUseGivenPrimaryKeyColumnName(String givenKeyColumnName, String usedKeyColumnName);
 
-	@Message(id = 1219, value = "Database %s does not exist. Either create it yourself or set property '" + OgmProperties.CREATE_DATABASE + "' to true.")
+	@Message(id = 1219, value = "Database %s does not exist. Either create it yourself or check the properties '" + AvailableSettings.HBM2DDL_AUTO + "' or '"
+			+ AvailableSettings.HBM2DDL_DATABASE_ACTION + "'.")
 	HibernateException databaseDoesNotExistException(String databaseName);
 
 	// The following statements have to return MappingException to make sure Hibernate ORM doesn't wrap them in a

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
@@ -314,6 +314,7 @@ public class WriteConcernPropagationTest {
 	private void setupSessionFactory(MongoDBDatastoreProvider provider, AssociationStorageType associationStorage) {
 		Map<String, Object> settings = new HashMap<>();
 
+		settings.put( org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO, "create-drop" );
 		settings.put( OgmProperties.DATASTORE_PROVIDER, provider );
 		if ( associationStorage != null ) {
 			settings.put( DocumentStoreProperties.ASSOCIATIONS_STORE, associationStorage );

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
@@ -47,7 +47,9 @@ public class WriteConcernPropagationTest {
 
 	@After
 	public void closeSessionFactory() {
-		sessions.close();
+		if ( sessions != null ) {
+			sessions.close();
+		}
 	}
 
 	@Test

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/options/writeconcern/WriteConcernPropagationTest.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.bson.Document;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSessionFactory;
@@ -34,7 +35,6 @@ import org.junit.Test;
 
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.UpdateOptions;
-import org.bson.Document;
 
 /**
  * Tests that the configured write concern is applied when performing operations against MongoDB.

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionCLIQueryTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/nativequery/MongoDBSessionCLIQueryTest.java
@@ -12,12 +12,14 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import org.bson.Document;
 import org.fest.assertions.Fail;
 import org.fest.assertions.MapAssert;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.datastore.mongodb.utils.MongoDBTestHelper;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.hibernate.ogm.utils.TestForIssue;
 import org.junit.After;
@@ -25,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.mongodb.BasicDBList;
+import com.mongodb.client.MongoCollection;
 
 /**
  * Test the execution of native queries on MongoDB using the {@link Session}
@@ -57,6 +60,10 @@ public class MongoDBSessionCLIQueryTest extends OgmTestCase {
 			delete( session, athanasia );
 			delete( session, imperatrix );
 			tx.commit();
+		}
+		MongoCollection<Document> collection = MongoDBTestHelper.getProvider( sessionFactory ).getDatabase().getCollection( "WILDE_MAP_REDUCE" );
+		if ( collection != null ) {
+			collection.drop();
 		}
 	}
 

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/utils/MongoDBTestHelper.java
@@ -204,7 +204,7 @@ public class MongoDBTestHelper extends BaseGridDialectTestHelper implements Grid
 		result.put( key.getColumnNames()[0], idValue );
 	}
 
-	private static MongoDBDatastoreProvider getProvider(SessionFactory sessionFactory) {
+	public static MongoDBDatastoreProvider getProvider(SessionFactory sessionFactory) {
 		DatastoreProvider provider = ( (SessionFactoryImplementor) sessionFactory ).getServiceRegistry().getService(
 				DatastoreProvider.class );
 		if ( !( MongoDBDatastoreProvider.class.isInstance( provider ) ) ) {

--- a/mongodb/src/test/resources/hibernate.properties
+++ b/mongodb/src/test/resources/hibernate.properties
@@ -10,3 +10,5 @@ hibernate.ogm.datastore.database = ogm_test_database
 hibernate.ogm.datastore.create_database=true
 
 hibernate.ogm.mongodb.connection_timeout = 1000
+
+javax.persistence.schema-generation.database.action=create-drop

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/RemoteNeo4jSequenceGenerator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/dialect/impl/RemoteNeo4jSequenceGenerator.java
@@ -41,6 +41,13 @@ public abstract class RemoteNeo4jSequenceGenerator extends BaseNeo4jSequenceGene
 			+ " RETURN n";
 
 	/**
+	 * Query for validating SEQUENCE nodes.
+	 */
+	protected static final String SEQUENCE_VALIDATION_QUERY =
+			"MATCH (n:" + NodeLabel.SEQUENCE.name() + " {" + SEQUENCE_NAME_PROPERTY + ": {sequenceName}} )"
+			+ " RETURN n";
+
+	/**
 	 * Query for retrieving the next value from SEQUENCE nodes.
 	 */
 	protected static final String SEQUENCE_VALUE_QUERY =
@@ -180,4 +187,6 @@ public abstract class RemoteNeo4jSequenceGenerator extends BaseNeo4jSequenceGene
 	}
 
 	public abstract void createSequences(List<Sequence> sequences, Iterable<IdSourceKeyMetadata> idSourceKeyMetadata);
+
+	public abstract void validateSequences(List<Sequence> sequences, Iterable<IdSourceKeyMetadata> idSourceKeyMetadata);
 }

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/impl/EmbeddedNeo4jSchemaDefiner.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/embedded/impl/EmbeddedNeo4jSchemaDefiner.java
@@ -48,6 +48,10 @@ public class EmbeddedNeo4jSchemaDefiner extends BaseNeo4jSchemaDefiner {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	@Override
+	protected void validateSequences(List<Sequence> sequences, Set<IdSourceKeyMetadata> allIdSourceKeyMetadata, DatastoreProvider provider) {
+	}
+
+	@Override
 	protected void createSequences(List<Sequence> sequences, Set<IdSourceKeyMetadata> allIdSourceKeyMetadata, DatastoreProvider provider) {
 		EmbeddedNeo4jDatastoreProvider neo4jProvider = (EmbeddedNeo4jDatastoreProvider) provider;
 		neo4jProvider.getSequenceGenerator().createSequences( sequences );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jSchemaDefiner.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jSchemaDefiner.java
@@ -59,6 +59,13 @@ public class BoltNeo4jSchemaDefiner extends BaseNeo4jSchemaDefiner {
 	}
 
 	@Override
+	protected void validateSequences(List<Sequence> sequences, Set<IdSourceKeyMetadata> allIdSourceKeyMetadata, DatastoreProvider provider) {
+		BoltNeo4jDatastoreProvider boltProvider = (BoltNeo4jDatastoreProvider) provider;
+		BoltNeo4jSequenceGenerator sequenceGenerator = boltProvider.getSequenceGenerator();
+		sequenceGenerator.validateSequences( sequences, allIdSourceKeyMetadata );
+	}
+
+	@Override
 	protected void createUniqueConstraintsIfMissing(DatastoreProvider provider, List<UniqueConstraintDetails> constraints) {
 		List<Statement> statements = new ArrayList<>();
 		for ( UniqueConstraintDetails constraint : constraints ) {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jSequenceGenerator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/dialect/impl/HttpNeo4jSequenceGenerator.java
@@ -149,6 +149,10 @@ public class HttpNeo4jSequenceGenerator extends RemoteNeo4jSequenceGenerator {
 		validateSequencesCreation( response );
 	}
 
+	@Override
+	public void validateSequences(List<Sequence> sequences, Iterable<IdSourceKeyMetadata> idSourceKeyMetadata) {
+	}
+
 	private void createUniqueConstraints(List<Sequence> sequences, Iterable<IdSourceKeyMetadata> idSourceKeyMetadata) {
 		Statements statements = new Statements();
 		createSequencesConstraintsStatements( statements, sequences );

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/impl/HttpNeo4jSchemaDefiner.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/http/impl/HttpNeo4jSchemaDefiner.java
@@ -48,6 +48,10 @@ public class HttpNeo4jSchemaDefiner extends BaseNeo4jSchemaDefiner {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	@Override
+	protected void validateSequences(List<Sequence> sequences, Set<IdSourceKeyMetadata> allIdSourceKeyMetadata, DatastoreProvider provider) {
+	}
+
+	@Override
 	protected void createSequences(List<Sequence> sequences, Set<IdSourceKeyMetadata> allIdSourceKeyMetadata, DatastoreProvider provider) {
 		HttpNeo4jSequenceGenerator sequenceGenerator = ( (HttpNeo4jDatastoreProvider) provider ).getSequenceGenerator();
 		sequenceGenerator.createSequences( sequences, allIdSourceKeyMetadata );

--- a/neo4j/src/test/resources/hibernate.properties
+++ b/neo4j/src/test/resources/hibernate.properties
@@ -4,6 +4,7 @@
 # License: GNU Lesser General Public License (LGPL), version 2.1 or later
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
+javax.persistence.schema-generation.database.action=create-drop
 
 hibernate.ogm.datastore.provider = ${datastoreProvider}
 


### PR DESCRIPTION
Follows: https://github.com/hibernate/hibernate-ogm/pull/903

So, it took me some time to wrap my head around this and in the process I've found that some things were inconsistent in our test suit This solution should work but I would like some feedback.

This PR changes the existing SchemaDefiner class, it removes the validateMapping method and add the equivalent methods for the schema generation. I did this because the validateMapping was alaways called with the initializeSchema and it is confusing to have the validateMapping and validateSchema in the same interface.

I also implemented the dropSchema for MongoDB althought I still need to find  a way to test it (I tested it manually right now).


