### PR TITLE
OGM-1361 Build modules for WildFly 11

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,21 +26,25 @@
             See the version.wildfly property in the hibernate-ogm-parent pom
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
-        <hibernateSearchVersion>5.6.3.Final</hibernateSearchVersion>
-        <hibernate-search.module.slot>${hibernateSearchVersion}-orm51</hibernate-search.module.slot>
+
         <hibernateCommonsAnnotationsVersion>5.0.1.Final</hibernateCommonsAnnotationsVersion>
         <jbossLoggingVersion>3.3.0.Final</jbossLoggingVersion>
         <jbossLoggingProcessorVersion>2.0.2.Final</jbossLoggingProcessorVersion>
-        <classmateVersion>1.3.1</classmateVersion>
-        <resteasyVersion>3.0.19.Final</resteasyVersion> <!-- Used by CouchDB and Neo4j remote -->
-        <jacksonVersion>2.7.4</jacksonVersion>
-        <slf4jVersion>1.7.7</slf4jVersion> <!-- Note: Wildfly 10.1.0.CR1 uses a custom jboss version -->
-        <netty4Version>4.0.33.Final</netty4Version>
-        <jbossJtaAPIVersion>1.0.0.Final</jbossJtaAPIVersion>
-        <narayanaVersion>5.4.0.Final</narayanaVersion>
+        <classmateVersion>1.3.3</classmateVersion>
+        <resteasyVersion>3.0.24.Final</resteasyVersion> <!-- Used by CouchDB and Neo4j remote -->
+        <jacksonVersion>2.8.9</jacksonVersion>
+        <slf4jVersion>1.7.22</slf4jVersion>
+        <netty4Version>4.1.9.Final</netty4Version>
+        <jbossJtaAPIVersion>1.0.1.Final</jbossJtaAPIVersion>
+        <jbossTransactionSPIVersion>7.6.0.Final</jbossTransactionSPIVersion>
+        <narayanaVersion>5.5.30.Final</narayanaVersion>
 
         <!-- Hibernate ORM -->
         <hibernateVersion>5.1.10.Final</hibernateVersion>
+
+        <!-- Hibernate Search -->
+        <hibernateSearchVersion>5.6.3.Final</hibernateSearchVersion>
+        <hibernate-search.module.slot>${hibernateSearchVersion}-orm51</hibernate-search.module.slot>
 
         <!-- Careful: Lucene is shared across Neo4J dependencies, Infinispan and Hibernate Search -->
         <luceneVersion>5.5.4</luceneVersion>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
         <hibernateVersion>5.1.10.Final</hibernateVersion>
 
         <!-- Hibernate Search -->
-        <hibernateSearchVersion>5.6.3.Final</hibernateSearchVersion>
+        <hibernateSearchVersion>5.6.4.Final</hibernateSearchVersion>
         <hibernate-search.module.slot>${hibernateSearchVersion}-orm51</hibernate-search.module.slot>
 
         <!-- Careful: Lucene is shared across Neo4J dependencies, Infinispan and Hibernate Search -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,6 +88,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-transaction-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
             <scope>test</scope>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -11,7 +11,6 @@
     <description>Hibernate OGM integration and performance tests</description>
 
     <properties>
-        <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
         <jboss.home>${project.build.directory}/wildfly-${version.wildfly}</jboss.home>
         <infinispan-server.home>${project.build.directory}/infinispan-server-${infinispanVersion}</infinispan-server.home>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -131,15 +130,6 @@
                                         <outputDirectory>${project.build.directory}</outputDirectory>
                                     </artifactItem>
                                     <artifactItem>
-                                        <groupId>org.hibernate</groupId>
-                                        <artifactId>hibernate-orm-modules</artifactId>
-                                        <version>${hibernateVersion}</version>
-                                        <classifier>${hibernateWildflyClassifier}</classifier>
-                                        <type>zip</type>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${jboss.home}/modules</outputDirectory>
-                                    </artifactItem>
-                                    <artifactItem>
                                         <groupId>${project.groupId}</groupId>
                                         <artifactId>hibernate-ogm-modules</artifactId>
                                         <classifier>${hibernateWildflyClassifier}</classifier>
@@ -160,7 +150,12 @@
                                         <groupId>org.hibernate</groupId>
                                         <artifactId>hibernate-search-modules</artifactId>
                                         <version>${hibernateSearchVersion}</version>
-                                        <classifier>${hibernateWildflyClassifier}</classifier>
+                                        <!--
+                                        We don't have a wildfly-11-dist version of the Hibernate Search 5.6 modules.
+                                        Using the ones built for WildFly 10 will do so we hardcode the classifier here
+                                        for now.
+                                        -->
+                                        <classifier>wildfly-10-dist</classifier>
                                         <type>zip</type>
                                         <overWrite>false</overWrite>
                                         <outputDirectory>${jboss.home}/modules</outputDirectory>
@@ -268,7 +263,7 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>${version.org.wildfly.arquillian}</version>
+            <version>${wildflyArquillianVersion}</version>
             <scope>test</scope>
             <exclusions>
                 <!-- Pulled in transitively; Neither available on 

--- a/jipijapa/src/main/java/org/wildfly/jpa/hibernateogm5/HibernateOGMPersistenceProviderAdaptor.java
+++ b/jipijapa/src/main/java/org/wildfly/jpa/hibernateogm5/HibernateOGMPersistenceProviderAdaptor.java
@@ -8,6 +8,7 @@ package org.wildfly.jpa.hibernateogm5;
 
 import java.util.Map;
 
+import javax.enterprise.inject.spi.BeanManager;
 import javax.persistence.spi.PersistenceUnitInfo;
 
 import org.hibernate.cfg.Environment;
@@ -40,41 +41,58 @@ public class HibernateOGMPersistenceProviderAdaptor implements PersistenceProvid
 	}
 
 	/* All methods below delegate to the original Hibernate ORM 5 adaptor */
-
+	@Override
 	public void injectJtaManager(JtaManager jtaManager) {
 		ormOriginalAdaptor.injectJtaManager( jtaManager );
 	}
 
+	@Override
 	public void injectPlatform(Platform platform) {
 		ormOriginalAdaptor.injectPlatform( platform );
 	}
 
+	@Override
 	public void addProviderDependencies(PersistenceUnitMetadata pu) {
 		ormOriginalAdaptor.addProviderDependencies( pu );
 	}
 
+	@Override
 	public void beforeCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
 		ormOriginalAdaptor.beforeCreateContainerEntityManagerFactory( pu );
 	}
 
+	@Override
 	public void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
 		ormOriginalAdaptor.afterCreateContainerEntityManagerFactory( pu );
 	}
 
+	@Override
 	public ManagementAdaptor getManagementAdaptor() {
 		return ormOriginalAdaptor.getManagementAdaptor();
 	}
 
+	@Override
 	public boolean doesScopedPersistenceUnitNameIdentifyCacheRegionName(PersistenceUnitMetadata pu) {
 		return ormOriginalAdaptor.doesScopedPersistenceUnitNameIdentifyCacheRegionName( pu );
 	}
 
+	@Override
 	public void cleanup(PersistenceUnitMetadata pu) {
 		ormOriginalAdaptor.cleanup( pu );
 	}
 
+	@Override
 	public EntityManagerFactoryBuilder getBootstrap(PersistenceUnitInfo info, Map map) {
 		return ormOriginalAdaptor.getBootstrap( info, map );
 	}
 
+	@Override
+	public void markPersistenceUnitAvailable(Object wrapperBeanManagerLifeCycle) {
+		ormOriginalAdaptor.markPersistenceUnitAvailable( wrapperBeanManagerLifeCycle );
+	}
+
+	@Override
+	public Object beanManagerLifeCycle(BeanManager beanManager) {
+		return ormOriginalAdaptor.beanManagerLifeCycle( beanManager );
+	}
 }

--- a/modules/src/main/aliases/org/hibernate/search/engine/module.xml
+++ b/modules/src/main/aliases/org/hibernate/search/engine/module.xml
@@ -10,8 +10,8 @@
     we can use the same property hibernate-search.module.slot for hibernate-search-orm 
     and hibernate-search-engine.
 
-    WildFly 10 ships with Hibernate ORM 5.0 and Hibernate Search 5.5.4, to make it work with OGM 5.1
-    we need to add the ORM 5.1 module and the Search 5.6.1 module. The user can then select these modules
+    WildFly 11 ships with Hibernate ORM 5.1 and Hibernate Search 5.5.4, to make it work with OGM 5.1
+    we just need to add the Search 5.6.x module. The user can then select these modules
     using the property wildfly.jpa.hibernate.search.module.
 
     This module is referenced in the org.hibernate.search.orm and the org.hibernate.hql modules. Make

--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -5,7 +5,7 @@
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
 <assembly>
-    <id>wildfly-10-dist</id>
+    <id>${hibernateWildflyClassifier}</id>
     <formats>
         <format>zip</format>
     </formats>
@@ -85,7 +85,7 @@
             <filtered>true</filtered>
         </file>
 
-        <!-- HSEARCH 5.5 using ORM 5.1 -->
+        <!-- HSEARCH using the version of ORM we require for OGM -->
         <file>
             <source>${module.xml.basedir}/org/hibernate/search/orm/module.xml</source>
             <outputDirectory>/org/hibernate/search/orm/${hibernate-search.module.slot}</outputDirectory>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -141,6 +141,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-transaction-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             <scope>provided</scope>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>narayana-jta</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-transaction-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
         <!-- test / build-only dependency versions, managed below -->
         <jbossNamingVersion>7.1.0.Final</jbossNamingVersion>
         <shrinkwrapVersion>1.2.2</shrinkwrapVersion>
-        <arquillianVersion>1.1.5.Final</arquillianVersion>
+        <arquillianVersion>1.2.0.Final</arquillianVersion>
+        <wildflyArquillianVersion>2.1.0.Final</wildflyArquillianVersion>
         <jmhVersion>1.0</jmhVersion>
         <bytemanVersion>4.0.0-BETA5</bytemanVersion>
 
@@ -65,9 +66,9 @@
         <embeddedMongoDbPort>27018</embeddedMongoDbPort>
 
         <!-- Target version of WildFly (for testing and JipiJapa integration) -->
-        <version.wildfly>10.1.0.Final</version.wildfly>
-        <hibernateWildflyClassifier>wildfly-10-dist</hibernateWildflyClassifier>
-        <hibernate-orm.module.slot>5.1</hibernate-orm.module.slot>
+        <version.wildfly>11.0.0.Final</version.wildfly>
+        <hibernateWildflyClassifier>wildfly-11-dist</hibernateWildflyClassifier>
+        <hibernate-orm.module.slot>main</hibernate-orm.module.slot>
 
         <!-- Asciidoctor -->
         <hibernate-asciidoctor-theme.version>1.0.1.Final</hibernate-asciidoctor-theme.version>
@@ -189,7 +190,7 @@
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-transaction-spi</artifactId>
-                <version>7.3.0.Final</version>
+                <version>${jbossTransactionSPIVersion}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/OGM-1361
 * https://hibernate.atlassian.net/browse/OGM-1369

This is a partial backport of my work supporting ORM 5.2 (for which upgrading to WF 11 was necessary).

OGM 5.2 modules will be released as WF 11 modules. Note that, contrary to the other versions, it uses the main slot for ORM as OGM 5.2 uses ORM 5.1 and it is the version bundled with WF 11.

I also upgraded Search to 5.6.4.Final.