### PR TITLE
OGM-1460 In OgmSessionImpl, don't override the getTransaction() method

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionImpl.java
+++ b/core/src/main/java/org/hibernate/ogm/hibernatecore/impl/OgmSessionImpl.java
@@ -20,7 +20,6 @@ import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.SharedSessionBuilder;
 import org.hibernate.SimpleNaturalIdLoadAccess;
-import org.hibernate.Transaction;
 import org.hibernate.engine.spi.SessionDelegatorBaseImpl;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -69,16 +68,6 @@ public class OgmSessionImpl extends SessionDelegatorBaseImpl implements OgmSessi
 	@Override
 	public OgmSessionFactoryImplementor getSessionFactory() {
 		return factory;
-	}
-
-	/**
-	 * In ORM 5.2, it is not possible anymore to call getTransaction() in a JTA environment anymore.
-	 *
-	 * A lot of our shared tests rely on this and we want to keep them working for Neo4j.
-	 */
-	@Override
-	public Transaction getTransaction() {
-		return ( (SharedSessionContractImplementor) delegate ).accessTransaction();
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1460
  
When we upgraded to ORM 5.2 we had some failures because it wasn't possible anymore to
use the getTransaction() method in a JTA environment. We updated our tests since then and it
seems that this issue has been solved.

@fax4ever , this should be a quick one, let's just wait if it passes all the builds on CI.