### PR TITLE
OGM-1379 Pass the right parameters to RemoteAuthenticationFailureTest

### DIFF
--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/remote/RemoteAuthenticationFailureTest.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/test/remote/RemoteAuthenticationFailureTest.java
@@ -16,8 +16,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.impl.DatastoreProviderType;
 import org.hibernate.ogm.datastore.neo4j.remote.common.impl.RemoteNeo4jDatastoreProvider;
+import org.hibernate.ogm.datastore.neo4j.utils.Neo4jTestHelper;
 import org.hibernate.ogm.datastore.neo4j.utils.PropertiesReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -28,6 +30,11 @@ import org.junit.Test;
 public class RemoteAuthenticationFailureTest {
 
 	private final Map<String, String> properties = new HashMap<String, String>( 2 );
+
+	@BeforeClass
+	public static void initEnvironment() {
+		Neo4jTestHelper.initEnvironment();
+	}
 
 	@Before
 	public void setup() {

--- a/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
+++ b/neo4j/src/test/java/org/hibernate/ogm/datastore/neo4j/utils/Neo4jTestHelper.java
@@ -37,6 +37,10 @@ import org.hibernate.ogm.utils.TestHelper;
 public class Neo4jTestHelper extends BaseGridDialectTestHelper implements GridDialectTestHelper {
 
 	static {
+		initEnvironment();
+	}
+
+	public static void initEnvironment() {
 		// Read host, username and password from environment variable
 		// Maven's surefire plugin set it to the string 'null'
 		String neo4jHost = System.getenv( "NEO4J_HOSTNAME" );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1379

It turns out that the tests wasn't reading the right variables and also ci was launching the build with the wrong parameters.

This should fix the error we have on CI