### PR TITLE
OGM-1372 Put the distribution files to upload into distribution/target/dir so that release scripts find them

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -410,6 +410,13 @@
                 <artifactId>hibernate-ogm-neo4j</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>hibernate-ogm-modules</artifactId>
+                <version>${project.version}</version>
+                <classifier>wildfly-11-dist</classifier>
+                <type>zip</type>
+            </dependency>
 
             <!-- Logging -->
             <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -36,6 +36,9 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/dist/</outputDirectory>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -56,6 +59,21 @@
                                 </artifactItem>
                            </artifactItems>
                             <outputDirectory>${project.build.directory}/lib/neo4j</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-jbossmodules-to-dist</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>install</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dist/</outputDirectory>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeArtifactIds>hibernate-ogm-modules</includeArtifactIds>
+                            <includeTypes>zip</includeTypes>
+                            <includeClassifiers>wildfly-11-dist</includeClassifiers>
+                            <excludeTransitive>true</excludeTransitive>
                         </configuration>
                     </execution>
                 </executions>
@@ -154,6 +172,13 @@
                     <artifactId>lucene-analyzers-common</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-ogm-modules</artifactId>
+            <classifier>wildfly-11-dist</classifier>
+            <type>zip</type>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/OGM-1372

See also hibernate/hibernate-noorm-release-scripts#4 for more information about how this `dist` directory will be uploaded.

Note this also fixes an issue: the WildFly module would not be uploaded to Sourceforge without this change, because it doesn't match the pattern in the release script (`*-wildfly-10-*` vs. `wildfly-11`).