### PR TITLE
OGM-1377 Make RemoteAuthenticationFailureTest failures more informative

### DIFF
--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/remote/RemoteAuthenticationFailureTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/remote/RemoteAuthenticationFailureTest.java
@@ -49,9 +49,8 @@ public class RemoteAuthenticationFailureTest {
 				connectToRemoteDatastore( properties );
 				fail( "Credentials should be invalid" );
 			}
-			catch (Exception e) {
+			catch (HibernateException e) {
 				// Unable to start datastore provider
-				assertThat( e ).isInstanceOf( HibernateException.class );
 				assertThat( e.getMessage() ).startsWith( "OGM000071" );
 				assertThat( e.getCause().getMessage() ).startsWith( "OGM001419" );
 				assertThat( e.getCause().getMessage() ).contains( "Unauthorized" );


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/OGM-1377

If the exception is not a HibernateException, it's better to let the test throw the exception as we have a more informative message (done to diagnose a failure on CI).