### PR TITLE
OGM-1235 Fix exception when Id generation is used with Table per concrete class strategy

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/EmptyMultiTableBulkIdStrategy.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/EmptyMultiTableBulkIdStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.dialect.impl;
+
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.internal.ast.HqlSqlWalker;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+
+public class EmptyMultiTableBulkIdStrategy implements MultiTableBulkIdStrategy {
+	@Override
+	public void prepare(
+			JdbcServices jdbcServices,
+			JdbcConnectionAccess connectionAccess,
+			MetadataImplementor metadata,
+			SessionFactoryOptions sessionFactoryOptions) {
+
+	}
+
+	@Override
+	public void release(
+			JdbcServices jdbcServices, JdbcConnectionAccess connectionAccess) {
+
+	}
+
+	@Override
+	public UpdateHandler buildUpdateHandler(
+			SessionFactoryImplementor factory, HqlSqlWalker walker) {
+		return null;
+	}
+
+	@Override
+	public DeleteHandler buildDeleteHandler(
+			SessionFactoryImplementor factory, HqlSqlWalker walker) {
+		return null;
+	}
+}

--- a/core/src/main/java/org/hibernate/ogm/dialect/impl/OgmDialect.java
+++ b/core/src/main/java/org/hibernate/ogm/dialect/impl/OgmDialect.java
@@ -11,6 +11,7 @@ import javax.persistence.GenerationType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.ogm.dialect.identity.spi.IdentityColumnAwareGridDialect;
 import org.hibernate.ogm.dialect.spi.GridDialect;
@@ -31,6 +32,11 @@ public class OgmDialect extends Dialect {
 
 	public OgmDialect(GridDialect gridDialect) {
 		this.gridDialect = gridDialect;
+	}
+
+	@Override
+	public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+		return new EmptyMultiTableBulkIdStrategy();
 	}
 
 	/**

--- a/core/src/test/java/org/hibernate/ogm/backendtck/id/TableIdGeneratorInheritanceTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/id/TableIdGeneratorInheritanceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.backendtck.id;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static javax.persistence.InheritanceType.TABLE_PER_CLASS;
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Test that @Inheritance(strategy = TABLE_PER_CLASS) with generated id work correct
+ */
+public class TableIdGeneratorInheritanceTest extends OgmJpaTestCase {
+
+	private static final String someTruckName = "someTruckName";
+	private static final String someOtherTruckName = "someOtherTruckName";
+	private EntityManager em;
+
+	@Before
+	public void setUp() {
+		em = getFactory().createEntityManager();
+	}
+
+	@After
+	public void tearDown() {
+		em.close();
+	}
+
+	@Test
+	public void testTableIdGeneratesAndEqualsSaved() {
+		Truck truck = new Truck();
+		doInTransaction( em -> em.persist( truck ) );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			assertThat( loadedTruck.getId() ).isEqualTo( truck.getId() );
+		} );
+	}
+
+	@Test
+	public void testInheritedTableIdGenerates() {
+		Truck truck = new Truck();
+		doInTransaction( em -> em.persist( truck ) );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			assertThat( loadedTruck.getId() ).isNotNull();
+		} );
+	}
+
+
+	@Test
+	public void testInheritedTableUpdates() {
+		Truck truck = new Truck();
+		truck.setName( someTruckName );
+
+		doInTransaction( em -> em.persist( truck ) );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			assertThat( loadedTruck.getName() ).isEqualTo( someTruckName );
+
+			loadedTruck.setName( someOtherTruckName );
+			em.persist( loadedTruck );
+
+		} );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			assertThat( loadedTruck.getName() ).isEqualTo( someOtherTruckName );
+		} );
+	}
+
+	private void doInTransaction(Consumer<EntityManager> action) {
+		em.getTransaction().begin();
+
+		action.accept( em );
+
+		em.getTransaction().commit();
+		em.clear();
+	}
+
+	@Test
+	public void testInheritedTableDelete() {
+		Truck truck = new Truck();
+		doInTransaction( em -> em.persist( truck ) );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			em.remove( loadedTruck );
+		} );
+
+		doInTransaction( em -> {
+			Truck loadedTruck = em.find( Truck.class, truck.getId() );
+			assertThat( loadedTruck ).isNull();
+		} );
+
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				BaseCar.class,
+				Truck.class
+		};
+	}
+
+	@Entity
+	@Table(name = "TRUCK")
+	private static class Truck extends BaseCar {
+	}
+
+	@Entity
+	@Table(name = "BASE_CAR")
+	@Inheritance(strategy = TABLE_PER_CLASS)
+	private abstract static class BaseCar {
+		protected UUID id;
+		private String name;
+
+		@Id
+		@GeneratedValue(generator = "uuid")
+		@GenericGenerator(name = "uuid", strategy = "uuid2")
+		public UUID getId() {
+			return id;
+		}
+
+		public void setId(UUID id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}


### PR DESCRIPTION
Сontinuation of #968 and #985
added EmptyMultiTableBulkIdStrategy
switch dialect to EmptyMultiTableBulkIdStrategy
extend TableIdGeneratorInheritanceTest with delete and update tests