### PR TITLE
OGM-1413 Upgrade Wildfly distribution to 12.0.0

### DIFF
--- a/documentation/manual/src/main/asciidoc/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/configuration.asciidoc
@@ -527,6 +527,38 @@ https://docs.jboss.org/author/display/WFLY10/Class+Loading+in+WildFly[WildFly do
 
 WildFly will by default attempt to guess which Persistence Provider you need by having a look at the `provider` section of the `persistence.xml`.
 
+==== Enable support for JEE 8
+
+Hibernate OGM {hibernate-ogm-version} requires **CDI 2.0** and **JPA 2.2**, that belong to **JEE8** specification.
+WildFly 12 has limited support for Java EE8.
+
+To enable required CDI version we need to start the server with __ee8.preview.mode__ Java system property set to **true** :
+
+----
+-Dee8.preview.mode=true
+----
+
+To enable required JPA version we need to apply __hibernate-jpa-api-2.2-wildflymodules__ patch to the server.
+Download the patch from here:
+
+ * http://central.maven.org/maven2/org/hibernate/javax/persistence/hibernate-jpa-api-2.2-wildflymodules/1.0.0.Beta2/hibernate-jpa-api-2.2-wildflymodules-1.0.0.Beta2-wildfly-12.0.0.Final-patch.zip
+
+Or using these maven coordinates:
+[source, XML]
+[subs="verbatim,attributes"]
+----
+<groupId>org.hibernate.javax.persistence</groupId>
+<artifactId>hibernate-jpa-api-2.2-wildflymodules</artifactId>
+<classifier>wildfly-{wildfly-version}-patch</classifier>
+<version>1.0.0.Beta2</version>
+<type>zip</type>
+----
+
+To apply the patch execute the JBoss cli command:
+----
+patch apply --override-all hibernate-jpa-api-2.2-wildflymodules-1.0.0.Beta2-wildfly-12.0.0-patch.zip
+----
+
 ==== Using the Hibernate OGM modules with Infinispan
 
 The Infinispan project also provides custom modules for WildFly {wildfly-short-version}.

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -172,24 +172,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>fetch-cdi20-patch</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>${cdi20patch.url}</url>
-                            <unpack>false</unpack>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-           <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
@@ -203,27 +185,8 @@
                         <configuration>
                             <offline>true</offline>
                             <jbossHome>${jboss.home}</jbossHome>
-                            <!-- The CLI script below will fail if the patch was already applied in a previous build -->
-                            <fail-on-error>false</fail-on-error>
                             <commands>
-                                <command>patch apply --override-all --path ${project.build.directory}/${jpa22patch.filename}</command>
-                            </commands>
-                        </configuration>
-                    </execution>
-                    <!-- Install CDI 2.0 patch -->
-                    <execution>
-                        <id>apply-wildfly-node1-cdi20-patch-file</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>execute-commands</goal>
-                        </goals>
-                        <configuration>
-                            <offline>true</offline>
-                            <jbossHome>${jboss.home}</jbossHome>
-                            <!-- The CLI script below will fail if the patch was already applied in a previous build -->
-                            <fail-on-error>false</fail-on-error>
-                            <commands>
-                                <command>patch apply --override-all --path ${project.build.directory}/${cdi20patch.filename}</command>
+                                <command>patch apply --override-all ${project.build.directory}/${jpa22patch.filename}</command>
                             </commands>
                         </configuration>
                     </execution>

--- a/integrationtest/src/test/resources/arquillian.xml
+++ b/integrationtest/src/test/resources/arquillian.xml
@@ -19,7 +19,9 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions</property>
+            <!-- -Dee8.preview.mode=true is to Enable CDI 2.0 on Wildfly 12.0 -->
+            <!-- When JEE8 will be available by default we can remove it -->
+            <property name="javaVmArguments">-XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true -XX:+IgnoreUnrecognizedVMOptions -Dee8.preview.mode=true</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property> -->
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <embeddedMongoDbPort>27018</embeddedMongoDbPort>
 
         <!-- Target version of WildFly (for testing and JipiJapa integration) -->
-        <version.wildfly>11.0.0.Final</version.wildfly>
-        <hibernateWildflyClassifier>wildfly-11-dist</hibernateWildflyClassifier>
-        <jpa22patch.version>1.0.0.Beta1</jpa22patch.version>
+        <version.wildfly>12.0.0.Final</version.wildfly>
+        <hibernateWildflyClassifier>wildfly-12-dist</hibernateWildflyClassifier>
+        <jpa22patch.version>1.0.0.Beta2</jpa22patch.version>
         <jpa22patch.filename>hibernate-jpa-api-2.2-wildflymodules-${jpa22patch.version}-wildfly-${version.wildfly}-patch.zip</jpa22patch.filename>
 
         <cdi20patch.version>3.0.2.Final</cdi20patch.version>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1413

Wildfly 12 has a partial support of JEE8, for instance CDI 2.0 is supported, not JPA 2.2.
We need to patch WF using JPA 2.2 patch for WF12.
We need to start the server with -Dee8.preview.mode=true to enable CDI 2.0. 