### PR TITLE
OGM-359 Stored procedures for Mongo

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/boot/impl/OgmServiceRegistryInitializer.java
+++ b/core/src/main/java/org/hibernate/ogm/boot/impl/OgmServiceRegistryInitializer.java
@@ -20,6 +20,7 @@ import org.hibernate.ogm.dialect.impl.MultigetGridDialectInitiator;
 import org.hibernate.ogm.dialect.impl.OgmDialectFactoryInitiator;
 import org.hibernate.ogm.dialect.impl.OptimisticLockingAwareGridDialectInitiator;
 import org.hibernate.ogm.dialect.impl.QueryableGridDialectInitiator;
+import org.hibernate.ogm.dialect.impl.StoredProcedureGridDialectInitiator;
 import org.hibernate.ogm.jdbc.impl.OgmConnectionProviderInitiator;
 import org.hibernate.ogm.jpa.impl.OgmMutableIdentifierGeneratorFactoryInitiator;
 import org.hibernate.ogm.jpa.impl.OgmPersisterClassResolverInitiator;
@@ -81,6 +82,7 @@ public class OgmServiceRegistryInitializer implements ServiceContributor {
 		serviceRegistryBuilder.addInitiator( IdentityColumnAwareGridDialectInitiator.INSTANCE );
 		serviceRegistryBuilder.addInitiator( OptimisticLockingAwareGridDialectInitiator.INSTANCE );
 		serviceRegistryBuilder.addInitiator( MultigetGridDialectInitiator.INSTANCE );
+		serviceRegistryBuilder.addInitiator( StoredProcedureGridDialectInitiator.INSTANCE );
 	}
 
 	private boolean isOgmEnabled(Map<?, ?> settings) {

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/ForwardingGridDialect.java
@@ -34,6 +34,7 @@ import org.hibernate.ogm.dialect.spi.OperationContext;
 import org.hibernate.ogm.dialect.spi.SessionFactoryLifecycleAwareDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.dialect.storedprocedure.spi.StoredProcedureAwareGridDialect;
 import org.hibernate.ogm.entityentry.impl.TuplePointer;
 import org.hibernate.ogm.model.key.spi.AssociationKey;
 import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
@@ -41,6 +42,7 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Association;
 import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.storedprocedure.ProcedureQueryParameters;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.ogm.util.impl.Contracts;
 import org.hibernate.persister.entity.Lockable;
@@ -60,7 +62,7 @@ import org.hibernate.type.Type;
  *
  * @author Gunnar Morling
  */
-public class ForwardingGridDialect<T extends Serializable> implements GridDialect, BatchableGridDialect, SessionFactoryLifecycleAwareDialect, IdentityColumnAwareGridDialect, QueryableGridDialect<T>, OptimisticLockingAwareGridDialect, Configurable, ServiceRegistryAwareService, MultigetGridDialect, GroupingByEntityDialect {
+public class ForwardingGridDialect<T extends Serializable> implements GridDialect, BatchableGridDialect, SessionFactoryLifecycleAwareDialect, IdentityColumnAwareGridDialect, QueryableGridDialect<T>, OptimisticLockingAwareGridDialect, Configurable, ServiceRegistryAwareService, MultigetGridDialect, GroupingByEntityDialect, StoredProcedureAwareGridDialect {
 
 	private final GridDialect gridDialect;
 	private final BatchableGridDialect batchableGridDialect;
@@ -70,6 +72,7 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 	private final IdentityColumnAwareGridDialect identityColumnAwareGridDialect;
 	private final OptimisticLockingAwareGridDialect optimisticLockingAwareGridDialect;
 	private final MultigetGridDialect multigetGridDialect;
+	private final StoredProcedureAwareGridDialect storedProcedureAwareGridDialect;
 
 	@SuppressWarnings("unchecked")
 	public ForwardingGridDialect(GridDialect gridDialect) {
@@ -83,6 +86,7 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 		this.identityColumnAwareGridDialect = GridDialects.getDialectFacetOrNull( gridDialect, IdentityColumnAwareGridDialect.class );
 		this.optimisticLockingAwareGridDialect = GridDialects.getDialectFacetOrNull( gridDialect, OptimisticLockingAwareGridDialect.class );
 		this.multigetGridDialect = GridDialects.getDialectFacetOrNull( gridDialect, MultigetGridDialect.class );
+		this.storedProcedureAwareGridDialect = GridDialects.getDialectFacetOrNull( gridDialect, StoredProcedureAwareGridDialect.class );
 	}
 
 	/**
@@ -308,4 +312,9 @@ public class ForwardingGridDialect<T extends Serializable> implements GridDialec
 		return gridDialect.usesNavigationalInformationForInverseSideOfAssociations();
 	}
 
+	@Override
+	public ClosableIterator<Tuple> callStoredProcedure(String storedProcedureName, ProcedureQueryParameters queryParameters,
+			TupleContext tupleContext) {
+		return storedProcedureAwareGridDialect.callStoredProcedure( storedProcedureName, queryParameters,tupleContext );
+	}
 }

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/StoredProcedureGridDialectInitiator.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/StoredProcedureGridDialectInitiator.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.storedprocedure.spi.StoredProcedureAwareGridDialect;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class StoredProcedureGridDialectInitiator implements StandardServiceInitiator<StoredProcedureAwareGridDialect> {
+
+	public static final StoredProcedureGridDialectInitiator INSTANCE = new StoredProcedureGridDialectInitiator();
+
+	private StoredProcedureGridDialectInitiator() {
+	}
+
+	@Override
+	public Class<StoredProcedureAwareGridDialect> getServiceInitiated() {
+		return StoredProcedureAwareGridDialect.class;
+	}
+
+	@Override
+	public StoredProcedureAwareGridDialect initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		return GridDialects.getDialectFacetOrNull( registry.getService( GridDialect.class ), StoredProcedureAwareGridDialect.class );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/storedprocedure/spi/StoredProcedureAwareGridDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/storedprocedure/spi/StoredProcedureAwareGridDialect.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.storedprocedure.spi;
+
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.storedprocedure.ProcedureQueryParameters;
+
+/**
+ * A facet for {@link GridDialect} implementations which support the execution of stored procedures.
+ * <p>
+ * Cases of stored procedures are:
+ * <ol>
+ * <li>procedure without any input or output parameters</li>
+ * <li>function with many input parameters and one returned value (primitive)</li>
+ * <li>function with many input parameters and result set</li>
+ * </ol>
+ *
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public interface StoredProcedureAwareGridDialect extends GridDialect {
+
+	/**
+	 * Returns the result of a stored procedure executed on the backend.
+	 *
+	 * @param storedProcedureName name of stored procedure
+	 * @param queryParameters parameters passed for this query
+	 * @param tupleContext the tuple context
+	 *
+	 * @return a {@link ClosableIterator} with the result of the query
+	 */
+	ClosableIterator<Tuple> callStoredProcedure( String storedProcedureName, ProcedureQueryParameters queryParameters, TupleContext tupleContext);
+}

--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/BackendCustomLoader.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/BackendCustomLoader.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
-import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.custom.CustomLoader;
@@ -28,13 +27,11 @@ import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
 import org.hibernate.ogm.dialect.query.spi.QueryParameters;
 import org.hibernate.ogm.dialect.query.spi.QueryableGridDialect;
 import org.hibernate.ogm.dialect.spi.TupleContext;
-import org.hibernate.ogm.loader.impl.OgmLoadingContext;
-import org.hibernate.ogm.loader.impl.TupleBasedEntityLoader;
 import org.hibernate.ogm.loader.nativeloader.impl.BackendCustomQuery;
 import org.hibernate.ogm.model.spi.Tuple;
-import org.hibernate.ogm.persister.impl.OgmEntityPersister;
 import org.hibernate.ogm.type.spi.GridType;
 import org.hibernate.ogm.type.spi.TypeTranslator;
+import org.hibernate.ogm.util.impl.CustomLoaderHelper;
 import org.hibernate.type.Type;
 
 /**
@@ -91,7 +88,7 @@ public class BackendCustomLoader extends CustomLoader {
 				QueryParameters.fromOrmQueryParameters( queryParameters, typeTranslator, session.getFactory() ) );
 		try {
 			if ( isEntityQuery() ) {
-				return listOfEntities( session, resultTypes, tuples );
+				return CustomLoaderHelper.listOfEntities( session, resultTypes, tuples );
 			}
 			else {
 				return listOfArrays( session, tuples );
@@ -100,23 +97,6 @@ public class BackendCustomLoader extends CustomLoader {
 		finally {
 			tuples.close();
 		}
-	}
-
-	// At the moment we only support the case where one entity type is returned
-	private List<Object> listOfEntities(SharedSessionContractImplementor session, Type[] resultTypes, ClosableIterator<Tuple> tuples) {
-		Class<?> returnedClass = resultTypes[0].getReturnedClass();
-		TupleBasedEntityLoader loader = getLoader( session, returnedClass );
-		OgmLoadingContext ogmLoadingContext = new OgmLoadingContext();
-		ogmLoadingContext.setTuples( getTuplesAsList( tuples ) );
-		return loader.loadEntitiesFromTuples( session, LockOptions.NONE, ogmLoadingContext );
-	}
-
-	private List<Tuple> getTuplesAsList(ClosableIterator<Tuple> tuples) {
-		List<Tuple> tuplesAsList = new ArrayList<>();
-		while ( tuples.hasNext() ) {
-			tuplesAsList.add( tuples.next() );
-		}
-		return tuplesAsList;
 	}
 
 	private List<Object> listOfArrays(SharedSessionContractImplementor session, Iterator<Tuple> tuples) {
@@ -161,12 +141,6 @@ public class BackendCustomLoader extends CustomLoader {
 		}
 
 		return results;
-	}
-
-	private TupleBasedEntityLoader getLoader(SharedSessionContractImplementor session, Class<?> entityClass) {
-		OgmEntityPersister persister = (OgmEntityPersister) ( session.getFactory() ).getMetamodel().entityPersister( entityClass );
-		TupleBasedEntityLoader loader = (TupleBasedEntityLoader) persister.getAppropriateLoader( LockOptions.READ, session );
-		return loader;
 	}
 
 	/**

--- a/core/src/main/java/org/hibernate/ogm/storedprocedure/ProcedureQueryParameters.java
+++ b/core/src/main/java/org/hibernate/ogm/storedprocedure/ProcedureQueryParameters.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.storedprocedure;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Named or positional parameters to pass to a stored procedure.
+ *
+ * @author Davide D'Alto
+ */
+public class ProcedureQueryParameters {
+
+	private final Map<String, Object> namedParameters;
+	private final List<Object> positionalParameters;
+
+	/**
+	 * Create a new instance containing the values of the parameters to pass to the stored procedure.
+	 *
+	 * @param namedParameters a map where the key is the parameter name and value the parameter value
+	 * @param positionalParameters a list of parameters in the right order to be passed
+	 */
+	public ProcedureQueryParameters(Map<String, Object> namedParameters, List<Object> positionalParameters) {
+		this.namedParameters = namedParameters;
+		this.positionalParameters = positionalParameters;
+	}
+
+	public List<Object> getPositionalParameters() {
+		return positionalParameters;
+	}
+
+	public Map<String, Object> getNamedParameters() {
+		return namedParameters;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureCallMemento.java
+++ b/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureCallMemento.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.storedprocedure.impl;
+
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.procedure.ProcedureCallMemento;
+import org.hibernate.procedure.internal.NoSQLProcedureCallImpl;
+
+public class NoSQLProcedureCallMemento implements ProcedureCallMemento {
+
+	private final ProcedureCallMemento delegate;
+
+	public NoSQLProcedureCallMemento(ProcedureCallMemento delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public ProcedureCall makeProcedureCall(SharedSessionContractImplementor session) {
+		return new NoSQLProcedureCallImpl( session, this );
+	}
+
+	@Override
+	public Map<String, Object> getHintsMap() {
+		return delegate.getHintsMap();
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(Class<T> cls) {
+		if ( cls.isInstance( delegate ) ) {
+			return (T) delegate;
+		}
+		if ( cls.isInstance( this ) ) {
+			return (T) this;
+		}
+		throw new HibernateException( "Cannot unwrap the following type: " + cls );
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureOutputsImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureOutputsImpl.java
@@ -1,0 +1,176 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.storedprocedure.impl;
+
+import static org.hibernate.ogm.util.impl.CustomLoaderHelper.listOfEntities;
+import static org.hibernate.ogm.util.impl.TupleContextHelper.tupleContext;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.ParameterMode;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.spi.MetamodelImplementor;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.storedprocedure.spi.StoredProcedureAwareGridDialect;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.model.spi.EntityMetadataInformation;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.ogm.storedprocedure.ProcedureQueryParameters;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.procedure.ParameterRegistration;
+import org.hibernate.procedure.ProcedureOutputs;
+import org.hibernate.procedure.internal.NoSQLProcedureCallImpl;
+import org.hibernate.result.Output;
+
+/**
+ * @author Davide D'Alto
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class NoSQLProcedureOutputsImpl implements ProcedureOutputs {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final NoSQLProcedureCallImpl procedureCall;
+	private final SessionFactoryImplementor sessionFactory;
+	private StoredProcedureAwareGridDialect gridDialect;
+
+	public NoSQLProcedureOutputsImpl(NoSQLProcedureCallImpl procedureCall) {
+		this.procedureCall = procedureCall;
+		this.sessionFactory = procedureCall.getSession().getFactory();
+		this.gridDialect = this.sessionFactory.getServiceRegistry().getService( StoredProcedureAwareGridDialect.class );
+	}
+
+	@Override
+	public <T> T getOutputParameterValue(ParameterRegistration<T> parameterRegistration) {
+		throw new UnsupportedOperationException( "Out parameters not supported yet!" );
+	}
+
+	@Override
+	public Object getOutputParameterValue(String name) {
+		throw new UnsupportedOperationException( "Out parameters not supported yet!" );
+	}
+
+	@Override
+	public Object getOutputParameterValue(int position) {
+		throw new UnsupportedOperationException( "Out parameters not supported yet!" );
+	}
+
+	@Override
+	public Output getCurrent() {
+		ProcedureQueryParameters queryParameters = createProcedureQueryParameters( (List<ParameterRegistration<?>>) procedureCall.getRegisteredParameters() );
+
+		if ( !procedureCall.getSynchronizedQuerySpaces().isEmpty() ) {
+			return entitiesOutput( procedureCall, queryParameters );
+		}
+		else {
+			TupleContext tupleContext = tupleContext( procedureCall.getSession(), null );
+			ClosableIterator<Tuple> result = gridDialect.callStoredProcedure( procedureCall.getProcedureName(), queryParameters, tupleContext );
+			if ( result == null ) {
+				// call a procedure without result
+				return null;
+			}
+			else {
+				// we just return the values
+				return objectsOuput( result );
+			}
+		}
+	}
+
+	private Output entitiesOutput(NoSQLProcedureCallImpl procedureCall, ProcedureQueryParameters queryParameters) {
+		if ( procedureCall.getSynchronizedQuerySpaces().size() > 1 ) {
+			throw log.multipleEntitiesOutputNotSupported( procedureCall.getProcedureName(), procedureCall.getSynchronizedQuerySpaces() );
+		}
+		@SuppressWarnings("unchecked")
+		Iterator<String> iterator = procedureCall.getSynchronizedQuerySpaces().iterator();
+		String querySpace = iterator.next();
+		MetamodelImplementor metamodelImplementor = procedureCall.getSession().getFactory().getMetamodel();
+		OgmEntityPersister entityPersister = entityPersister( querySpace, metamodelImplementor );
+		EntityMetadataInformation entityMetadata = entityMetadataInfo( querySpace, metamodelImplementor, entityPersister );
+		TupleContext tupleContext = tupleContext( procedureCall.getSession(), entityMetadata );
+		ClosableIterator<Tuple> result = gridDialect.callStoredProcedure( procedureCall.getProcedureName(), queryParameters, tupleContext );
+		List<?> entityList = listOfEntities( procedureCall.getSession(), entityPersister.getMappedClass(), result );
+		return new NoSQLProcedureResultSetOutputImpl( entityList );
+	}
+
+	private EntityMetadataInformation entityMetadataInfo(String querySpace, MetamodelImplementor metamodelImplementor, OgmEntityPersister entityPersister) {
+		String entityName = null;
+		for ( Map.Entry<String, EntityPersister> entry : metamodelImplementor.entityPersisters().entrySet() ) {
+			List<Serializable> querySpaces = Arrays.asList( entry.getValue().getQuerySpaces() );
+			if ( querySpaces.contains( querySpace ) ) {
+				entityName = entry.getKey();
+			}
+		}
+
+		EntityKeyMetadata entityKeyMetadata = entityPersister.getEntityKeyMetadata();
+		EntityMetadataInformation entityMetadata = new EntityMetadataInformation( entityKeyMetadata, entityName );
+		return entityMetadata;
+	}
+
+	private OgmEntityPersister entityPersister(String querySpace, MetamodelImplementor metamodelImplementor) {
+		for ( Map.Entry<String, EntityPersister> entry : metamodelImplementor.entityPersisters().entrySet() ) {
+			List<Serializable> querySpaces = Arrays.asList( entry.getValue().getQuerySpaces() );
+			if ( querySpaces.contains( querySpace ) ) {
+				return (OgmEntityPersister) entry.getValue();
+			}
+		}
+		return null;
+	}
+
+	private ProcedureQueryParameters createProcedureQueryParameters(List<ParameterRegistration<?>> list) {
+		List<Object> positionalParameters = new ArrayList<>();
+		Map<String, Object> namedParameters = new HashMap<>();
+		for ( ParameterRegistration<?> nosqlParameterRegistration : list ) {
+			if ( nosqlParameterRegistration.getMode() != ParameterMode.REF_CURSOR ) {
+				Object value = nosqlParameterRegistration.getBind().getValue();
+				if ( nosqlParameterRegistration.getName() != null ) {
+					namedParameters.put( nosqlParameterRegistration.getName(), value );
+				}
+				else if ( nosqlParameterRegistration.getPosition() != null ) {
+					positionalParameters.add( value );
+				}
+			}
+		}
+
+		return new ProcedureQueryParameters( namedParameters, positionalParameters );
+	}
+
+	private static Output objectsOuput(ClosableIterator<Tuple> tuples) {
+		List<Object> tuplesAsList = new ArrayList<>();
+		while ( tuples.hasNext() ) {
+			Tuple next = tuples.next();
+			for ( String columnName : next.getColumnNames() ) {
+				tuplesAsList.add( next.get( columnName ) );
+			}
+		}
+		return new NoSQLProcedureResultSetOutputImpl( tuplesAsList );
+	}
+
+	@Override
+	public boolean goToNext() {
+		return false;
+	}
+
+	@Override
+	public void release() {
+	}
+
+	public boolean isResultSet() {
+		return getCurrent().isResultSet();
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureResultSetOutputImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/storedprocedure/impl/NoSQLProcedureResultSetOutputImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.storedprocedure.impl;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.hibernate.result.ResultSetOutput;
+
+/**
+ * Implementation of {@link ResultSetOutput} for OGM.
+ * <p>
+ * This is a copy of the implementation in ORM that is package private and therefore we cannot use.
+ *
+ * @see org.hibernate.result.internal.ResultSetOutputImpl
+ * @author Davide D'Alto
+ */
+class NoSQLProcedureResultSetOutputImpl implements ResultSetOutput {
+
+	private final Supplier<List<?>> resultSetSupplier;
+
+	public NoSQLProcedureResultSetOutputImpl(List<?> results) {
+		this.resultSetSupplier = () -> results;
+	}
+
+	public NoSQLProcedureResultSetOutputImpl(Supplier<List<?>> resultSetSupplier) {
+		this.resultSetSupplier = resultSetSupplier;
+	}
+
+	@Override
+	public boolean isResultSet() {
+		return true;
+	}
+
+	@Override
+	public List<?> getResultList() {
+		return resultSetSupplier.get();
+	}
+
+	@Override
+	public Object getSingleResult() {
+		final List<?> results = getResultList();
+		if ( results == null || results.isEmpty() ) {
+			return null;
+		}
+		else {
+			return results.get( 0 );
+		}
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/CustomLoaderHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/CustomLoaderHelper.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.util.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.LockOptions;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.loader.impl.OgmLoadingContext;
+import org.hibernate.ogm.loader.impl.TupleBasedEntityLoader;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.type.Type;
+
+/**
+ * The helper contains common code from {@link org.hibernate.ogm.hibernatecore.impl.BackendCustomLoader}
+ *
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class CustomLoaderHelper {
+
+	// At the moment we only support the case where one entity type is returned
+	public static List<Object> listOfEntities(SharedSessionContractImplementor session, Type[] resultTypes, ClosableIterator<Tuple> tuples) {
+		Class<?> returnedClass = resultTypes[0].getReturnedClass();
+		TupleBasedEntityLoader loader = getLoader( session, returnedClass );
+		OgmLoadingContext ogmLoadingContext = new OgmLoadingContext();
+		ogmLoadingContext.setTuples( getTuplesAsList( tuples ) );
+		return loader.loadEntitiesFromTuples( session, LockOptions.NONE, ogmLoadingContext );
+	}
+
+	public static List<Object> listOfEntities(SharedSessionContractImplementor session, Class<?> returnedClass, ClosableIterator<Tuple> tuples) {
+		TupleBasedEntityLoader loader = getLoader( session, returnedClass );
+		OgmLoadingContext ogmLoadingContext = new OgmLoadingContext();
+		ogmLoadingContext.setTuples( getTuplesAsList( tuples ) );
+		return loader.loadEntitiesFromTuples( session, LockOptions.NONE, ogmLoadingContext );
+	}
+
+	private static List<Tuple> getTuplesAsList(ClosableIterator<Tuple> tuples) {
+		List<Tuple> tuplesAsList = new ArrayList<>();
+		while ( tuples.hasNext() ) {
+			tuplesAsList.add( tuples.next() );
+		}
+		return tuplesAsList;
+	}
+
+	public static TupleBasedEntityLoader getLoader(SharedSessionContractImplementor session, Class<?> entityClass) {
+		OgmEntityPersister persister = (OgmEntityPersister) ( session.getFactory() ).getMetamodel().entityPersister( entityClass.getName() );
+		TupleBasedEntityLoader loader = (TupleBasedEntityLoader) persister.getAppropriateLoader( LockOptions.READ, session );
+		return loader;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/Log.java
@@ -304,4 +304,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 89, value = "%1$s does not support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy. You should try using SINGLE_TABLE instead. Entities: %2$s")
 	HibernateException queriesOnPolymorphicEntitiesAreNotSupportedWithTablePerClass( String datastore, Collection<String> subclassEntityNames );
+
+	@Message(id = 90, value = "Returning multiple entities is not supported. Procedure '%1$s' expects results of type %2$s")
+	HibernateException multipleEntitiesOutputNotSupported(String procedureName, Collection<?> synchronizedQuerySpaces);
 }

--- a/core/src/main/java/org/hibernate/ogm/util/impl/StringHelper.java
+++ b/core/src/main/java/org/hibernate/ogm/util/impl/StringHelper.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 /**
  * Utility functions for dealing with strings.
  *
+ * @author Davide D'Alto
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  * @author Gunnar Morling
  */
@@ -77,5 +78,29 @@ public class StringHelper {
 			return sb.substring( separator.length() );
 		}
 		return "";
+	}
+
+	/**
+	 * If a text contains double quotes, escape them.
+	 *
+	 * @param text the text to escape
+	 * @return Escaped text or {@code null} if the text is null
+	 */
+	public static String escapeDoubleQuotesForJson(String text) {
+		if ( text == null ) {
+			return null;
+		}
+		StringBuilder builder = new StringBuilder( text.length() );
+		for ( int i = 0; i < text.length(); i++ ) {
+			char c = text.charAt( i );
+			switch ( c ) {
+				case '"':
+				case '\\':
+					builder.append( "\\" );
+				default:
+					builder.append( c );
+			}
+		}
+		return builder.toString();
 	}
 }

--- a/core/src/main/java/org/hibernate/procedure/internal/NoSQLProcedureCallImpl.java
+++ b/core/src/main/java/org/hibernate/procedure/internal/NoSQLProcedureCallImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.procedure.internal;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.ogm.storedprocedure.impl.NoSQLProcedureCallMemento;
+import org.hibernate.ogm.storedprocedure.impl.NoSQLProcedureOutputsImpl;
+import org.hibernate.procedure.ProcedureOutputs;
+
+/**
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class NoSQLProcedureCallImpl extends ProcedureCallImpl {
+
+	private final NoSQLProcedureCallMemento memento;
+
+	public NoSQLProcedureCallImpl(SharedSessionContractImplementor session, String procedureName) {
+		super( session, procedureName );
+		this.memento = null;
+	}
+
+	public NoSQLProcedureCallImpl(SharedSessionContractImplementor session, String procedureName, Class<?>... resultClasses) {
+		super( session, procedureName, resultClasses );
+		this.memento = null;
+	}
+
+	public NoSQLProcedureCallImpl(SharedSessionContractImplementor session, String procedureName, String... resultSetMappings) {
+		super( session, procedureName, resultSetMappings );
+		this.memento = null;
+	}
+
+	public NoSQLProcedureCallImpl(SharedSessionContractImplementor session, NoSQLProcedureCallMemento memento) {
+		super( session, memento.unwrap( ProcedureCallMementoImpl.class ) );
+		this.memento = memento;
+	}
+
+	@Override
+	public ProcedureOutputs getOutputs() {
+		return new NoSQLProcedureOutputsImpl( this );
+	}
+
+	public NoSQLProcedureCallMemento getMemento() {
+		return memento;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/Car.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/Car.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.storedprocedures;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityResult;
+import javax.persistence.Id;
+import javax.persistence.NamedStoredProcedureQueries;
+import javax.persistence.NamedStoredProcedureQuery;
+import javax.persistence.ParameterMode;
+import javax.persistence.SqlResultSetMapping;
+import javax.persistence.StoredProcedureParameter;
+
+/**
+ * This entity map a stored procedure.
+ * <p>
+ * The implementation of the store procedure can change between dialect but the idea
+ * is that it will returned a {@link Car} initialized with the value passed as parameters.
+ *
+ * @author Davide D'Alto
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+@Entity
+@NamedStoredProcedureQueries({
+		@NamedStoredProcedureQuery(name = "returnPositionalParametersWithEntity", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = String.class)
+			}, resultClasses = Car.class),
+		@NamedStoredProcedureQuery(name = "returnPositionalParametersWithMapping", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = String.class)
+				}, resultSetMappings = "carMapping"),
+		@NamedStoredProcedureQuery(name = "returnPositionalParametersRaw", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = String.class)
+				}),
+		@NamedStoredProcedureQuery(name = "returnNamedParametersWithEntity", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(name = "result", mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_ID_PARAM, mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_TITLE_PARAM, mode = ParameterMode.IN, type = String.class)
+			}, resultClasses = Car.class),
+		@NamedStoredProcedureQuery(name = "returnNamedParametersWithMapping", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(name = "result", mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_ID_PARAM, mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_TITLE_PARAM, mode = ParameterMode.IN, type = String.class)
+			}, resultSetMappings = "carMapping"),
+		@NamedStoredProcedureQuery(name = "returnNamedParametersRaw", procedureName = Car.RESULT_SET_PROC,
+			parameters = {
+				@StoredProcedureParameter(name = "result", mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_ID_PARAM, mode = ParameterMode.IN, type = Integer.class),
+				@StoredProcedureParameter(name = Car.RESULT_SET_PROC_TITLE_PARAM, mode = ParameterMode.IN, type = String.class)
+			})
+})
+@SqlResultSetMapping(name = "carMapping", entities = { @EntityResult(entityClass = Car.class) })
+public class Car {
+
+	public static final String SIMPLE_VALUE_PROC = "simpleValueProcedure";
+	public static final String UNIQUE_VALUE_PROC_PARAM = "param";
+
+	public static final String RESULT_SET_PROC = "resultSetProcedure";
+	public static final String RESULT_SET_PROC_ID_PARAM = "id";
+	public static final String RESULT_SET_PROC_TITLE_PARAM = "title";
+
+	@Id
+	private Integer id;
+
+	private String title;
+
+	public Car() {
+	}
+
+	public Car(Integer id, String title) {
+		this.id = id;
+		this.title = title;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Car car = (Car) o;
+		return Objects.equals( id, car.id ) &&
+				Objects.equals( title, car.title );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( id );
+	}
+
+	@Override
+	public String toString() {
+		return "Car{" + id + ", '" + title + '}';
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/Motorbike.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/Motorbike.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.storedprocedures;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * This class is only use to test that an exception is thrown when calling a stored procedure that returns multiple
+ * entities.
+ *
+ * @author Davide D'Alto
+ */
+@Entity
+class Motorbike {
+
+	@Id
+	private Integer id;
+
+	private String title;
+
+	public Motorbike() {
+	}
+
+	public Motorbike(Integer id, String title) {
+		this.id = id;
+		this.title = title;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Motorbike car = (Motorbike) o;
+		return Objects.equals( id, car.id );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( id );
+	}
+
+	@Override
+	public String toString() {
+		return "Motorbike{" + id + ", '" + title + '}';
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/NamedParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/NamedParametersStoredProcedureCallTest.java
@@ -1,0 +1,169 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.storedprocedures;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.RESULT_SET_PROC;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.RESULT_SET_PROC_ID_PARAM;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.RESULT_SET_PROC_TITLE_PARAM;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.SIMPLE_VALUE_PROC;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.UNIQUE_VALUE_PROC_PARAM;
+import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
+import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.ParameterMode;
+import javax.persistence.PersistenceException;
+import javax.persistence.StoredProcedureQuery;
+
+import org.hibernate.HibernateException;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Testing call of stored procedures that supports named parameters.
+ * <p>
+ * Note that the datastore must have defined 2 stored procedures:
+ * <p>
+ * One that returns a value that can be mapped to {@link Car} and another store procedure that returns the value passed
+ * as parameter. The name of the stored procedures are respectively {@link Car#RESULT_SET_PROC} and
+ * {@link Car#SIMPLE_VALUE_PROC}.
+ *
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+@SkipByGridDialect(
+		value = { HASHMAP, INFINISPAN, INFINISPAN_REMOTE, NEO4J_EMBEDDED, NEO4J_REMOTE, MONGODB },
+		comment = "These dialects don't support stored procedures with named parameters")
+@TestForIssue(jiraKey = { "OGM-359" })
+public class NamedParametersStoredProcedureCallTest extends OgmJpaTestCase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	protected EntityManager em;
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testSingleResultDynamicCall() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( SIMPLE_VALUE_PROC );
+		storedProcedureQuery.registerStoredProcedureParameter( UNIQUE_VALUE_PROC_PARAM, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( UNIQUE_VALUE_PROC_PARAM, 1 );
+
+		Number singleResult = (Number) storedProcedureQuery.getSingleResult();
+		assertThat( singleResult ).isEqualTo( 1 );
+	}
+
+	@Test
+	public void testResultSetDynamicCallWithResultClass() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class );
+
+		storedProcedureQuery.registerStoredProcedureParameter( "result", Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( RESULT_SET_PROC_ID_PARAM, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( RESULT_SET_PROC_TITLE_PARAM, String.class, ParameterMode.IN );
+
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_ID_PARAM, 1 );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_TITLE_PARAM, "title" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 1, "title" ) );
+	}
+
+	@Test
+	public void testResultSetDynamicCallWithResultMapping() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, "carMapping" );
+
+		storedProcedureQuery.registerStoredProcedureParameter( "result", Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( RESULT_SET_PROC_ID_PARAM, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( RESULT_SET_PROC_TITLE_PARAM, String.class, ParameterMode.IN );
+
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_ID_PARAM, 2 );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_TITLE_PARAM, "title'1" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 2, "title'1" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithResultClass() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnNamedParametersWithEntity" );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_ID_PARAM, 1 );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_TITLE_PARAM, "title" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 1, "title" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithResultMapping() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnNamedParametersWithMapping" );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_ID_PARAM, 2 );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_TITLE_PARAM, "title'2" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 2, "title'2" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallRaw() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnNamedParametersRaw" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_ID_PARAM, 2 );
+		storedProcedureQuery.setParameter( RESULT_SET_PROC_TITLE_PARAM, "title'2" );
+
+		@SuppressWarnings("unchecked")
+		List<Object[]> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Object[]{ 2, "title'2" } );
+	}
+
+	@Test
+	public void testExceptionWhenMultipleEntitiesAreUsed() throws Exception {
+		thrown.expect( PersistenceException.class );
+		thrown.expectCause( isA( HibernateException.class ) );
+		thrown.expectMessage(
+				"org.hibernate.HibernateException: OGM000090: Returning multiple entities is not supported. Procedure '" + RESULT_SET_PROC
+						+ "' expects results of type [Car, Motorbike]" );
+
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class, Motorbike.class );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( 2, String.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 1, 1 );
+		storedProcedureQuery.setParameter( 2, "title" );
+		storedProcedureQuery.getResultList();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Car.class, Motorbike.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -1,0 +1,227 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.storedprocedures;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.RESULT_SET_PROC;
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.SIMPLE_VALUE_PROC;
+import static org.hibernate.ogm.utils.GridDialectType.HASHMAP;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
+import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Parameter;
+import javax.persistence.ParameterMode;
+import javax.persistence.PersistenceException;
+import javax.persistence.StoredProcedureQuery;
+
+import org.hibernate.HibernateException;
+import org.hibernate.ogm.utils.SkipByGridDialect;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Testing call of stored procedures that supports indexed parameters
+ * <p>
+ * Note that the datastore must have defined 2 stored procedures:
+ * <p>
+ * One that returns a value that can be mapped to {@link Car} and another store procedure that returns the value passed
+ * as parameter. The name of the stored procedures are respectively {@link Car#RESULT_SET_PROC} and
+ * {@link Car#SIMPLE_VALUE_PROC}.
+ *
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+@SkipByGridDialect(
+		value = { HASHMAP, INFINISPAN, INFINISPAN_REMOTE, NEO4J_EMBEDDED, NEO4J_REMOTE },
+		comment = "These dialects not support stored procedures with positional parameters")
+@TestForIssue(jiraKey = { "OGM-359" })
+public class PositionalParametersStoredProcedureCallTest extends OgmJpaTestCase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	protected EntityManager em;
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testSingleResultDynamicCall() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( SIMPLE_VALUE_PROC );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 0, 1 );
+
+		Number singleResult = (Number) storedProcedureQuery.getSingleResult();
+		assertThat( singleResult.intValue() ).isEqualTo( 1 );
+	}
+
+	@Test
+	public void testResultSetDynamicCallWithResultClass() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( 2, String.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 1, 1 );
+		storedProcedureQuery.setParameter( 2, "title" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsOnly( new Car( 1, "title" ) );
+	}
+
+	@Test
+	public void testResultSetDynamicCallWithResultMapping() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, "carMapping" );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( 2, String.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 1, 1 );
+		Parameter<String> p2 = storedProcedureQuery.getParameter( 2,String.class );
+		storedProcedureQuery.setParameter( p2, "title'1" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsOnly( new Car( 1, "title'1" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithResultClass() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithEntity" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 1 );
+		storedProcedureQuery.setParameter( 3, "title" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsOnly( new Car( 1, "title" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithResultMapping() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithMapping" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 2 );
+		storedProcedureQuery.setParameter( 3, "title'2" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 2, "title'2" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallRaw() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersRaw" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 2 );
+		storedProcedureQuery.setParameter( 3, "title'2" );
+
+		@SuppressWarnings("unchecked")
+		List<Object[]> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Object[]{ 2, "title'2" } );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithCodeInjectionForMongoDB() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithMapping" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 2 );
+		storedProcedureQuery.setParameter( 3, "title'2\") && returnPositionalParametersWithMapping(2,\"\");" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 2, "title'2\") && returnPositionalParametersWithMapping(2,\"\");" ) );
+
+		storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithMapping" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 3 );
+		storedProcedureQuery.setParameter( 3, "title'2\\" );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult2 = storedProcedureQuery.getResultList();
+		assertThat( listResult2 ).containsExactly( new Car( 3, "title'2\\" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithNullStringParameter() throws Exception {
+		thrown.expect( IllegalArgumentException.class );
+		thrown.expectMessage( "String" ); // String parameter cannot be null
+
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithMapping" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, 2 );
+		storedProcedureQuery.setParameter( 3, null );
+
+		@SuppressWarnings("unchecked")
+		List<Car> listResult = storedProcedureQuery.getResultList();
+		assertThat( listResult ).containsExactly( new Car( 2, "title'2" ) );
+	}
+
+	@Test
+	public void testResultSetStaticCallWithNullIntegerParameter() throws Exception {
+		thrown.expect( IllegalArgumentException.class );
+		thrown.expectMessage( "Integer" ); // Integer parameter cannot be null
+
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnPositionalParametersWithMapping" );
+		// First parameter is void
+		storedProcedureQuery.setParameter( 2, null );
+		storedProcedureQuery.setParameter( 3, "Whatever" );
+		storedProcedureQuery.getResultList();
+	}
+
+	@Test
+	public void testExceptionWhenMultipleEntitiesAreUsed() throws Exception {
+		thrown.expect( PersistenceException.class );
+		thrown.expectCause( isA( HibernateException.class ) );
+		thrown.expectMessage(
+				"org.hibernate.HibernateException: OGM000090: Returning multiple entities is not supported. Procedure '" + RESULT_SET_PROC
+						+ "' expects results of type [Car, Motorbike]" );
+
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class, Motorbike.class );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( 2, String.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 1, 1 );
+		storedProcedureQuery.setParameter( 2, "title" );
+		storedProcedureQuery.getResultList();
+	}
+
+	@Test
+	public void testExceptionWhenInvalidTypeIsPassed() throws Exception {
+		thrown.expect( IllegalArgumentException.class );
+
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class );
+		storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+		storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+		storedProcedureQuery.registerStoredProcedureParameter( 2, String.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( 1, 1 );
+		// Should be a string
+		storedProcedureQuery.setParameter( 2, 5 );
+		storedProcedureQuery.getResultList();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Car.class, Motorbike.class };
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/test/storedprocedures/MockStoredProcedureDialect.java
+++ b/core/src/test/java/org/hibernate/ogm/test/storedprocedures/MockStoredProcedureDialect.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.storedprocedures;
+
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.UNIQUE_VALUE_PROC_PARAM;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.ogm.backendtck.storedprocedures.Car;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.dialect.spi.AssociationContext;
+import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
+import org.hibernate.ogm.dialect.spi.BaseGridDialect;
+import org.hibernate.ogm.dialect.spi.ModelConsumer;
+import org.hibernate.ogm.dialect.spi.NextValueRequest;
+import org.hibernate.ogm.dialect.spi.OperationContext;
+import org.hibernate.ogm.dialect.spi.TupleContext;
+import org.hibernate.ogm.dialect.spi.TupleTypeContext;
+import org.hibernate.ogm.dialect.storedprocedure.spi.StoredProcedureAwareGridDialect;
+import org.hibernate.ogm.entityentry.impl.TuplePointer;
+import org.hibernate.ogm.model.key.spi.AssociationKey;
+import org.hibernate.ogm.model.key.spi.AssociationKeyMetadata;
+import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.model.spi.Association;
+import org.hibernate.ogm.model.spi.Tuple;
+import org.hibernate.ogm.storedprocedure.ProcedureQueryParameters;
+import org.hibernate.ogm.util.impl.CollectionHelper;
+
+/**
+ * This dialect is used to test stored procedures calls.
+ *
+ * @see Car
+ *
+ * @author Davide D'Alto
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class MockStoredProcedureDialect extends BaseGridDialect implements StoredProcedureAwareGridDialect {
+
+	public MockStoredProcedureDialect(DatastoreProvider provider) {
+	}
+
+	@Override
+	public ClosableIterator<Tuple> callStoredProcedure(String storedProcedureName, ProcedureQueryParameters queryParameters, TupleContext tupleContext) {
+		switch ( storedProcedureName ) {
+			case Car.RESULT_SET_PROC:
+				return callResultsetStoredProcedure( queryParameters );
+			case Car.SIMPLE_VALUE_PROC:
+				return callSimpleValueStoredProcedure( queryParameters );
+			default:
+				return CollectionHelper.newClosableIterator( Collections.emptyList() );
+		}
+	}
+
+	private ClosableIterator<Tuple> callSimpleValueStoredProcedure(ProcedureQueryParameters queryParameters) {
+		Integer simpleValueParam = getSimpleValue( queryParameters );
+		if ( simpleValueParam == 1 ) {
+			Tuple tuple = new Tuple();
+			tuple.put( "", 1 );
+			return CollectionHelper.newClosableIterator( Arrays.asList( tuple ) );
+		}
+		return CollectionHelper.newClosableIterator( Collections.emptyList() );
+	}
+
+	private static ClosableIterator<Tuple> callResultsetStoredProcedure(ProcedureQueryParameters queryParameters) {
+		List<Tuple> tuples = new ArrayList<>();
+		Integer carId = carId( queryParameters );
+		String carTitle = carTitle( queryParameters );
+		Tuple tuple = new Tuple();
+		tuple.put( "id", carId );
+		tuple.put( "title", carTitle );
+		tuples.add( tuple );
+		return CollectionHelper.newClosableIterator( tuples );
+	}
+
+	private static Integer getSimpleValue(ProcedureQueryParameters queryParameters) {
+		if ( queryParameters.getNamedParameters().isEmpty() ) {
+			return (Integer) queryParameters.getPositionalParameters().get( 0 );
+		}
+		return (Integer) queryParameters.getNamedParameters().get( UNIQUE_VALUE_PROC_PARAM );
+	}
+
+	private static Integer carId(ProcedureQueryParameters queryParameters) {
+		if ( queryParameters.getNamedParameters().isEmpty() ) {
+			return (Integer) queryParameters.getPositionalParameters().get( 0 );
+		}
+		return (Integer) queryParameters.getNamedParameters().get( Car.RESULT_SET_PROC_ID_PARAM );
+	}
+
+	private static String carTitle(ProcedureQueryParameters queryParameters) {
+		if ( queryParameters.getNamedParameters().isEmpty() ) {
+			return (String) queryParameters.getPositionalParameters().get( 1 );
+		}
+		return (String) queryParameters.getNamedParameters().get( Car.RESULT_SET_PROC_TITLE_PARAM );
+	}
+
+	public Tuple getTuple(EntityKey key, OperationContext tupleContext) {
+		return null;
+	}
+
+	@Override
+	public Tuple createTuple(EntityKey key, OperationContext tupleContext) {
+		return null;
+	}
+
+	@Override
+	public void insertOrUpdateTuple(EntityKey key, TuplePointer tuplePointer, TupleContext tupleContext) {
+	}
+
+	@Override
+	public void removeTuple(EntityKey key, TupleContext tupleContext) {
+	}
+
+	@Override
+	public Association getAssociation(AssociationKey key, AssociationContext associationContext) {
+		return null;
+	}
+
+	@Override
+	public Association createAssociation(AssociationKey key, AssociationContext associationContext) {
+		return null;
+	}
+
+	@Override
+	public void insertOrUpdateAssociation(AssociationKey key, Association association, AssociationContext associationContext) {
+	}
+
+	@Override
+	public void removeAssociation(AssociationKey key, AssociationContext associationContext) {
+	}
+
+	@Override
+	public boolean isStoredInEntityStructure(AssociationKeyMetadata associationKeyMetadata, AssociationTypeContext associationTypeContext) {
+		return false;
+	}
+
+	@Override
+	public Number nextValue(NextValueRequest request) {
+		return null;
+	}
+
+	@Override
+	public void forEachTuple(ModelConsumer consumer, TupleTypeContext tupleTypeContext, EntityKeyMetadata entityKeyMetadata) {
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/test/storedprocedures/NamedParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/storedprocedures/NamedParametersStoredProcedureCallTest.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.storedprocedures;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Properties;
+
+import javax.persistence.StoredProcedureQuery;
+
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
+import org.hibernate.procedure.internal.NoSQLProcedureCallImpl;
+import org.junit.Test;
+
+/**
+ * This class is supposed to run the tests in {@link NamedParametersStoredProcedureCallTest} on a mock dialect to make
+ * sure that the right parameters are passed.
+ *
+ * @see MockStoredProcedureDialect
+ * @author Davide D'Alto
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+public class NamedParametersStoredProcedureCallTest extends org.hibernate.ogm.backendtck.storedprocedures.NamedParametersStoredProcedureCallTest {
+
+	@Test
+	public void testStoredProcedureQueryImplementation() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( "Whatever" );
+		assertThat( storedProcedureQuery ).isInstanceOf( NoSQLProcedureCallImpl.class );
+	}
+
+	@Test
+	public void testNamedStoredProcedureQueryImplementation() throws Exception {
+		StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "returnNamedParametersWithEntity" );
+		assertThat( storedProcedureQuery ).isInstanceOf( NoSQLProcedureCallImpl.class );
+	}
+
+	@Override
+	protected void configure(GetterPersistenceUnitInfo info) {
+		Properties properties = info.getProperties();
+		properties.setProperty( OgmProperties.GRID_DIALECT, MockStoredProcedureDialect.class.getName() );
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/test/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/test/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.test.storedprocedures;
+
+import java.util.Properties;
+
+import org.hibernate.ogm.cfg.OgmProperties;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.GetterPersistenceUnitInfo;
+
+/**
+ * @author Sergey Chernolyas &amp;sergey_chernolyas@gmail.com&amp;
+ */
+@TestForIssue(jiraKey = { "OGM-359" })
+public class PositionalParametersStoredProcedureCallTest extends org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest {
+
+	@Override
+	protected void configure(GetterPersistenceUnitInfo info) {
+		Properties properties = info.getProperties();
+		properties.setProperty( OgmProperties.GRID_DIALECT, MockStoredProcedureDialect.class.getName() );
+	}
+}

--- a/documentation/manual/src/main/asciidoc/modules/mongodb.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/mongodb.asciidoc
@@ -3473,6 +3473,59 @@ List<Poem> result = session.createNativeQuery( nativeQuery ).addEntity( Poem.cla
 ----
 ====
 
+[[ogm-mongodb-stored-proc-native]]
+
+==== Server-side JavaScript and stored procedures
+
+[NOTE]
+====
+This is an experimental feature.
+====
+
+In MongoDB, it is possible to call server-side JavaScript as if it is a stored procedure.
+You can use the existing methods in JPA:
+
+.Calling server-side JavaScript with positional parameters
+====
+[source, JAVA]
+----
+  @Entity
+  public class Car {
+    @Id
+    private Integer id;
+
+    private String brand;
+
+    ...
+  }
+
+  EntityManager em = ...
+  StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( "findMostExpensiveCars", Car.class );
+  storedProcedureQuery.registerStoredProcedureParameter( "year", Integer.class, ParameterMode.IN );
+  storedProcedureQuery.setParameter( "year", 1995 );
+  List<Car> cars = storedProcedureQuery.getResultList();
+----
+====
+
+This example will work assuming that there is a `findMostExpensiveCars` JavaScript function in MongoDB 
+and that the result of the function is a list of cars that can be mapped to the `Car` entity.
+
+.Calling server-side JavaScript with Hibernate OGM with positional parameters
+====
+[source, JSON]
+----
+{
+  "result" : [
+    { "id":1, "brand":"Bentley" },
+    { "id":2, "brand":"Maserati" },
+  ]
+}
+----
+====
+
+More details about server-side functions can be found in
+https://docs.mongodb.com/manual/core/server-side-JavaScript[the MongoDB reference documentation].
+
 ==== Hibernate Search
 
 You can index your entities using Hibernate Search.

--- a/documentation/manual/src/main/asciidoc/modules/query.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/query.asciidoc
@@ -8,6 +8,7 @@ With Hibernate OGM, you have a few alternatives that should get you covered:
 * Use JPQL - only for simple queries for now
 * Use the NoSQL native query mapping the result as managed entities
 * Use Hibernate Search queries - primarily full-text queries
+* Use stored procedures mapping the result as managed entities
 
 [[ogm-jpql-query]]
 === Using JPQL
@@ -421,3 +422,73 @@ go check the https://docs.jboss.org/hibernate/search/{hibernate-search-major-min
 === Using the Criteria API
 
 At this time, we have not implemented support for the Criteria APIs (neither Hibernate native nor JPA).
+
+=== Using stored procedures
+
+Often you want the raw power of the underlying NoSQL query engine.
+Even if that costs you portability.
+
+Hibernate OGM addresses that requirement by letting you express stored procedures (e.g. in server-side JavaScript for MongoDB)
+and map the result of these queries as mapped entities or return primitive results.
+
+In JPA, use `EntityManager.createStoredProcedureQuery` or `EntityManager.createNamedStoredProcedureQuery`.
+The first form accepts a result class if your result set maps the mapping definition of the entity.
+The second form accepts the name of a resultSetMapping
+and lets you customize how properties are mapped to columns by the query.
+You can also use a predefined named query which defines its result set mapping.
+
+Let's take a look at how it is done:
+
+.Various ways to create a stored procedure query in JPA
+====
+[source, JAVA]
+----
+@Entity
+@NamedStoredProcedureQueries({
+		@NamedStoredProcedureQuery(name = "find_cars_by_brand", procedureName = "resultSetResultProc", parameters = {
+				@StoredProcedureParameter(mode = ParameterMode.REF_CURSOR, type = Void.class),
+				@StoredProcedureParameter(mode = ParameterMode.IN, type = String.class)
+		}, resultSetMappings = "carMapping")
+})
+
+@SqlResultSetMapping(name = "carMapping", entities = { @EntityResult(entityClass = Car.class) })
+public class Car {
+
+    @Id
+    private Long id;
+
+    private String brand;
+
+   // getters, setters ...
+
+}
+
+...
+
+javax.persistence.EntityManager em = ...
+
+StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( "mostExpensiveCarsPerYear", Car.class );
+storedProcedureQuery.registerStoredProcedureParameter( 0, Void.class, ParameterMode.REF_CURSOR );
+storedProcedureQuery.registerStoredProcedureParameter( 1, Integer.class, ParameterMode.IN );
+storedProcedureQuery.setParameter( 1, 1995 );
+List<Car> cars = storedProcedureQuery.getResultList();
+
+// named stored procedure query
+StoredProcedureQuery storedProcedureQuery = em.createNamedStoredProcedureQuery( "find_cars_by_brand" );
+storedProcedureQuery.setParameter( 1, "Bentley" );
+List<Car> cars = storedProcedureQuery.getResultList();
+
+----
+====
+
+You can also use named parameters and `StoredProcedureQuery#getSingleResult()`.
+
+Check out each individual datastore chapter for more info
+on the specifics of the native query language mapping.
+
+[WARNING]
+====
+'OUT' and 'IN_OUT' parameters of stored procedures are not supported yet.
+Main reason of it is supported data storages support 'IN' parameters only.
+====
+

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/logging/impl/Log.java
@@ -16,7 +16,9 @@ import org.hibernate.MappingException;
 import org.hibernate.ogm.cfg.OgmProperties;
 import org.hibernate.ogm.datastore.mongodb.query.impl.MongoDBQueryDescriptor;
 import org.hibernate.ogm.model.key.spi.EntityKey;
+import org.hibernate.ogm.util.impl.ClassObjectFormatter;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.FormatWith;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -134,4 +136,12 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1237, value = "Invalid GeoJSON type %1$s. Expecting %2$s.")
 	HibernateException invalidGeoJsonType(String actualType, String expectedType);
 
+	@Message(id = 1238, value = "Unable to execute command \"%s\". Error message : %s. Code name: %s")
+	HibernateException unableToExecuteCommand(String command, String errorMessage,String codeMessage, @Cause Exception e);
+
+	@Message(id = 1239, value = "Dialect %s does not support named parameters when calling stored procedures")
+	HibernateException dialectDoesNotSupportNamedParametersForStoredProcedures( @FormatWith(ClassObjectFormatter.class) Class<?> dialectClass );
+
+	@Message(id = 1240, value = "Procedures returning muliple documents are not supported. Procedure '%1$s' returned %2$d results")
+	HibernateException multipleDocumentReturnedByStoredProcedure(String storedProcedureName, int size);
 }

--- a/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/storedprocedures/MongoDBStoredProcedureCallExceptionsTest.java
+++ b/mongodb/src/test/java/org/hibernate/ogm/datastore/mongodb/test/query/storedprocedures/MongoDBStoredProcedureCallExceptionsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.mongodb.test.query.storedprocedures;
+
+import static org.hibernate.ogm.backendtck.storedprocedures.Car.RESULT_SET_PROC;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import javax.persistence.EntityManager;
+import javax.persistence.ParameterMode;
+import javax.persistence.PersistenceException;
+import javax.persistence.StoredProcedureQuery;
+
+import org.hibernate.ogm.backendtck.storedprocedures.Car;
+import org.hibernate.ogm.utils.TestForIssue;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Testing call of stored procedures that supports indexed parameters
+ *
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = { "OGM-359" })
+public class MongoDBStoredProcedureCallExceptionsTest extends OgmJpaTestCase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	protected EntityManager em;
+
+	final Date groundhogDay = new GregorianCalendar( 1993, Calendar.FEBRUARY, 2 ).getTime();
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testExceptionWhenInvalidTypeIsPassedAsNamedParameter() throws Exception {
+		thrown.expect( PersistenceException.class );
+		thrown.expectMessage( "org.hibernate.HibernateException: OGM001239: Dialect org.hibernate.ogm.datastore.mongodb.MongoDBDialect does not support named parameters when calling stored procedures" );
+
+		StoredProcedureQuery storedProcedureQuery = em.createStoredProcedureQuery( RESULT_SET_PROC, Car.class );
+		storedProcedureQuery.registerStoredProcedureParameter( "param", Date.class, ParameterMode.IN );
+		storedProcedureQuery.setParameter( "param", groundhogDay );
+		storedProcedureQuery.getSingleResult();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Car.class };
+	}
+}


### PR DESCRIPTION
[OGM-359](https://hibernate.atlassian.net/browse/OGM-359)

Follows #976 

While  I was checking the latest PR on stored procedures I noticed several issues and ended up fixing them and rebase the history. I think now it's in a state the we can merge. In particular,  this PR:

* Fix the logic by making it more similar to the one in ORM
* Removes commons-lang library to escape strings and created a utility method that hopefully will work
* Adds test cases for when an exception is raised
* NoSQLProcedureResultSetOutputImpl.java is now the same as the one in ORM. The problem with the one in ORM is that it is package private
* Clean up the exception messages, they are more user friendly now 

There are still a couple of tests to add:
* Check storeprocedures returning multiple entities
* Test case for stored procedures in MongoDB causing log.multipleDocumentReturnedByStoredProcedure

I'll create a separate issue for these latest couple of cases