### PR TITLE
OGM-1426 InfinispanRemote native queries follow up

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/query/parsing/impl/HibernateOGMQueryResolverDelegate.java
+++ b/core/src/main/java/org/hibernate/ogm/query/parsing/impl/HibernateOGMQueryResolverDelegate.java
@@ -4,29 +4,30 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.ogm.datastore.mongodb.query.parsing.impl;
+package org.hibernate.ogm.query.parsing.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.antlr.runtime.tree.Tree;
 import org.hibernate.hql.ast.common.JoinType;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PathedPropertyReference;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PathedPropertyReferenceSource;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
 import org.hibernate.hql.ast.spi.QueryResolverDelegate;
-import org.hibernate.ogm.datastore.mongodb.logging.impl.Log;
-import org.hibernate.ogm.datastore.mongodb.logging.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
+import org.antlr.runtime.tree.Tree;
 
 /**
- * Query resolver delegate targeting MongoDB queries. Very basic implementation atm., need to decide on
+ * Query resolver delegate. Very basic implementation atm., need to decide on
  * type checks, validation etc.
  *
  * @author Gunnar Morling
  *
  */
-public class MongoDBQueryResolverDelegate implements QueryResolverDelegate {
+public class HibernateOGMQueryResolverDelegate implements QueryResolverDelegate {
 
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 

--- a/core/src/main/java/org/hibernate/ogm/query/parsing/impl/KeepNamedParametersQueryRendererDelegate.java
+++ b/core/src/main/java/org/hibernate/ogm/query/parsing/impl/KeepNamedParametersQueryRendererDelegate.java
@@ -1,0 +1,177 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.query.parsing.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.hql.ast.origin.hql.resolve.path.AggregationPropertyPath;
+import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.hql.ast.spi.PropertyHelper;
+import org.hibernate.hql.ast.spi.SingleEntityQueryBuilder;
+import org.hibernate.hql.ast.spi.SingleEntityQueryRendererDelegate;
+import org.hibernate.hql.ast.spi.predicate.ComparisonPredicate;
+
+/**
+ * SingleEntityQueryRendererDelegate replaces named parameters with the corresponding values when the query is converted,
+ * but if the dialect supports queries with parameters it should instead keep the name of the parameters in the query and convert it to the right syntax.
+ * We cannot do this at the moment because some methods are private and cannot be overridden {@link SingleEntityQueryRendererDelegate#parameterValue(String)}.
+ * Therefore in this class there is a lot of duplicated code that we plan to remove when issue [https://hibernate.atlassian.net/browse/HQLPARSER-79] is solved.
+ *
+ * @param <Q> Builder class
+ * @param <R> Output class
+ *
+ * @see SingleEntityQueryRendererDelegate
+ */
+public abstract class KeepNamedParametersQueryRendererDelegate<Q, R> extends SingleEntityQueryRendererDelegate<Q, R> {
+
+	protected PropertyHelper propertyHelper;
+
+	public KeepNamedParametersQueryRendererDelegate(PropertyHelper propertyHelper, EntityNamesResolver entityNames,
+			SingleEntityQueryBuilder<Q> builder, Map<String, Object> namedParameters) {
+		super( propertyHelper, entityNames, builder, namedParameters );
+		this.propertyHelper = propertyHelper;
+	}
+
+	@Override
+	public void predicateLike(String patternValue, Character escapeCharacter) {
+		Object pattern = parameterValue( patternValue );
+		List<String> property = resolveAlias( propertyPath );
+		if ( status == Status.DEFINING_WHERE ) {
+			builder.addLikePredicate( property, (String) pattern, escapeCharacter );
+		}
+		else if ( status == Status.DEFINING_HAVING ) {
+			getHavingBuilder().addLikePredicate( getAggregation(), property, (String) pattern, escapeCharacter );
+		}
+		else {
+			throw new IllegalStateException();
+		}
+	}
+
+	@Override
+	public void predicateBetween(String lower, String upper) {
+		Object lowerComparisonValue = parameterValue( lower );
+		Object upperComparisonValue = parameterValue( upper );
+
+		List<String> property = resolveAlias( propertyPath );
+		if ( status == Status.DEFINING_WHERE ) {
+			builder.addRangePredicate( property, lowerComparisonValue, upperComparisonValue );
+		}
+		else if ( status == Status.DEFINING_HAVING ) {
+			getHavingBuilder().addRangePredicate( getAggregation(), property, lowerComparisonValue, upperComparisonValue );
+		}
+		else {
+			throw new IllegalStateException();
+		}
+	}
+
+	@Override
+	public void predicateLess(String comparativePredicate) {
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.LESS );
+	}
+
+	@Override
+	public void predicateLessOrEqual(String comparativePredicate) {
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.LESS_OR_EQUAL );
+	}
+
+	@Override
+	public void predicateEquals(final String comparativePredicate) {
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.EQUALS );
+	}
+
+	@Override
+	public void predicateNotEquals(String comparativePredicate) {
+		activateNOT();
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.EQUALS );
+		deactivateBoolean();
+	}
+
+	@Override
+	public void predicateGreaterOrEqual(String comparativePredicate) {
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.GREATER_OR_EQUAL );
+	}
+
+	@Override
+	public void predicateGreater(String comparativePredicate) {
+		addComparisonPredicate( comparativePredicate, ComparisonPredicate.Type.GREATER );
+	}
+
+	@Override
+	public void predicateIn(List<String> list) {
+		List<Object> values = fromNamedQuery( list );
+		List<String> property = resolveAlias( propertyPath );
+		if ( status == Status.DEFINING_WHERE ) {
+			builder.addInPredicate( property, values );
+		}
+		else if ( status == Status.DEFINING_HAVING ) {
+			getHavingBuilder().addInPredicate( getAggregation(), property, values );
+		}
+		else {
+			throw new IllegalStateException();
+		}
+	}
+
+	private AggregationPropertyPath.Type getAggregation() {
+		if ( propertyPath instanceof AggregationPropertyPath ) {
+			return ( (AggregationPropertyPath) propertyPath ).getType();
+		}
+		return null;
+	}
+
+	private void addComparisonPredicate(String comparativePredicate, ComparisonPredicate.Type comparisonType) {
+		Object comparisonValue = parameterValue( comparativePredicate );
+		List<String> property = resolveAlias( propertyPath );
+		if ( status == Status.DEFINING_WHERE ) {
+			builder.addComparisonPredicate( property, comparisonType, comparisonValue );
+		}
+		else if ( status == Status.DEFINING_HAVING ) {
+			getHavingBuilder().addComparisonPredicate( getAggregation(), property, comparisonType, comparisonValue );
+		}
+		else {
+			throw new IllegalStateException();
+		}
+	}
+
+	protected List<Object> fromNamedQuery(List<String> list) {
+		List<Object> elements = new ArrayList<>( list.size() );
+
+		for ( String string : list ) {
+			elements.add( parameterValue( string ) );
+		}
+
+		return elements;
+	}
+
+	protected Object parameterValue(String comparativePredicate) {
+		// It's a named parameter, we need to keep it as it is
+		if ( comparativePredicate.startsWith( ":" ) ) {
+			return getObjectParameter( comparativePredicate );
+		}
+		// It's a value given in JP-QL; Convert the literal value
+		else {
+			List<String> path = new ArrayList<String>();
+			path.addAll( propertyPath.getNodeNamesWithoutAlias() );
+
+			PropertyPath fullPath = propertyPath;
+
+			// create the complete path in case it's a join
+			while ( fullPath.getFirstNode().isAlias() && aliasToPropertyPath.containsKey( fullPath.getFirstNode().getName() ) ) {
+				fullPath = aliasToPropertyPath.get( fullPath.getFirstNode().getName() );
+				path.addAll( 0, fullPath.getNodeNamesWithoutAlias() );
+			}
+
+			return propertyHelper.convertToPropertyType( targetTypeName, path, comparativePredicate );
+		}
+	}
+
+	protected Object getObjectParameter(String comparativePredicate) {
+		return comparativePredicate;
+	}
+}

--- a/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/TablePerClassInheritancePersistTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/inheritance/tableperclass/family/TablePerClassInheritancePersistTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.backendtck.inheritance.tableperclass.family;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.MONGODB;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.NEO4J_BOLT;
 import static org.hibernate.ogm.datastore.impl.DatastoreProviderType.NEO4J_EMBEDDED;
@@ -68,7 +69,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testJpqlWithSingleResult() {
 		initDB();
@@ -82,7 +83,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testJpql() {
 		initDB();
@@ -96,7 +97,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testJpqlReturnPropertiesForMan() {
 		initDB();
@@ -112,7 +113,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testJpqlReturnPropertiesForChildren() {
 		initDB();
@@ -132,7 +133,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testJpqlReturnPropertiesForSubClasses() {
 		initDB();
@@ -158,7 +159,7 @@ public class TablePerClassInheritancePersistTest extends OgmJpaTestCase {
 	@Test
 	@TestForIssue(jiraKey = "OGM-1294")
 	@SkipByDatastoreProvider(
-			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED },
+			value = { MONGODB, NEO4J_BOLT, NEO4J_HTTP, NEO4J_EMBEDDED, INFINISPAN_REMOTE },
 			comment = "They don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy; requires multiple queries")
 	public void testPolymorphicAssociation() {
 		initDB();

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
@@ -541,7 +541,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 		hypothesis.setPosition( 29 );
 		session.persist( hypothesis );
 
-		if ( EnumSet.of( MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE ).contains( TestHelper.getCurrentDialectType() ) ) {
+		if ( EnumSet.of( MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE ).contains( TestHelper.getCurrentDialectType() ) ) {
 			assertQuery( session, query, 9, "Auto-flush should be performed prior to query execution" );
 		}
 		else {

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesTest.java
@@ -8,6 +8,7 @@ package org.hibernate.ogm.backendtck.queries;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
@@ -129,21 +130,21 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Selecting from associations is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Selecting from associations is not yet implemented.")
 	public void testSelectingAttributeFromAssociatedEntityInProjectionQuery() throws Exception {
 		List<ProjectionResult> projectionResult = asProjectionResults( "select h.author.name from Hypothesis h where h.id = 16" );
 		assertThat( projectionResult ).containsOnly( new ProjectionResult( "alfred" ) );
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Selecting from associations is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Selecting from associations is not yet implemented.")
 	public void testSelectingAttributeFromIndirectlyAssociatedEntityInProjectionQuery() throws Exception {
 		List<ProjectionResult> projectionResult = asProjectionResults( "select h.author.address.street from Hypothesis h where h.id = 16" );
 		assertThat( projectionResult ).containsOnly( new ProjectionResult( "Main Street" ) );
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Projecting complete entity is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Projecting complete entity is not yet implemented.")
 	public void testSelectingCompleteEntityInProjectionQuery() throws Exception {
 		List<?> projectionResult = session.createQuery( "select h, h.id from Hypothesis h where h.id = 16" ).list();
 		assertThat( projectionResult ).hasSize( 1 );
@@ -153,7 +154,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Doesn't apply to MongoDB or Neo4j queries.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Doesn't apply to MongoDB, Neo4j or Infinispan Remote queries.")
 	public void testSelectingCompleteIndexedEmbeddedEntityInProjectionQueryRaisesException() throws Exception {
 		thrown.expect( ParsingException.class );
 		thrown.expectMessage( "HQL100005" );
@@ -192,7 +193,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Selecting from associations is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Selecting from associations is not yet implemented.")
 	public void testQueryWithPropertyFromAssociatedEntityInWhereClause() throws Exception {
 		List<?> result = session.createQuery( "from Hypothesis h where h.author.name = 'alfred'" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( "16" );
@@ -307,7 +308,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Selecting from associated entities is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Selecting from associated entities is not yet implemented.")
 	public void testInQueryOnAssociatedEntity() throws Exception {
 		List<?> result = session.createQuery( "from Hypothesis h where h.author.name IN ('alma', 'alfred')" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( "14", "16" );
@@ -376,7 +377,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Querying on associated entities is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Querying on associated entities is not yet implemented.")
 	public void testLikeQueryWithSingleCharacterWildCard() throws Exception {
 		List<?> result = session.createQuery( "from Hypothesis h where h.author.name LIKE 'al_red'" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( "16" );
@@ -432,7 +433,7 @@ public class SimpleQueriesTest extends OgmTestCase {
 	}
 
 	@Test
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE }, comment = "Querying on associated entities is not yet implemented.")
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE }, comment = "Querying on associated entities is not yet implemented.")
 	public void testIsNullQueryOnPropertyOfAssociatedEntity() throws Exception {
 		List<?> result = session.createQuery( "from Hypothesis h where h.author.name IS null" ).list();
 		assertThat( result ).onProperty( "id" ).containsOnly( "19" );

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassInheritanceTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/SimpleQueriesWithTablePerClassInheritanceTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.backendtck.queries;
 
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 import static org.hibernate.ogm.utils.GridDialectType.MONGODB;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_EMBEDDED;
 import static org.hibernate.ogm.utils.GridDialectType.NEO4J_REMOTE;
@@ -67,7 +68,7 @@ public class SimpleQueriesWithTablePerClassInheritanceTest extends OgmTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "OGM-732")
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE })
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE })
 	public void testResultsFromPerson() throws Exception {
 		try ( Session session = openSession() ) {
 			Transaction tx = session.beginTransaction();
@@ -81,7 +82,7 @@ public class SimpleQueriesWithTablePerClassInheritanceTest extends OgmTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "OGM-732")
-	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE })
+	@SkipByGridDialect(value = { MONGODB, NEO4J_EMBEDDED, NEO4J_REMOTE, INFINISPAN_REMOTE })
 	public void testResultsFromCommunityMember() throws Exception {
 		try ( Session session = openSession() ) {
 			Transaction tx = session.beginTransaction();

--- a/core/src/test/java/org/hibernate/ogm/backendtck/queries/parameters/QueryWithParametersTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/queries/parameters/QueryWithParametersTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.ogm.backendtck.queries.parameters;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.ogm.utils.GridDialectType.INFINISPAN_REMOTE;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -16,6 +17,7 @@ import java.util.List;
 import javax.persistence.EntityManager;
 
 import org.hibernate.ogm.utils.PackagingRule;
+import org.hibernate.ogm.utils.SkipByGridDialect;
 import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -33,6 +35,7 @@ public class QueryWithParametersTest extends OgmJpaTestCase {
 	public PackagingRule packaging = new PackagingRule( "persistencexml/ogm.xml", Movie.class );
 
 	@Test
+	@SkipByGridDialect(value = { INFINISPAN_REMOTE }, comment = "Query on Byte field are currently not supported")
 	public void canUseByteForSimpleComparison() {
 		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
@@ -47,6 +50,7 @@ public class QueryWithParametersTest extends OgmJpaTestCase {
 	}
 
 	@Test
+	@SkipByGridDialect(value = { INFINISPAN_REMOTE }, comment = "Query on Byte field are currently not supported")
 	public void canUseByteAsParameterForSimpleComparison() {
 		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();
@@ -62,6 +66,7 @@ public class QueryWithParametersTest extends OgmJpaTestCase {
 	}
 
 	@Test
+	@SkipByGridDialect(value = { INFINISPAN_REMOTE }, comment = "Query on Byte field are currently not supported")
 	public void canUseByteAsParameterForInComparison() {
 		EntityManager entityManager = getFactory().createEntityManager();
 		entityManager.getTransaction().begin();

--- a/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
+++ b/core/src/test/java/org/hibernate/ogm/utils/GridDialectType.java
@@ -21,7 +21,7 @@ public enum GridDialectType {
 
 	INFINISPAN( "org.hibernate.ogm.datastore.infinispan.InfinispanDialect", false, false),
 
-	INFINISPAN_REMOTE( "org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect", true, false ),
+	INFINISPAN_REMOTE( "org.hibernate.ogm.datastore.infinispanremote.InfinispanRemoteDialect", true, true ),
 
 	MONGODB( "org.hibernate.ogm.datastore.mongodb.MongoDBDialect", true, true ),
 

--- a/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
@@ -2709,12 +2709,13 @@ We always recommend using transactional caches, at least unless you are confiden
 ==== Remote Query Capability
 
 Hibernate OGM backend is able to run the queries it needs to materialize relations.
-From version __5.4.0.Alpha2__ the dialect is capable to translate JPQL or Criteria queries to the Infinispan remote queries.
+From version __5.4.0.Alpha2__ the dialect is capable to translate JPQL to the **corresponding** Infinispan remote queries
+or to execute native queries.
 But there are still some limitations:
 
 * We don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy
-* Selecting from associations is not yet implemented
-* Query on Byte filed is not currently supported
+* Selecting from associations is not yet implemented (example: select h.author.name from Hypothesis h where author is a one-to-one association)
+* Query on Byte filed is currently unsupported
 
 ==== Known Limitations & Future improvements
 

--- a/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/infinispan.asciidoc
@@ -2577,24 +2577,10 @@ Hibernate OGM by convention will write to several named ``Cache``s, mapping each
 to a "cache name". In the above example, when having an `Hypothesis` entity this will
 write to a Cache named `Hypothesis`.
 
-The benefit is that you can tune each cache (each "table") independently; for example you could
+The benefit is that you can tune, or query, each cache (each "table") independently; for example you could
 configure the caches for the most important data to have a synchronous CacheStore which replicates
 data to a relational database, and have less important entries use an asynchronous CacheStore,
 or none at all, to favour performance over redundancy.
-
-The drawback of this design choice is that each named cache must be pre-defined in the Infinispan
-Server configuration: at this point, the Hot Rod protocol is not allowed to start missing caches
-so Hibernate OGM can not define the missing tables automatically.
-It generates the encoding protobuf, but you have to list the Cache names in the server configuration.
-
-[WARNING]
-====
-For each "table name" your model would generate on a relational database, you have to define
-a matching Cache on the Infinispan Server.
-
-If any Cache is missing, Hibernate OGM will fail to start and list which table names were
-expected, but not found. We plan to automate the creation of missing caches in the future.
-====
 
 ==== Caches creation and Configuration
 
@@ -2720,6 +2706,16 @@ __OGM default configuration__ is transactional.
 We always recommend using transactional caches, at least unless you are confident that data consistency is not important for your use case.
 ====
 
+==== Remote Query Capability
+
+Hibernate OGM backend is able to run the queries it needs to materialize relations.
+From version __5.4.0.Alpha2__ the dialect is capable to translate JPQL or Criteria queries to the Infinispan remote queries.
+But there are still some limitations:
+
+* We don't support queries on polymorphic entities using TABLE_PER_CLASS inheritance strategy
+* Selecting from associations is not yet implemented
+* Query on Byte filed is not currently supported
+
 ==== Known Limitations & Future improvements
 
 The Infinispan Remote dataprovider has some known limitations, some of which are
@@ -2728,11 +2724,6 @@ unsolvable without further development of Infinispan itself.
 Transaction Support::
 We're eagerly waiting for Infinispan to support transactions over Hot Rod, as it
 already provides this feature in Embedded Mode.
-
-Queries::
-At this point the Hibernate OGM backend is able to run the queries it needs to materialize
-relations, but does not yet translate JPQL queries nor Criteria queries to the
-Infinispan remote queries.
 
 Indexing::
 Infinispan supports Hibernate Search annotations directly embedded within its protobuf

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
@@ -28,6 +28,7 @@ import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
 import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryHandler;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteNativeQueryParser;
 import org.hibernate.ogm.datastore.map.impl.MapAssociationSnapshot;
 import org.hibernate.ogm.datastore.map.impl.MapHelpers;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
@@ -179,7 +180,7 @@ public class InfinispanRemoteDialect<EK, AK, ISK> extends AbstractGroupingByEnti
 
 	@Override
 	public InfinispanRemoteQueryDescriptor parseNativeQuery(String nativeQuery) {
-		throw new UnsupportedOperationException( "Native Query not supported by Infinispan Remote Dialect" );
+		return new InfinispanRemoteNativeQueryParser( nativeQuery ).parse();
 	}
 
 	/**

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/InfinispanRemoteDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,7 +26,8 @@ import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.Protostream
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryHandler;
 import org.hibernate.ogm.datastore.map.impl.MapAssociationSnapshot;
 import org.hibernate.ogm.datastore.map.impl.MapHelpers;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
@@ -36,7 +38,12 @@ import org.hibernate.ogm.dialect.batch.spi.Operation;
 import org.hibernate.ogm.dialect.batch.spi.RemoveAssociationOperation;
 import org.hibernate.ogm.dialect.impl.AbstractGroupingByEntityDialect;
 import org.hibernate.ogm.dialect.multiget.spi.MultigetGridDialect;
+import org.hibernate.ogm.dialect.query.spi.BackendQuery;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.dialect.query.spi.NoOpParameterMetadataBuilder;
+import org.hibernate.ogm.dialect.query.spi.ParameterMetadataBuilder;
+import org.hibernate.ogm.dialect.query.spi.QueryParameters;
+import org.hibernate.ogm.dialect.query.spi.QueryableGridDialect;
 import org.hibernate.ogm.dialect.spi.AssociationContext;
 import org.hibernate.ogm.dialect.spi.AssociationTypeContext;
 import org.hibernate.ogm.dialect.spi.DuplicateInsertPreventionStrategy;
@@ -60,6 +67,7 @@ import org.hibernate.ogm.model.spi.AssociationOperation;
 import org.hibernate.ogm.model.spi.AssociationOperationType;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
+
 import org.infinispan.client.hotrod.MetadataValue;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.Search;
@@ -71,33 +79,31 @@ import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
 
 /**
- *  Some implementation notes for evolution:
+ * Some implementation notes for evolution:
  *
- *  - QueryableGridDialect can't be implemented as "native queries" in Hot Rod are DSL based
- *    and have no String representation; this might change as Hot Rod exposes the underlying
- *    query representation which is similar to HQL; alternatively we could look at exposing
- *    native queries in some way other than a String.
+ * - OptimisticLockingAwareGridDialect can't be implemented as it requires an atomic replace
+ * operation on a subset of the columns, while atomic operations in Hot Rod have to involve
+ * either the full value or the version metadata of Infinispan's VersionedValue.
  *
- *  - OptimisticLockingAwareGridDialect can't be implemented as it requires an atomic replace
- *    operation on a subset of the columns, while atomic operations in Hot Rod have to involve
- *    either the full value or the version metadata of Infinispan's VersionedValue.
+ * - IdentityColumnAwareGridDialect can't work out of the box. I suspect we could do this but
+ * would need extending the Infinispan server deployment with some extension such as a
+ * custom script to be invoked from the client.
  *
- *  - IdentityColumnAwareGridDialect can't work out of the box. I suspect we could do this but
- *    would need extending the Infinispan server deployment with some extension such as a
- *    custom script to be invoked from the client.
- *
- *  - BatchableGridDialect could probably be implemented.
+ * - BatchableGridDialect could probably be implemented.
  *
  * @author Sanne Grinovero
+ * @author Fabio Massimo Ercoli
  */
-public class InfinispanRemoteDialect<EK,AK,ISK> extends AbstractGroupingByEntityDialect implements MultigetGridDialect {
+public class InfinispanRemoteDialect<EK, AK, ISK> extends AbstractGroupingByEntityDialect implements QueryableGridDialect<InfinispanRemoteQueryDescriptor>, MultigetGridDialect {
 
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	private final InfinispanRemoteDatastoreProvider provider;
+	private final InfinispanRemoteQueryHandler queryHandler;
 
 	public InfinispanRemoteDialect(InfinispanRemoteDatastoreProvider provider) {
 		this.provider = Objects.requireNonNull( provider );
+		this.queryHandler = new InfinispanRemoteQueryHandler( provider );
 	}
 
 	@Override
@@ -154,6 +160,26 @@ public class InfinispanRemoteDialect<EK,AK,ISK> extends AbstractGroupingByEntity
 		}
 
 		owningEntity.flushOperations();
+	}
+
+	@Override
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<InfinispanRemoteQueryDescriptor> backendQuery, QueryParameters queryParameters, TupleContext tupleContext) {
+		return queryHandler.executeBackendQuery( backendQuery, queryParameters );
+	}
+
+	@Override
+	public int executeBackendUpdateQuery(BackendQuery<InfinispanRemoteQueryDescriptor> query, QueryParameters queryParameters, TupleContext tupleContext) {
+		throw new UnsupportedOperationException( "Update Query not supported by Infinispan Remote Dialect" );
+	}
+
+	@Override
+	public ParameterMetadataBuilder getParameterMetadataBuilder() {
+		return NoOpParameterMetadataBuilder.INSTANCE;
+	}
+
+	@Override
+	public InfinispanRemoteQueryDescriptor parseNativeQuery(String nativeQuery) {
+		throw new UnsupportedOperationException( "Native Query not supported by Infinispan Remote Dialect" );
 	}
 
 	/**

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/InfinispanRemoteDatastoreProvider.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/impl/InfinispanRemoteDatastoreProvider.java
@@ -25,11 +25,13 @@ import org.hibernate.ogm.datastore.infinispanremote.impl.schema.SequenceTableDef
 import org.hibernate.ogm.datastore.infinispanremote.impl.sequences.HotRodSequenceHandler;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
 import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteBasedQueryParserService;
 import org.hibernate.ogm.datastore.infinispanremote.schema.spi.SchemaCapture;
 import org.hibernate.ogm.datastore.infinispanremote.schema.spi.SchemaOverride;
 import org.hibernate.ogm.datastore.spi.BaseDatastoreProvider;
 import org.hibernate.ogm.datastore.spi.SchemaDefiner;
 import org.hibernate.ogm.dialect.spi.GridDialect;
+import org.hibernate.ogm.query.spi.QueryParserService;
 import org.hibernate.ogm.util.impl.EffectivelyFinal;
 import org.hibernate.service.spi.Configurable;
 import org.hibernate.service.spi.ServiceRegistryAwareService;
@@ -192,6 +194,11 @@ public class InfinispanRemoteDatastoreProvider extends BaseDatastoreProvider
 	public boolean allowsTransactionEmulation() {
 		// Hot Rod doesn't support "true" transaction yet
 		return true;
+	}
+
+	@Override
+	public Class<? extends QueryParserService> getDefaultQueryParserServiceType() {
+		return InfinispanRemoteBasedQueryParserService.class;
 	}
 
 	public String getProtobufPackageName() {

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
@@ -86,4 +86,6 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1719, value = "Error during caches start phase")
 	HibernateException errorAtCachesStart(@Cause Exception cause);
 
+	@Message(id = 1720, value = "Error on parsing native query: <%s>")
+	HibernateException errorOnParsingNativeQuery(String nativeQuery);
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/logging/impl/Log.java
@@ -86,6 +86,9 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 	@Message(id = 1719, value = "Error during caches start phase")
 	HibernateException errorAtCachesStart(@Cause Exception cause);
 
-	@Message(id = 1720, value = "Error on parsing native query: <%s>")
-	HibernateException errorOnParsingNativeQuery(String nativeQuery);
+	@Message(id = 1720, value = "Missing from clause in native query: <%s>")
+	HibernateException missingFromClauseInNativeQuery(String nativeQuery);
+
+	@Message(id = 1721, value = "Infinispan queries can only target a single entity type. Found %s for query: %s")
+	HibernateException multipleEntitiesInFromClause(String[] split, String nativeQuery);
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.impl;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes a query to be executed against Infinispan Server.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteQueryDescriptor implements Serializable {
+
+	private final String cache;
+	private final String text;
+	private final List<String> projections;
+
+	public InfinispanRemoteQueryDescriptor(String cache, String text, List<String> projections) {
+		this.cache = cache;
+		this.text = text;
+		this.projections = projections;
+	}
+
+	public String getCache() {
+		return cache;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public List<String> getProjections() {
+		return projections;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		InfinispanRemoteQueryDescriptor that = (InfinispanRemoteQueryDescriptor) o;
+		return Objects.equals( cache, that.cache ) &&
+				Objects.equals( text, that.text ) &&
+				Objects.equals( projections, that.projections );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( cache, text, projections );
+	}
+
+	@Override
+	public String toString() {
+		return "InfinispanRemoteQueryDescriptor{" +
+				"cache='" + cache + '\'' +
+				", text='" + text + '\'' +
+				", projections=" + projections +
+				'}';
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
@@ -7,8 +7,7 @@
 package org.hibernate.ogm.datastore.infinispanremote.query.impl;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Objects;
+import java.util.Arrays;
 
 /**
  * Describes a query to be executed against Infinispan Server.
@@ -19,9 +18,9 @@ public class InfinispanRemoteQueryDescriptor implements Serializable {
 
 	private final String cache;
 	private final String query;
-	private final List<String> projections;
+	private final String[] projections;
 
-	public InfinispanRemoteQueryDescriptor(String cache, String query, List<String> projections) {
+	public InfinispanRemoteQueryDescriptor(String cache, String query, String[] projections) {
 		this.cache = cache;
 		this.query = query;
 		this.projections = projections;
@@ -35,27 +34,8 @@ public class InfinispanRemoteQueryDescriptor implements Serializable {
 		return query;
 	}
 
-	public List<String> getProjections() {
+	public String[] getProjections() {
 		return projections;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
-			return true;
-		}
-		if ( o == null || getClass() != o.getClass() ) {
-			return false;
-		}
-		InfinispanRemoteQueryDescriptor that = (InfinispanRemoteQueryDescriptor) o;
-		return Objects.equals( cache, that.cache ) &&
-				Objects.equals( query, that.query ) &&
-				Objects.equals( projections, that.projections );
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash( cache, query, projections );
 	}
 
 	@Override
@@ -63,7 +43,7 @@ public class InfinispanRemoteQueryDescriptor implements Serializable {
 		return "InfinispanRemoteQueryDescriptor{" +
 				"cache='" + cache + '\'' +
 				", query='" + query + '\'' +
-				", projections=" + projections +
+				", projections='" + Arrays.toString( projections ) + '\'' +
 				'}';
 	}
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryDescriptor.java
@@ -18,12 +18,12 @@ import java.util.Objects;
 public class InfinispanRemoteQueryDescriptor implements Serializable {
 
 	private final String cache;
-	private final String text;
+	private final String query;
 	private final List<String> projections;
 
-	public InfinispanRemoteQueryDescriptor(String cache, String text, List<String> projections) {
+	public InfinispanRemoteQueryDescriptor(String cache, String query, List<String> projections) {
 		this.cache = cache;
-		this.text = text;
+		this.query = query;
 		this.projections = projections;
 	}
 
@@ -31,8 +31,8 @@ public class InfinispanRemoteQueryDescriptor implements Serializable {
 		return cache;
 	}
 
-	public String getText() {
-		return text;
+	public String getQuery() {
+		return query;
 	}
 
 	public List<String> getProjections() {
@@ -49,20 +49,20 @@ public class InfinispanRemoteQueryDescriptor implements Serializable {
 		}
 		InfinispanRemoteQueryDescriptor that = (InfinispanRemoteQueryDescriptor) o;
 		return Objects.equals( cache, that.cache ) &&
-				Objects.equals( text, that.text ) &&
+				Objects.equals( query, that.query ) &&
 				Objects.equals( projections, that.projections );
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash( cache, text, projections );
+		return Objects.hash( cache, query, projections );
 	}
 
 	@Override
 	public String toString() {
 		return "InfinispanRemoteQueryDescriptor{" +
 				"cache='" + cache + '\'' +
-				", text='" + text + '\'' +
+				", query='" + query + '\'' +
 				", projections=" + projections +
 				'}';
 	}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
@@ -49,7 +49,7 @@ public class InfinispanRemoteQueryHandler {
 		QueryFactory queryFactory = Search.getQueryFactory( cache );
 		Query query = queryFactory.create( queryDescriptor.getText() );
 
-		applyNamedParamters( queryParameters, query );
+		applyNamedParameters( queryParameters, query );
 		applyRowSelection( queryParameters, query );
 
 		boolean hasProjection = !queryDescriptor.getProjections().isEmpty();
@@ -66,7 +66,7 @@ public class InfinispanRemoteQueryHandler {
 				new ProtostreamPayloadClosableIterator( query.list() );
 	}
 
-	private void applyNamedParamters(QueryParameters queryParameters, Query query) {
+	private void applyNamedParameters(QueryParameters queryParameters, Query query) {
 		for ( Map.Entry<String, TypedGridValue> param : queryParameters.getNamedParameters().entrySet() ) {
 			query.setParameter( param.getKey(), getValue( param ) );
 		}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
@@ -47,7 +47,7 @@ public class InfinispanRemoteQueryHandler {
 		RemoteCache<ProtostreamId, ProtostreamPayload> cache = provider.getCache( queryDescriptor.getCache() );
 
 		QueryFactory queryFactory = Search.getQueryFactory( cache );
-		Query query = queryFactory.create( queryDescriptor.getText() );
+		Query query = queryFactory.create( queryDescriptor.getQuery() );
 
 		applyNamedParameters( queryParameters, query );
 		applyRowSelection( queryParameters, query );

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/InfinispanRemoteQueryHandler.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamId;
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.dialect.query.spi.BackendQuery;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.dialect.query.spi.QueryParameters;
+import org.hibernate.ogm.dialect.query.spi.RowSelection;
+import org.hibernate.ogm.dialect.query.spi.TypedGridValue;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.model.spi.Tuple;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+
+/**
+ * Handles the query execution on the infinispan server.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteQueryHandler {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final InfinispanRemoteDatastoreProvider provider;
+
+	public InfinispanRemoteQueryHandler(InfinispanRemoteDatastoreProvider provider) {
+		this.provider = provider;
+	}
+
+	public ClosableIterator<Tuple> executeBackendQuery(BackendQuery<InfinispanRemoteQueryDescriptor> backendQuery, QueryParameters queryParameters) {
+		InfinispanRemoteQueryDescriptor queryDescriptor = backendQuery.getQuery();
+		RemoteCache<ProtostreamId, ProtostreamPayload> cache = provider.getCache( queryDescriptor.getCache() );
+
+		QueryFactory queryFactory = Search.getQueryFactory( cache );
+		Query query = queryFactory.create( queryDescriptor.getText() );
+
+		applyNamedParamters( queryParameters, query );
+		applyRowSelection( queryParameters, query );
+
+		boolean hasProjection = !queryDescriptor.getProjections().isEmpty();
+		EntityKeyMetadata entityKeyMetadata = backendQuery.getSingleEntityMetadataInformationOrNull() == null
+				? null
+				: backendQuery.getSingleEntityMetadataInformationOrNull().getEntityKeyMetadata();
+
+		if ( hasProjection && entityKeyMetadata != null ) {
+			throw log.addEntityNotAllowedInNativeQueriesUsingProjection( entityKeyMetadata.getTable(), backendQuery.toString() );
+		}
+
+		return hasProjection ?
+				new RawTypeClosableIterator( query.list(), queryDescriptor.getProjections() ) :
+				new ProtostreamPayloadClosableIterator( query.list() );
+	}
+
+	private void applyNamedParamters(QueryParameters queryParameters, Query query) {
+		for ( Map.Entry<String, TypedGridValue> param : queryParameters.getNamedParameters().entrySet() ) {
+			query.setParameter( param.getKey(), getValue( param ) );
+		}
+	}
+
+	private Object getValue(Map.Entry<String, TypedGridValue> param) {
+		Object value = param.getValue().getValue();
+
+		// Protobuf does not support Character type
+		// convert to String type
+		if ( value instanceof Character ) {
+			return value.toString();
+		}
+
+		return value;
+	}
+
+	private void applyRowSelection(QueryParameters queryParameters, Query query) {
+		RowSelection rowSelection = queryParameters.getRowSelection();
+		if ( rowSelection == null ) {
+			return;
+		}
+
+		Integer firstRow = rowSelection.getFirstRow();
+		Integer maxRows = rowSelection.getMaxRows();
+
+		if ( firstRow != null ) {
+			query.startOffset( firstRow );
+		}
+		if ( maxRows != null ) {
+			query.maxResults( maxRows );
+		}
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/ProtostreamPayloadClosableIterator.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/ProtostreamPayloadClosableIterator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote.query.impl;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
@@ -20,21 +21,20 @@ import org.hibernate.ogm.model.spi.Tuple;
  */
 public class ProtostreamPayloadClosableIterator implements ClosableIterator<Tuple> {
 
-	private final List<ProtostreamPayload> queryResult;
-	private int index = 0;
+	private final Iterator<ProtostreamPayload> delegate;
 
 	public ProtostreamPayloadClosableIterator(List<ProtostreamPayload> queryResult) {
-		this.queryResult = queryResult;
+		this.delegate = queryResult.iterator();
 	}
 
 	@Override
 	public boolean hasNext() {
-		return index < queryResult.size();
+		return delegate.hasNext();
 	}
 
 	@Override
 	public Tuple next() {
-		return queryResult.get( index++ ).toTuple( Tuple.SnapshotType.UPDATE );
+		return delegate.next().toTuple( Tuple.SnapshotType.UPDATE );
 	}
 
 	@Override

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/ProtostreamPayloadClosableIterator.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/ProtostreamPayloadClosableIterator.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.impl;
+
+import java.util.List;
+
+import org.hibernate.ogm.datastore.infinispanremote.impl.protostream.ProtostreamPayload;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.model.spi.Tuple;
+
+/**
+ * Iterates over the result of an Infinispan query, when each result is a **full** cache entry.
+ * This is the case when the result of query is mapped from a Protostream payload type.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class ProtostreamPayloadClosableIterator implements ClosableIterator<Tuple> {
+
+	private final List<ProtostreamPayload> queryResult;
+	private int index = 0;
+
+	public ProtostreamPayloadClosableIterator(List<ProtostreamPayload> queryResult) {
+		this.queryResult = queryResult;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return index < queryResult.size();
+	}
+
+	@Override
+	public Tuple next() {
+		return queryResult.get( index++ ).toTuple( Tuple.SnapshotType.UPDATE );
+	}
+
+	@Override
+	public void close() {
+		// nothing to close
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/RawTypeClosableIterator.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/RawTypeClosableIterator.java
@@ -6,9 +6,10 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote.query.impl;
 
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
@@ -24,24 +25,23 @@ import org.hibernate.ogm.model.spi.Tuple;
  */
 public class RawTypeClosableIterator implements ClosableIterator<Tuple> {
 
-	private final List<Object> queryResult;
+	private final Iterator<Object> queryResultIterator;
 	private final List<String> projections;
-	private int index = 0;
 
 	public RawTypeClosableIterator(List<Object> queryResult, List<String> projections) {
-		this.queryResult = queryResult;
+		this.queryResultIterator = queryResult.iterator();
 		this.projections = projections;
 	}
 
 	@Override
 	public boolean hasNext() {
-		return index < queryResult.size();
+		return queryResultIterator.hasNext();
 	}
 
 	@Override
 	public Tuple next() {
-		Object[] rawType = (Object[]) queryResult.get( index++ );
-		HashMap<String, Object> map = new LinkedHashMap<>();
+		Object[] rawType = (Object[]) queryResultIterator.next();
+		Map<String, Object> map = new LinkedHashMap<>();
 		int i = 0;
 
 		for ( String projection : projections ) {

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/RawTypeClosableIterator.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/impl/RawTypeClosableIterator.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.impl;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
+import org.hibernate.ogm.dialect.query.spi.ClosableIterator;
+import org.hibernate.ogm.model.spi.Tuple;
+
+/**
+ * Iterates over the result of an Infinispan query, when each result is a <b>partial</b> cache entry.
+ * This is the case when the result of query is mapped from a raw type.
+ * We have raw type result set in case of projection.
+ * The result will be a single or a List of {@link Object[]}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class RawTypeClosableIterator implements ClosableIterator<Tuple> {
+
+	private final List<Object> queryResult;
+	private final List<String> projections;
+	private int index = 0;
+
+	public RawTypeClosableIterator(List<Object> queryResult, List<String> projections) {
+		this.queryResult = queryResult;
+		this.projections = projections;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return index < queryResult.size();
+	}
+
+	@Override
+	public Tuple next() {
+		Object[] rawType = (Object[]) queryResult.get( index++ );
+		HashMap<String, Object> map = new LinkedHashMap<>();
+		int i = 0;
+
+		for ( String projection : projections ) {
+			map.put( projection, rawType[i++] );
+		}
+
+		return new Tuple( new MapTupleSnapshot( map ), Tuple.SnapshotType.UPDATE );
+	}
+
+	@Override
+	public void close() {
+		// nothing to close
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteBasedQueryParserService.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteBasedQueryParserService.java
@@ -34,7 +34,7 @@ public class InfinispanRemoteBasedQueryParserService extends BaseQueryParserServ
 
 	@Override
 	public QueryParsingResult parseQuery(SessionFactoryImplementor sessionFactory, String queryString, Map<String, Object> namedParameters) {
-		throw new UnsupportedOperationException( "The Infinispan Remote query parser supports parameterized queries" );
+		throw new UnsupportedOperationException( "The Infinispan Remote query parser doesn't support parameterized queries" );
 	}
 
 	@Override

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteBasedQueryParserService.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteBasedQueryParserService.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.Map;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.QueryParser;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.ogm.query.spi.BaseQueryParserService;
+import org.hibernate.ogm.query.spi.QueryParserService;
+import org.hibernate.ogm.query.spi.QueryParsingResult;
+import org.hibernate.ogm.service.impl.SessionFactoryEntityNamesResolver;
+import org.hibernate.ogm.util.impl.Log;
+import org.hibernate.ogm.util.impl.LoggerFactory;
+
+/**
+ * A {@link QueryParserService} implementation which creates Infinispan server queries in form of {@link String}s.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteBasedQueryParserService extends BaseQueryParserService {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private volatile SessionFactoryEntityNamesResolver entityNamesResolver;
+
+	@Override
+	public QueryParsingResult parseQuery(SessionFactoryImplementor sessionFactory, String queryString, Map<String, Object> namedParameters) {
+		throw new UnsupportedOperationException( "The Infinispan Remote query parser supports parameterized queries" );
+	}
+
+	@Override
+	public QueryParsingResult parseQuery(SessionFactoryImplementor sessionFactory, String queryString) {
+		QueryParser queryParser = new QueryParser();
+		InfinispanRemoteProcessingChain processingChain = createProcessingChain( sessionFactory );
+		InfinispanRemoteQueryParsingResult result = queryParser.parseQuery( queryString, processingChain );
+
+		log.createdQuery( queryString, result );
+
+		return result;
+	}
+
+	@Override
+	public boolean supportsParameters() {
+		return true;
+	}
+
+	private InfinispanRemoteProcessingChain createProcessingChain(SessionFactoryImplementor sessionFactory) {
+		EntityNamesResolver entityNamesResolver = getDefinedEntityNames( sessionFactory );
+		return new InfinispanRemoteProcessingChain( sessionFactory, entityNamesResolver, Collections.emptyMap() );
+	}
+
+	private EntityNamesResolver getDefinedEntityNames(SessionFactory sessionFactory) {
+		if ( entityNamesResolver == null ) {
+			entityNamesResolver = new SessionFactoryEntityNamesResolver( sessionFactory );
+		}
+		return entityNamesResolver;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteNativeQueryParser.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteNativeQueryParser.java
@@ -1,0 +1,136 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
+
+/**
+ * Utility class to extract the cache name and projections from an Infinispan Server native query.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteNativeQueryParser {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final SelectAndFromExtractor extractor = new SelectAndFromExtractor();
+	private final String nativeQuery;
+
+	private String select = null;
+	private String from = null;
+	private String alias = null;
+	private List<String> projections = new ArrayList<>();
+
+	public InfinispanRemoteNativeQueryParser(String nativeQuery) {
+		this.nativeQuery = nativeQuery;
+	}
+
+	/**
+	 * Creates an instance of {@link InfinispanRemoteQueryDescriptor},
+	 * as a result of the parse of a given native query
+	 *
+	 * @return Query descriptor
+	 */
+	public InfinispanRemoteQueryDescriptor parse() {
+		clearStatus();
+		extractor.extractSelectAndFrom();
+
+		if ( from == null || from.isEmpty() ) {
+			throw log.errorOnParsingNativeQuery( nativeQuery );
+		}
+
+		String[] fromWords = from.split( "\\s" );
+		if ( fromWords.length > 2 ) {
+			throw log.errorOnParsingNativeQuery( nativeQuery );
+		}
+
+		if ( fromWords.length == 2 ) {
+			alias = fromWords[1];
+		}
+		String[] cacheFullName = fromWords[0].split( "\\." );
+		String cacheName = cacheFullName[cacheFullName.length - 1];
+
+		makeProjection();
+		return new InfinispanRemoteQueryDescriptor( cacheName, nativeQuery, projections );
+	}
+
+	private void clearStatus() {
+		select = null;
+		from = null;
+		alias = null;
+		projections.clear();
+	}
+
+	private void makeProjection() {
+		if ( select.isEmpty() ) {
+			projections = Collections.emptyList();
+			return;
+		}
+
+		String[] projectors = select.split( "\\s*,\\s*" );
+		for ( int i = 0; i < projectors.length; i++ ) {
+			addProjector( projectors[i] );
+		}
+	}
+
+	private void addProjector(String projector) {
+		if ( alias == null ) {
+			projections.add( projector );
+			return;
+		}
+		if ( alias.equals( projector ) ) {
+			return;
+		}
+		if ( !projector.startsWith( alias + "." ) ) {
+			throw log.errorOnParsingNativeQuery( nativeQuery );
+		}
+
+		projections.add( projector.substring( alias.length() + 1 ) );
+	}
+
+	private final class SelectAndFromExtractor {
+
+		private Pattern fromPattern = Pattern.compile( "^\\s*from\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
+		private Pattern fromWherePattern = Pattern.compile( "^\\s*from\\s+(.*?)\\s+where\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
+		private Pattern selectPattern = Pattern.compile( "\\s*select\\s*(.*?)\\s+from\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
+		private Pattern selectWherePattern = Pattern.compile( "\\s*select\\s*(.*?)\\s+from\\s+(.*?)\\s*where\\s*(.*)\\s*", Pattern.CASE_INSENSITIVE );
+
+		private void extractSelectAndFrom() {
+			Matcher fromMatcher = fromPattern.matcher( nativeQuery );
+			Matcher fromWhereMatcher = fromWherePattern.matcher( nativeQuery );
+			Matcher selectMatcher = selectPattern.matcher( nativeQuery );
+			Matcher selectWhereMatcher = selectWherePattern.matcher( nativeQuery );
+
+			boolean matchFrom = fromMatcher.find();
+			boolean matchFromWhere = fromWhereMatcher.find();
+			boolean matchSelect = selectMatcher.find();
+			boolean matchSelectWhere = selectWhereMatcher.find();
+
+			if ( !matchFrom && !matchSelect ) {
+				throw log.errorOnParsingNativeQuery( nativeQuery );
+			}
+
+			if ( matchFrom ) {
+				select = "";
+				from = ( matchFromWhere ) ? fromWhereMatcher.group( 1 ) : fromMatcher.group( 1 );
+			}
+			else {
+				select = selectMatcher.group( 1 );
+				from = ( matchSelectWhere ) ? selectWhereMatcher.group( 2 ) : selectMatcher.group( 2 );
+			}
+		}
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteNativeQueryParser.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteNativeQueryParser.java
@@ -7,9 +7,6 @@
 package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,119 +15,86 @@ import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
 
 /**
- * Utility class to extract the cache name and projections from an Infinispan Server native query.
+ * Utility class to extract information we need about the Ickle native query
  *
+ * @author Davide D'Alto
  * @author Fabio Massimo Ercoli
  */
+
 public class InfinispanRemoteNativeQueryParser {
 
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
-	private final SelectAndFromExtractor extractor = new SelectAndFromExtractor();
-	private final String nativeQuery;
+	private static final Pattern PROJECTIONS_PATTERN = Pattern.compile( "^\\s*select\\s+(.*?)\\s+from\\s+(.*?)", Pattern.CASE_INSENSITIVE );
+	private static final Pattern FROM_PATTERN = Pattern.compile( "^\\s*(select\\s+(.*?)\\s+)?(from\\s+.*?)(\\s+where\\s*.*)?\\s*", Pattern.CASE_INSENSITIVE );
 
-	private String select = null;
-	private String from = null;
-	private String alias = null;
-	private List<String> projections = new ArrayList<>();
+	private final String nativeQuery;
 
 	public InfinispanRemoteNativeQueryParser(String nativeQuery) {
 		this.nativeQuery = nativeQuery;
 	}
 
 	/**
-	 * Creates an instance of {@link InfinispanRemoteQueryDescriptor},
-	 * as a result of the parse of a given native query
+	 * Creates an instance of {@link InfinispanRemoteQueryDescriptor}, as a result of the parse of a given native query
 	 *
 	 * @return Query descriptor
 	 */
 	public InfinispanRemoteQueryDescriptor parse() {
-		clearStatus();
-		extractor.extractSelectAndFrom();
-
-		if ( from == null || from.isEmpty() ) {
-			throw log.errorOnParsingNativeQuery( nativeQuery );
-		}
-
-		String[] fromWords = from.split( "\\s" );
-		if ( fromWords.length > 2 ) {
-			throw log.errorOnParsingNativeQuery( nativeQuery );
-		}
-
-		if ( fromWords.length == 2 ) {
-			alias = fromWords[1];
-		}
-		String[] cacheFullName = fromWords[0].split( "\\." );
-		String cacheName = cacheFullName[cacheFullName.length - 1];
-
-		makeProjection();
+		String fromClause = fromClause();
+		validateFromClause( fromClause );
+		String cacheName = cacheName( fromClause );
+		String entityAlias = entityAlias( fromClause );
+		String[] projections = projections( entityAlias );
 		return new InfinispanRemoteQueryDescriptor( cacheName, nativeQuery, projections );
 	}
 
-	private void clearStatus() {
-		select = null;
-		from = null;
-		alias = null;
-		projections.clear();
+	private String[] projections(String entityAlias) {
+		Matcher matcher = PROJECTIONS_PATTERN.matcher( nativeQuery );
+		if ( matcher.matches() ) {
+			String selectClause = matcher.group( 1 );
+			String[] split = selectClause.split( "\\s*,\\s*" );
+			if ( split.length > 1 ) {
+				return split;
+			}
+			if ( split.length == 1 && !split[0].equals( entityAlias ) ) {
+				// We exclude the case when the projection is the entity.
+				// Example: SELECT f FROM Flower f
+				return split;
+			}
+		}
+		return null;
 	}
 
-	private void makeProjection() {
-		if ( select.isEmpty() ) {
-			projections = Collections.emptyList();
-			return;
-		}
-
-		String[] projectors = select.split( "\\s*,\\s*" );
-		for ( int i = 0; i < projectors.length; i++ ) {
-			addProjector( projectors[i] );
-		}
+	private String cacheName(String fromClause) {
+		String[] fromWords = fromClause.split( "\\s+" );
+		String[] cacheFullName = fromWords[0].split( "\\." );
+		String cacheName = cacheFullName[cacheFullName.length - 1];
+		return cacheName;
 	}
 
-	private void addProjector(String projector) {
-		if ( alias == null ) {
-			projections.add( projector );
-			return;
+	private String entityAlias(String fromClause) {
+		String[] fromWords = fromClause.split( "\\s+" );
+		if ( fromWords.length > 1 ) {
+			return fromWords[1];
 		}
-		if ( alias.equals( projector ) ) {
-			return;
-		}
-		if ( !projector.startsWith( alias + "." ) ) {
-			throw log.errorOnParsingNativeQuery( nativeQuery );
-		}
-
-		projections.add( projector.substring( alias.length() + 1 ) );
+		return null;
 	}
 
-	private final class SelectAndFromExtractor {
+	private String fromClause() {
+		Matcher fromMatcher = FROM_PATTERN.matcher( nativeQuery );
+		if ( fromMatcher.matches() ) {
+			String clause = fromMatcher.group( 3 );
+			// Remove the initial part: "from "
+			return clause.substring( 4 ).trim();
+		}
 
-		private Pattern fromPattern = Pattern.compile( "^\\s*from\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
-		private Pattern fromWherePattern = Pattern.compile( "^\\s*from\\s+(.*?)\\s+where\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
-		private Pattern selectPattern = Pattern.compile( "\\s*select\\s*(.*?)\\s+from\\s+(.*)\\s*", Pattern.CASE_INSENSITIVE );
-		private Pattern selectWherePattern = Pattern.compile( "\\s*select\\s*(.*?)\\s+from\\s+(.*?)\\s*where\\s*(.*)\\s*", Pattern.CASE_INSENSITIVE );
+		throw log.missingFromClauseInNativeQuery( nativeQuery );
+	}
 
-		private void extractSelectAndFrom() {
-			Matcher fromMatcher = fromPattern.matcher( nativeQuery );
-			Matcher fromWhereMatcher = fromWherePattern.matcher( nativeQuery );
-			Matcher selectMatcher = selectPattern.matcher( nativeQuery );
-			Matcher selectWhereMatcher = selectWherePattern.matcher( nativeQuery );
-
-			boolean matchFrom = fromMatcher.find();
-			boolean matchFromWhere = fromWhereMatcher.find();
-			boolean matchSelect = selectMatcher.find();
-			boolean matchSelectWhere = selectWhereMatcher.find();
-
-			if ( !matchFrom && !matchSelect ) {
-				throw log.errorOnParsingNativeQuery( nativeQuery );
-			}
-
-			if ( matchFrom ) {
-				select = "";
-				from = ( matchFromWhere ) ? fromWhereMatcher.group( 1 ) : fromMatcher.group( 1 );
-			}
-			else {
-				select = selectMatcher.group( 1 );
-				from = ( matchSelectWhere ) ? selectWhereMatcher.group( 2 ) : selectMatcher.group( 2 );
-			}
+	private void validateFromClause(String clause) {
+		String[] split = clause.split( "\\s*,\\s*" );
+		if ( split.length > 1 ) {
+			throw log.multipleEntitiesInFromClause( split, nativeQuery );
 		}
 	}
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePredicateFactory.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePredicateFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.util.List;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.ast.spi.predicate.ComparisonPredicate;
+import org.hibernate.hql.ast.spi.predicate.ConjunctionPredicate;
+import org.hibernate.hql.ast.spi.predicate.DisjunctionPredicate;
+import org.hibernate.hql.ast.spi.predicate.InPredicate;
+import org.hibernate.hql.ast.spi.predicate.IsNullPredicate;
+import org.hibernate.hql.ast.spi.predicate.LikePredicate;
+import org.hibernate.hql.ast.spi.predicate.NegationPredicate;
+import org.hibernate.hql.ast.spi.predicate.PredicateFactory;
+import org.hibernate.hql.ast.spi.predicate.RangePredicate;
+import org.hibernate.hql.ast.spi.predicate.RootPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.impl.InfinispanRemoteDatastoreProvider;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteComparisonPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteConjunctionPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteDisjunctionPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteInPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteIsNullPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteLikePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteNegationPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteRangePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl.InfinispanRemoteRootPredicate;
+import org.hibernate.ogm.datastore.spi.DatastoreProvider;
+import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * Factory for {@link org.hibernate.hql.ast.spi.predicate.Predicate}s creating Infinispan server queries in form of
+ * {@link StringBuilder}s.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemotePredicateFactory implements PredicateFactory<InfinispanRemoteQueryBuilder> {
+
+	private final SessionFactoryImplementor sessionFactory;
+	private final InfinispanRemotePropertyHelper propertyHelper;
+
+	public InfinispanRemotePredicateFactory(SessionFactoryImplementor sessionFactory, InfinispanRemotePropertyHelper propertyHelper) {
+		this.sessionFactory = sessionFactory;
+		this.propertyHelper = propertyHelper;
+	}
+
+	@Override
+	public RootPredicate<InfinispanRemoteQueryBuilder> getRootPredicate(String entityType) {
+		EntityKeyMetadata entityKeyMetadata = ( (OgmEntityPersister) ( sessionFactory )
+				.getMetamodel()
+				.entityPersister( entityType ) )
+				.getEntityKeyMetadata();
+
+		ServiceRegistryImplementor serviceRegistry = sessionFactory.getServiceRegistry();
+		InfinispanRemoteDatastoreProvider datastoreProvider = (InfinispanRemoteDatastoreProvider) serviceRegistry.getService( DatastoreProvider.class );
+
+		return new InfinispanRemoteRootPredicate( entityKeyMetadata.getTable(), datastoreProvider.getProtobufPackageName() );
+	}
+
+	@Override
+	public ComparisonPredicate<InfinispanRemoteQueryBuilder> getComparisonPredicate(String entityType, ComparisonPredicate.Type comparisonType, List<String> propertyPath, Object value) {
+		String columnName = propertyHelper.getColumnName( entityType, propertyPath );
+		return new InfinispanRemoteComparisonPredicate( columnName, comparisonType, value );
+	}
+
+	@Override
+	public InPredicate<InfinispanRemoteQueryBuilder> getInPredicate(String entityType, List<String> propertyPath, List<Object> typedElements) {
+		String columnName = propertyHelper.getColumnName( entityType, propertyPath );
+		return new InfinispanRemoteInPredicate( columnName, typedElements );
+	}
+
+	@Override
+	public RangePredicate<InfinispanRemoteQueryBuilder> getRangePredicate(String entityType, List<String> propertyPath, Object lowerValue, Object upperValue) {
+		String columnName = propertyHelper.getColumnName( entityType, propertyPath );
+		return new InfinispanRemoteRangePredicate( columnName, lowerValue, upperValue );
+	}
+
+	@Override
+	public NegationPredicate<InfinispanRemoteQueryBuilder> getNegationPredicate() {
+		return new InfinispanRemoteNegationPredicate();
+	}
+
+	@Override
+	public DisjunctionPredicate<InfinispanRemoteQueryBuilder> getDisjunctionPredicate() {
+		return new InfinispanRemoteDisjunctionPredicate();
+	}
+
+	@Override
+	public ConjunctionPredicate<InfinispanRemoteQueryBuilder> getConjunctionPredicate() {
+		return new InfinispanRemoteConjunctionPredicate();
+	}
+
+	@Override
+	public LikePredicate<InfinispanRemoteQueryBuilder> getLikePredicate(String entityType, List<String> propertyPath, String patternValue, Character escapeCharacter) {
+		String columnName = propertyHelper.getColumnName( entityType, propertyPath );
+		return new InfinispanRemoteLikePredicate( columnName, patternValue, '/' );
+	}
+
+	@Override
+	public IsNullPredicate<InfinispanRemoteQueryBuilder> getIsNullPredicate(String entityType, List<String> propertyPath) {
+		String columnName = propertyHelper.getColumnName( entityType, propertyPath );
+		return new InfinispanRemoteIsNullPredicate( columnName );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteProcessingChain.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteProcessingChain.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.ast.spi.AstProcessingChain;
+import org.hibernate.hql.ast.spi.AstProcessor;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.hql.ast.spi.QueryRendererProcessor;
+import org.hibernate.hql.ast.spi.QueryResolverProcessor;
+import org.hibernate.ogm.query.parsing.impl.HibernateOGMQueryResolverDelegate;
+
+/**
+ * AST processing chain for creating Infinispan server queries in form of {@link String}s from HQL queries.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteProcessingChain implements AstProcessingChain<InfinispanRemoteQueryParsingResult> {
+
+	private final QueryResolverProcessor resolverProcessor;
+	private final QueryRendererProcessor rendererProcessor;
+	private final InfinispanRemoteQueryRendererDelegate rendererDelegate;
+
+	public InfinispanRemoteProcessingChain(SessionFactoryImplementor sessionFactory, EntityNamesResolver entityNamesResolver, Map<String, Object> namedParameters) {
+		HibernateOGMQueryResolverDelegate resolverDelegate = new HibernateOGMQueryResolverDelegate();
+		rendererDelegate = new InfinispanRemoteQueryRendererDelegate(
+				sessionFactory, entityNamesResolver, new InfinispanRemotePropertyHelper( sessionFactory, entityNamesResolver ), namedParameters );
+		this.resolverProcessor = new QueryResolverProcessor( resolverDelegate );
+		this.rendererProcessor = new QueryRendererProcessor( rendererDelegate );
+	}
+
+	@Override
+	public Iterator<AstProcessor> iterator() {
+		return Arrays.asList( resolverProcessor, rendererProcessor ).iterator();
+	}
+
+	@Override
+	public InfinispanRemoteQueryParsingResult getResult() {
+		return rendererDelegate.getResult();
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePropertyHelper.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePropertyHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.util.List;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.ogm.query.parsing.impl.ParserPropertyHelper;
+import org.hibernate.ogm.type.spi.GridType;
+import org.hibernate.ogm.type.spi.TypeTranslator;
+import org.hibernate.type.CollectionType;
+import org.hibernate.type.Type;
+
+/**
+ * Property helper dealing with Infinispan Remote.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemotePropertyHelper extends ParserPropertyHelper {
+
+	private final SessionFactoryImplementor sessionFactory;
+
+	public InfinispanRemotePropertyHelper(SessionFactoryImplementor sessionFactory, EntityNamesResolver entityNames) {
+		super( sessionFactory, entityNames );
+		this.sessionFactory = sessionFactory;
+	}
+
+	public String getColumnName(String entityType, List<String> propertyPath) {
+		return getColumn( getPersister( entityType ), propertyPath );
+	}
+
+	@Override
+	protected Type getPropertyType(String entityType, List<String> propertyPath) {
+		Type propertyType = super.getPropertyType( entityType, propertyPath );
+		if ( isElementCollection( propertyType ) ) {
+			// For collection of elements we return the type of the collection
+			return ( (CollectionType) propertyType ).getElementType( sessionFactory );
+		}
+		return propertyType;
+	}
+
+	@Override
+	public Object convertToBackendType(String entityType, List<String> propertyPath, Object value) {
+		if ( value instanceof InfinispanRemoteQueryParameter ) {
+			return value;
+		}
+
+		if ( value instanceof String ) {
+			return value;
+		}
+
+		Type propertyType = getPropertyType( entityType, propertyPath );
+		if ( isElementCollection( propertyType ) ) {
+			// For collection of elements we return the type of the collection
+			propertyType = ( (CollectionType) propertyType ).getElementType( sessionFactory );
+		}
+		GridType ogmType = sessionFactory.getServiceRegistry().getService( TypeTranslator.class ).getType( propertyType );
+		return ogmType.convertToBackendType( value, sessionFactory );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePropertyHelper.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemotePropertyHelper.java
@@ -50,10 +50,6 @@ public class InfinispanRemotePropertyHelper extends ParserPropertyHelper {
 			return value;
 		}
 
-		if ( value instanceof String ) {
-			return value;
-		}
-
 		Type propertyType = getPropertyType( entityType, propertyPath );
 		if ( isElementCollection( propertyType ) ) {
 			// For collection of elements we return the type of the collection

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryBuilder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+
+/**
+ * Helper class to append single or multiple values to the wrapped {@link StringBuilder}
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteQueryBuilder implements Serializable {
+
+	private StringBuilder builder;
+	private boolean where;
+
+	public InfinispanRemoteQueryBuilder() {
+		this.builder = new StringBuilder();
+	}
+
+	public InfinispanRemoteQueryBuilder(String content) {
+		this.builder = new StringBuilder( content );
+	}
+
+	public InfinispanRemoteQueryBuilder(String content, String otherContent) {
+		this.builder = new StringBuilder( content );
+		append( otherContent );
+	}
+
+	public InfinispanRemoteQueryBuilder(String content, InfinispanRemoteQueryBuilder child) {
+		this.builder = new StringBuilder( content );
+		append( child );
+	}
+
+	public void append(String content) {
+		builder.append( content );
+	}
+
+	public void append(InfinispanRemoteQueryBuilder child) {
+		builder.append( child.builder );
+	}
+
+	public void appendValue(Object value) {
+		boolean isConstant = value instanceof String;
+
+		if ( isConstant ) {
+			builder.append( "'" );
+		}
+		builder.append( value );
+		if ( isConstant ) {
+			builder.append( "'" );
+		}
+	}
+
+	public void appendValues(List<?> values) {
+		for ( int i = 0; i < values.size(); i++ ) {
+			appendValue( values.get( i ) );
+
+			if ( i != values.size() - 1 ) {
+				builder.append( ", " );
+			}
+		}
+	}
+
+	public void appendStrings(List<String> values) {
+		for ( int i = 0; i < values.size(); i++ ) {
+			builder.append( values.get( i ) );
+
+			if ( i != values.size() - 1 ) {
+				builder.append( ", " );
+			}
+		}
+	}
+
+	public void addWhere(InfinispanRemoteQueryBuilder subQuery) {
+		if ( where ) {
+			throw new HibernateException( "Impossible to add two times a where clause to the same query" );
+		}
+
+		builder.append( " where " );
+		builder.append( subQuery );
+		where = true;
+	}
+
+	public String getQuery() {
+		return builder.toString();
+	}
+
+	public boolean hasWhere() {
+		return where;
+	}
+
+	@Override
+	public String toString() {
+		return builder.toString();
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryBuilder.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryBuilder.java
@@ -109,7 +109,7 @@ public class InfinispanRemoteQueryBuilder implements Serializable {
 
 	public void addWhere(InfinispanRemoteQueryBuilder subQuery) {
 		if ( where ) {
-			throw new HibernateException( "Impossible to add two times a where clause to the same query" );
+			throw new HibernateException( "Impossible to add a where clause twice in the same query" );
 		}
 
 		builder.append( " where " );

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParameter.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParameter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.io.Serializable;
+
+/**
+ * Class represents a parameter of an Infinispan server query
+ */
+public class InfinispanRemoteQueryParameter implements Serializable {
+
+	private final String name;
+
+	public InfinispanRemoteQueryParameter(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return ":" + name;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParsingResult.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParsingResult.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.util.List;
+
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
+import org.hibernate.ogm.query.spi.QueryParsingResult;
+
+/**
+ * The result of walking a query parse tree using a {@link InfinispanRemoteQueryRendererDelegate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteQueryParsingResult implements QueryParsingResult {
+
+	private final String query;
+	private final String cache;
+	private final List<String> projection;
+
+	public InfinispanRemoteQueryParsingResult(InfinispanRemoteQueryBuilder builder, String cache, List<String> projection) {
+		this.query = builder.getQuery();
+		this.cache = cache;
+		this.projection = projection;
+	}
+
+	@Override
+	public Object getQueryObject() {
+		return new InfinispanRemoteQueryDescriptor( cache, query, projection );
+	}
+
+	@Override
+	public List<String> getColumnNames() {
+		return projection;
+	}
+
+	@Override
+	public String toString() {
+		return "InfinispanRemoteQueryParsingResult{" +
+				"query='" + query + '\'' +
+				", cache='" + cache + '\'' +
+				", projection=" + projection +
+				'}';
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParsingResult.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryParsingResult.java
@@ -30,7 +30,14 @@ public class InfinispanRemoteQueryParsingResult implements QueryParsingResult {
 
 	@Override
 	public Object getQueryObject() {
-		return new InfinispanRemoteQueryDescriptor( cache, query, projection );
+		return new InfinispanRemoteQueryDescriptor( cache, query, asArray( projection ) );
+	}
+
+	private String[] asArray(List<String> projection) {
+		if ( projection == null ) {
+			return null;
+		}
+		return projection.toArray( new String[projection.size()] );
 	}
 
 	@Override

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryRendererDelegate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/InfinispanRemoteQueryRendererDelegate.java
@@ -1,0 +1,177 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.ast.origin.hql.resolve.path.PathedPropertyReferenceSource;
+import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.hql.ast.spi.SingleEntityQueryBuilder;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.Log;
+import org.hibernate.ogm.datastore.infinispanremote.logging.impl.LoggerFactory;
+import org.hibernate.ogm.persister.impl.OgmEntityPersister;
+import org.hibernate.ogm.query.parsing.impl.KeepNamedParametersQueryRendererDelegate;
+
+/**
+ * Parser delegate which creates Infinispan Remote queries in form of {@link StringBuilder}s.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteQueryRendererDelegate extends KeepNamedParametersQueryRendererDelegate<InfinispanRemoteQueryBuilder, InfinispanRemoteQueryParsingResult> {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final SessionFactoryImplementor sessionFactory;
+	private InfinispanRemoteQueryBuilder sortClause;
+
+	public InfinispanRemoteQueryRendererDelegate(SessionFactoryImplementor sessionFactory, EntityNamesResolver entityNames,
+			InfinispanRemotePropertyHelper propertyHelper, Map<String, Object> namedParameters) {
+		super(
+				propertyHelper, entityNames, getSingleEntityQueryBuilder( sessionFactory, propertyHelper ),
+				namedParameters
+		);
+		this.sessionFactory = sessionFactory;
+	}
+
+	private static SingleEntityQueryBuilder<InfinispanRemoteQueryBuilder> getSingleEntityQueryBuilder(SessionFactoryImplementor sessionFactory,
+			InfinispanRemotePropertyHelper propertyHelper) {
+		return SingleEntityQueryBuilder.getInstance( new InfinispanRemotePredicateFactory( sessionFactory, propertyHelper ), propertyHelper );
+	}
+
+	@Override
+	public InfinispanRemoteQueryParsingResult getResult() {
+		OgmEntityPersister ogmEntityPersister = (OgmEntityPersister) ( sessionFactory )
+				.getMetamodel()
+				.entityPersister( targetTypeName );
+
+		String table = ogmEntityPersister
+				.getEntityKeyMetadata()
+				.getTable();
+
+		InfinispanRemoteQueryBuilder queryBuilder;
+
+		if ( projections.isEmpty() ) {
+			queryBuilder = builder.build();
+		}
+		else {
+			queryBuilder = createFromProjection();
+			queryBuilder.append( builder.build() );
+		}
+
+		applyInheritanceStrategy( ogmEntityPersister, queryBuilder );
+
+		if ( sortClause != null ) {
+			queryBuilder.append( sortClause );
+		}
+
+		return new InfinispanRemoteQueryParsingResult( queryBuilder, table, projections );
+	}
+
+	private void applyInheritanceStrategy(OgmEntityPersister entityPersister, InfinispanRemoteQueryBuilder queryBuilder) {
+		String discriminatorColumnName = entityPersister.getDiscriminatorColumnName();
+
+		if ( discriminatorColumnName != null ) {
+			addConditionOnDiscriminatorValue( entityPersister, queryBuilder, discriminatorColumnName );
+		}
+		else if ( entityPersister.hasSubclasses() ) {
+			Set<String> subclassEntityNames = entityPersister.getEntityMetamodel().getSubclassEntityNames();
+			throw LOG.queriesOnPolymorphicEntitiesAreNotSupportedWithTablePerClass( "Infinispan Server", subclassEntityNames );
+		}
+	}
+
+	private void addConditionOnDiscriminatorValue(OgmEntityPersister entityPersister, InfinispanRemoteQueryBuilder queryBuilder, String discriminatorColumnName) {
+		Object discriminatorValue = entityPersister.getDiscriminatorValue();
+		Set<String> subclassEntityNames = entityPersister.getEntityMetamodel().getSubclassEntityNames();
+
+		if ( queryBuilder.hasWhere() ) {
+			queryBuilder.append( " and " );
+		}
+		else {
+			queryBuilder.append( " where " );
+		}
+
+		queryBuilder.append( discriminatorColumnName );
+
+		if ( subclassEntityNames.size() == 1 ) {
+			queryBuilder.append( " = " );
+			queryBuilder.appendValue( discriminatorValue );
+		}
+		else {
+			List<Object> discriminatorValues = new ArrayList<>();
+			for ( String subclass : subclassEntityNames ) {
+				OgmEntityPersister subclassPersister = (OgmEntityPersister) sessionFactory.getMetamodel().entityPersister( subclass );
+				discriminatorValues.add( subclassPersister.getDiscriminatorValue() );
+			}
+
+			queryBuilder.append( " in (" );
+			queryBuilder.appendValues( discriminatorValues );
+			queryBuilder.append( ")" );
+		}
+	}
+
+	@Override
+	public void setPropertyPath(PropertyPath propertyPath) {
+		if ( status == Status.DEFINING_SELECT ) {
+			PathedPropertyReferenceSource last = propertyPath.getLastNode();
+
+			if ( !last.isAlias() ) {
+				String columnName = getColumnName( propertyPath );
+				projections.add( columnName );
+			}
+		}
+		else {
+			this.propertyPath = propertyPath;
+		}
+	}
+
+	@Override
+	protected void addSortField(PropertyPath propertyPath, String collateName, boolean isAscending) {
+		String columnName = getColumnName( propertyPath );
+		if ( sortClause == null ) {
+			sortClause = new InfinispanRemoteQueryBuilder( " order by " );
+		}
+		else {
+			sortClause.append( ", " );
+		}
+
+		appendSortField( isAscending, columnName );
+	}
+
+	private String getColumnName(PropertyPath propertyPath) {
+		return ( (InfinispanRemotePropertyHelper) propertyHelper ).getColumnName( targetTypeName, propertyPath.getNodeNamesWithoutAlias() );
+	}
+
+	private void appendSortField(boolean isAscending, String columnName) {
+		sortClause.append( columnName );
+
+		if ( isAscending ) {
+			sortClause.append( " asc" );
+		}
+		else {
+			sortClause.append( " desc" );
+		}
+	}
+
+	private InfinispanRemoteQueryBuilder createFromProjection() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( "select " );
+
+		builder.appendStrings( projections );
+		builder.append( " " );
+		return builder;
+	}
+
+	@Override
+	protected Object getObjectParameter(String comparativePredicate) {
+		return new InfinispanRemoteQueryParameter( comparativePredicate.substring( 1 ) );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteComparisonPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteComparisonPredicate.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.ComparisonPredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote implementation of {@link ComparisonPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteComparisonPredicate extends ComparisonPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteComparisonPredicate(String propertyName, ComparisonPredicate.Type comparisonType, Object value) {
+		super( propertyName, comparisonType, value );
+	}
+
+	@Override
+	protected InfinispanRemoteQueryBuilder getStrictlyLessQuery() {
+		return comparison( " < " );
+	}
+
+	@Override
+	protected InfinispanRemoteQueryBuilder getLessOrEqualsQuery() {
+		return comparison( " <= " );
+	}
+
+	@Override
+	protected InfinispanRemoteQueryBuilder getEqualsQuery() {
+		return comparison( " = " );
+	}
+
+	private InfinispanRemoteQueryBuilder getNotEqualsQuery() {
+		return comparison( " <> " );
+	}
+
+	@Override
+	protected InfinispanRemoteQueryBuilder getGreaterOrEqualsQuery() {
+		return comparison( " >= " );
+	}
+
+	@Override
+	protected InfinispanRemoteQueryBuilder getStrictlyGreaterQuery() {
+		return comparison( " > " );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		switch ( type ) {
+			case LESS:
+				return getGreaterOrEqualsQuery();
+			case LESS_OR_EQUAL:
+				return getStrictlyGreaterQuery();
+			case EQUALS:
+				return getNotEqualsQuery();
+			case GREATER_OR_EQUAL:
+				return getStrictlyLessQuery();
+			case GREATER:
+				return getLessOrEqualsQuery();
+			default:
+				throw new UnsupportedOperationException( "Unsupported comparison type: " + type );
+		}
+	}
+
+	private InfinispanRemoteQueryBuilder comparison(String operator) {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( propertyName );
+		builder.append( operator );
+		builder.appendValue( value );
+
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteConjunctionPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteConjunctionPredicate.java
@@ -8,7 +8,6 @@ package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicat
 
 import org.hibernate.hql.ast.spi.predicate.ConjunctionPredicate;
 import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
-import org.hibernate.hql.ast.spi.predicate.Predicate;
 import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
 
 /**
@@ -23,33 +22,11 @@ public class InfinispanRemoteConjunctionPredicate extends ConjunctionPredicate<I
 
 	@Override
 	public InfinispanRemoteQueryBuilder getQuery() {
-		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
-
-		int counter = 1;
-		builder.append( "(" );
-		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
-			builder.append( child.getQuery() );
-			builder.append( ")" );
-			if ( counter++ < children.size() ) {
-				builder.append( " and (" );
-			}
-		}
-		return builder;
+		return new InfinispanRemoteQueryBuilder( "and", false, children );
 	}
 
 	@Override
 	public InfinispanRemoteQueryBuilder getNegatedQuery() {
-		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
-
-		int counter = 1;
-		builder.append( "(" );
-		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
-			builder.append( ( (NegatablePredicate<InfinispanRemoteQueryBuilder>) child ).getNegatedQuery() );
-			builder.append( ")" );
-			if ( counter++ < children.size() ) {
-				builder.append( " or (" );
-			}
-		}
-		return builder;
+		return new InfinispanRemoteQueryBuilder( "or", true, children );
 	}
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteConjunctionPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteConjunctionPredicate.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.ConjunctionPredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.hql.ast.spi.predicate.Predicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link ConjunctionPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteConjunctionPredicate extends ConjunctionPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteConjunctionPredicate() {
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+
+		int counter = 1;
+		builder.append( "(" );
+		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
+			builder.append( child.getQuery() );
+			builder.append( ")" );
+			if ( counter++ < children.size() ) {
+				builder.append( " and (" );
+			}
+		}
+		return builder;
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+
+		int counter = 1;
+		builder.append( "(" );
+		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
+			builder.append( ( (NegatablePredicate<InfinispanRemoteQueryBuilder>) child ).getNegatedQuery() );
+			builder.append( ")" );
+			if ( counter++ < children.size() ) {
+				builder.append( " or (" );
+			}
+		}
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteDisjunctionPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteDisjunctionPredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.DisjunctionPredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.hql.ast.spi.predicate.Predicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link DisjunctionPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteDisjunctionPredicate extends DisjunctionPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteDisjunctionPredicate() {
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		return getBaseQuery( " or " );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		return getBaseQuery( " and " );
+	}
+
+	private InfinispanRemoteQueryBuilder getBaseQuery(final String operator) {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( "(" );
+
+		int counter = 1;
+		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
+			builder.append( ( (NegatablePredicate<InfinispanRemoteQueryBuilder>) child ).getNegatedQuery() );
+			builder.append( ")" );
+			if ( counter++ < children.size() ) {
+				builder.append( operator + "(" );
+			}
+		}
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteDisjunctionPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteDisjunctionPredicate.java
@@ -8,7 +8,6 @@ package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicat
 
 import org.hibernate.hql.ast.spi.predicate.DisjunctionPredicate;
 import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
-import org.hibernate.hql.ast.spi.predicate.Predicate;
 import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
 
 /**
@@ -23,25 +22,11 @@ public class InfinispanRemoteDisjunctionPredicate extends DisjunctionPredicate<I
 
 	@Override
 	public InfinispanRemoteQueryBuilder getQuery() {
-		return getBaseQuery( " or " );
+		return new InfinispanRemoteQueryBuilder( "or", false, children );
 	}
 
 	@Override
 	public InfinispanRemoteQueryBuilder getNegatedQuery() {
-		return getBaseQuery( " and " );
-	}
-
-	private InfinispanRemoteQueryBuilder getBaseQuery(final String operator) {
-		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( "(" );
-
-		int counter = 1;
-		for ( Predicate<InfinispanRemoteQueryBuilder> child : children ) {
-			builder.append( ( (NegatablePredicate<InfinispanRemoteQueryBuilder>) child ).getNegatedQuery() );
-			builder.append( ")" );
-			if ( counter++ < children.size() ) {
-				builder.append( operator + "(" );
-			}
-		}
-		return builder;
+		return new InfinispanRemoteQueryBuilder( "and", true, children );
 	}
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteInPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteInPredicate.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import java.util.List;
+
+import org.hibernate.hql.ast.spi.predicate.InPredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan server-based implementation of {@link InPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteInPredicate extends InPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteInPredicate(String propertyName, List<Object> values) {
+		super( propertyName, values );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( propertyName );
+		builder.append( " in (" );
+		builder.appendValues( values );
+		builder.append( ")" );
+
+		return builder;
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder( "not " );
+		builder.append( getQuery() );
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteIsNullPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteIsNullPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.IsNullPredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link IsNullPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteIsNullPredicate extends IsNullPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteIsNullPredicate(String propertyName) {
+		super( propertyName );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		return new InfinispanRemoteQueryBuilder( propertyName, " is not null" );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		return new InfinispanRemoteQueryBuilder( propertyName, " is null" );
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteLikePredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteLikePredicate.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.LikePredicate;
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link LikePredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteLikePredicate extends LikePredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteLikePredicate(String propertyName, String patternValue, Character escapeCharacter) {
+		super( propertyName, patternValue, escapeCharacter );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		return new InfinispanRemoteQueryBuilder( "not ", getQuery() );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+
+		builder.append( propertyName );
+		builder.append( " LIKE " );
+		builder.appendValue( patternValue );
+
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteNegationPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteNegationPredicate.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.hql.ast.spi.predicate.NegationPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link NegationPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteNegationPredicate extends NegationPredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		return getChild().getQuery();
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+		if ( getChild() instanceof NegatablePredicate ) {
+			NegatablePredicate<InfinispanRemoteQueryBuilder> negatable = (NegatablePredicate<InfinispanRemoteQueryBuilder>) getChild();
+			return negatable.getNegatedQuery();
+		}
+		else {
+			builder.append( "NOT (" );
+			getChild().getQuery();
+			builder.append( ")" );
+			return builder;
+		}
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteRangePredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteRangePredicate.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.NegatablePredicate;
+import org.hibernate.hql.ast.spi.predicate.RangePredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan remote-based implementation of {@link RangePredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteRangePredicate extends RangePredicate<InfinispanRemoteQueryBuilder> implements NegatablePredicate<InfinispanRemoteQueryBuilder> {
+
+	public InfinispanRemoteRangePredicate(String propertyName, Object lower, Object upper) {
+		super( propertyName, lower, upper );
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+		builder.append( "( " );
+		builder.append( propertyName );
+		builder.append( " >= " );
+
+		builder.appendValue( lower );
+
+		builder.append( " && " );
+		builder.append( propertyName );
+		builder.append( " <= " );
+
+		builder.appendValue( upper );
+
+		builder.append( " )" );
+		return builder;
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getNegatedQuery() {
+		InfinispanRemoteQueryBuilder builder = new InfinispanRemoteQueryBuilder();
+		builder.append( "( " );
+		builder.append( propertyName );
+		builder.append( " < " );
+
+		builder.appendValue( lower );
+
+		builder.append( " || " );
+		builder.append( propertyName );
+		builder.append( " > " );
+
+		builder.appendValue( upper );
+
+		builder.append( " )" );
+		return builder;
+	}
+}

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteRootPredicate.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/query/parsing/impl/predicate/impl/InfinispanRemoteRootPredicate.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.predicate.impl;
+
+import org.hibernate.hql.ast.spi.predicate.RootPredicate;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteQueryBuilder;
+
+/**
+ * Infinispan server-based implementation of {@link RootPredicate}.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteRootPredicate extends RootPredicate<InfinispanRemoteQueryBuilder> {
+
+	private final String table;
+	private final String protobufPackage;
+
+	public InfinispanRemoteRootPredicate(String table, String protobufPackage) {
+		this.table = table;
+		this.protobufPackage = protobufPackage;
+	}
+
+	@Override
+	public InfinispanRemoteQueryBuilder getQuery() {
+		InfinispanRemoteQueryBuilder query = new InfinispanRemoteQueryBuilder( "from " );
+		query.append( protobufPackage );
+		query.append( "." );
+		query.append( table );
+
+		if ( child == null ) {
+			return query;
+		}
+
+		query.addWhere( child.getQuery() );
+
+		return query;
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/Employee.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/Employee.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * @author Fabio Massimo Ercoli
+ */
+@Entity
+@Table(name = "Registry")
+@NamedNativeQueries(
+		@NamedNativeQuery(name = "JohnQuery", query = "from HibernateOGMGenerated.Registry where level > 3 and name = 'John Doe'", resultClass = Employee.class)
+)
+public class Employee implements Serializable {
+
+	@Id
+	private Long id;
+
+	private String name;
+
+	@Temporal(TemporalType.DATE)
+	private Date start;
+
+	private Integer level;
+
+	private Employee() {
+	}
+
+	public Employee(Long id, String name, Date start, Integer level) {
+		this.id = id;
+		this.name = name;
+		this.start = start;
+		this.level = level;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Date getStart() {
+		return start;
+	}
+
+	public Integer getLevel() {
+		return level;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Employee employee = (Employee) o;
+		return Objects.equals( id, employee.id ) &&
+				Objects.equals( name, employee.name ) &&
+				Objects.equals( start, employee.start ) &&
+				Objects.equals( level, employee.level );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( id, name, start, level );
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder( "Employee{" );
+		sb.append( "id=" ).append( id );
+		sb.append( ", name='" ).append( name ).append( '\'' );
+		sb.append( ", start=" ).append( start );
+		sb.append( ", level=" ).append( level );
+		sb.append( '}' );
+		return sb.toString();
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteEntityManagerNativeQueryTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteEntityManagerNativeQueryTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
 
 import java.time.LocalDate;
@@ -13,12 +14,12 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteJpaServerRunner;
 import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,27 +83,36 @@ public class InfinispanRemoteEntityManagerNativeQueryTest extends OgmJpaTestCase
 	}
 
 	@Test
-	public void testSingleResultQueryWithProjection() {
+	public void testSingleResultQueryWithFieldProjection() {
 		inTransaction( em -> {
 			// projection can be declared in native query text
 			Object result = em.createNativeQuery( "select title from HibernateOGMGenerated.Plan where title = 'Mars'" )
-					.getSingleResult();
-			assertThat( result ).isEqualTo( mars.getName() );
-
-			// projection can be declared as result set mapping
-			result = em.createNativeQuery( "from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
-					.getSingleResult();
-			assertThat( result ).isEqualTo( mars.getName() );
-
-			// or in both
-			result = em.createNativeQuery( "select title from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
 					.getSingleResult();
 			assertThat( result ).isEqualTo( mars.getName() );
 		} );
 	}
 
 	@Test
-	public void testSingleResultQueryWithSeveralProjections() {
+	public void testSingleResultQueryWithProjectionAsResultSetMapping() {
+		inTransaction( em -> {
+			// projection can be declared as result set mapping
+			Object result = em.createNativeQuery( "from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
+					.getSingleResult();
+			assertThat( result ).isEqualTo( mars.getName() );
+		} );
+	}
+
+	@Test
+	public void testSingleResultQueryWithProjectionAsResultSetMappingAndProjection() {
+		inTransaction( em -> {
+			Object result = em.createNativeQuery( "select title from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
+					.getSingleResult();
+			assertThat( result ).isEqualTo( mars.getName() );
+		} );
+	}
+
+	@Test
+	public void testSingleResultQueryWithSeveralResultSetMapping() {
 		String moonQuery = "from HibernateOGMGenerated.Plan where title = 'Moon' and description = 'Travel to the Moon'";
 
 		inTransaction( em -> {

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteEntityManagerNativeQueryTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteEntityManagerNativeQueryTest.java
@@ -1,0 +1,145 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteJpaServerRunner;
+import org.hibernate.ogm.utils.jpa.OgmJpaTestCase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the execution of native queries on Infinispan Server using the {@link EntityManager}
+ *
+ * @author Fabio Massimo Ercoli &lt;fabio@hibernate.org&gt;
+ */
+@RunWith(InfinispanRemoteJpaServerRunner.class)
+public class InfinispanRemoteEntityManagerNativeQueryTest extends OgmJpaTestCase {
+
+	private final Employee john = new Employee( 1l, "John Doe", getDate( 2017, Month.JUNE, 12 ), 4 );
+	private final Employee jane = new Employee( 2l, "Jane Gee", getDate( 2016, Month.MARCH, 7 ), 7 );
+	private final Employee jake = new Employee( 3l, "Jake Dee", getDate( 2011, Month.APRIL, 1 ), 2 );
+	private final Employee dave = new Employee( 4l, "Dave Lee", getDate( 2010, Month.JULY, 21 ), 9 );
+
+	private final Project moon = new Project( 2018, "BU007", 1, "Moon", "Travel to the Moon" );
+	private final Project mars = new Project( 2020, "BU007", 1, "Mars", "Life on Mars?" );
+	private final Project sun = new Project( 2040, "BU007", 1, "Sun", "Ride into the Sun" );
+
+	@Before
+	public void before() {
+		inTransaction( em -> {
+			em.persist( john );
+			em.persist( jane );
+			em.persist( jake );
+			em.persist( dave );
+			em.persist( moon );
+			em.persist( mars );
+			em.persist( sun );
+		} );
+	}
+
+	@After
+	public void after() {
+		inTransaction( em -> {
+			List<Employee> allEmployee = em.createQuery( "from " + Employee.class.getName(), Employee.class ).getResultList();
+			assertThat( allEmployee ).hasSize( 4 );
+			for ( Employee employee : allEmployee ) {
+				em.remove( employee );
+			}
+
+			List<Project> allProjects = em.createQuery( "from " + Project.class.getName(), Project.class ).getResultList();
+			assertThat( allProjects ).hasSize( 3 );
+			for ( Project project : allProjects ) {
+				em.remove( project );
+			}
+		} );
+	}
+
+	@Test
+	public void testSingleResultQuery() {
+		inTransaction( em -> {
+			Project result = (Project) em.createNativeQuery( "from HibernateOGMGenerated.Plan where title = 'Mars'", Project.class )
+					.getSingleResult();
+
+			assertThat( result ).isEqualTo( mars );
+		} );
+	}
+
+	@Test
+	public void testSingleResultQueryWithProjection() {
+		inTransaction( em -> {
+			// projection can be declared in native query text
+			Object result = em.createNativeQuery( "select title from HibernateOGMGenerated.Plan where title = 'Mars'" )
+					.getSingleResult();
+			assertThat( result ).isEqualTo( mars.getName() );
+
+			// projection can be declared as result set mapping
+			result = em.createNativeQuery( "from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
+					.getSingleResult();
+			assertThat( result ).isEqualTo( mars.getName() );
+
+			// or in both
+			result = em.createNativeQuery( "select title from HibernateOGMGenerated.Plan where title = 'Mars'", "titleMapping" )
+					.getSingleResult();
+			assertThat( result ).isEqualTo( mars.getName() );
+		} );
+	}
+
+	@Test
+	public void testSingleResultQueryWithSeveralProjections() {
+		String moonQuery = "from HibernateOGMGenerated.Plan where title = 'Moon' and description = 'Travel to the Moon'";
+
+		inTransaction( em -> {
+			Query nativeQuery = em.createNativeQuery( moonQuery, "multiValueMapping" );
+
+			Object result = nativeQuery.getSingleResult();
+			assertThat( result ).isEqualTo( new Object[] { moon.getName(), moon.getDescription(), moon.getFiscalYear() } );
+
+			List<Object> results = nativeQuery.getResultList();
+			assertThat( results.get( 0 ) ).isEqualTo( new Object[] { moon.getName(), moon.getDescription(), moon.getFiscalYear() } );
+		} );
+	}
+
+	@Test
+	public void testSingleResultFromNamedNativeQuery() {
+		inTransaction( em -> {
+			Employee result = (Employee) em.createNamedQuery( "JohnQuery" ).getSingleResult();
+
+			assertThat( result ).isEqualTo( john );
+		} );
+	}
+
+	@Test
+	public void testSingleProjectionResultFromNamedNativeQuery() {
+		inTransaction( em -> {
+			Object result = em.createNamedQuery( "sunQuery" ).getSingleResult();
+
+			assertThat( result ).isEqualTo( sun.getName() );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Employee.class, Project.class };
+	}
+
+	private Date getDate(int year, Month month, int day) {
+		return Date.from( LocalDate.of( year, month, day ).atStartOfDay( ZoneId.systemDefault() ).toInstant() );
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteNativeQueryParserTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteNativeQueryParserTest.java
@@ -6,91 +6,195 @@
  */
 package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
 
-import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+import static org.fest.assertions.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.Collections;
-
+import org.hibernate.HibernateException;
 import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
 import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteNativeQueryParser;
-
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Unit test to verify the behaviour of the target class {@link InfinispanRemoteNativeQueryParser}
  *
+ * @author Davide D'Alto
  * @author Fabio Massimo Ercoli
  */
 public class InfinispanRemoteNativeQueryParserTest {
 
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
 	@Test
 	public void testLoad() {
 		String nativeQuery = "from org.hibernate.proto.Fruit";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
 	}
 
 	@Test
-	public void testWhere() {
-		String nativeQuery = "from proto.Flower where name = 'daisy'";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Flower", nativeQuery, Collections.emptyList() ) );
+	public void testLoadWithSpacesAndWeirdCase() {
+		String nativeQuery = "             fROm              org.hibernate.proto.Fruit              ";
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	@Test
+	public void testWhereWithSpacesAndWeirdCase() {
+		String nativeQuery = "    fRom  proto.Flower                      WHERE           name=                            '         daisy' ";
+		String expectedCacheName = "Flower";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
 	}
 
 	@Test
 	public void testAlias() {
 		String nativeQuery = "select a from org.hibernate.proto.Fruit a where a.color = 'red'";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	@Test
+	public void testUnusedAlias() {
+		String nativeQuery = "from org.hibernate.proto.Fruit a";
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	@Test
+	public void testUnusedAliasInProjections() {
+		String nativeQuery = "SELECT color from org.hibernate.proto.Fruit a";
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "color" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
+
+	@Test
+	public void testUnusedAliasWhereClause() {
+		String nativeQuery = "from org.hibernate.proto.Fruit  a where    color='yellow'";
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	@Test
+	public void testMixedAliasUsage() {
+		String nativeQuery = "Select a.color  ,  name   from org.hibernate.proto.Fruit  a where    color='yellow' and a.name = 'apple'";
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "a.color", "name" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
+
+	@Test
+	public void testAliasWithSpacesAndWeirdCase() {
+		String nativeQuery = "              SELECT                   a                fROm org.hibernate.proto.Fruit               a            where a.color='red'";
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
 	}
 
 	@Test
 	public void testProjection() {
 		String nativeQuery = "select name, color from proto.Flower where name = 'daisy'";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		String expectedCacheName = "Flower";
+		String[] expectedProjections = { "name", "color" };
 
-		ArrayList<String> expectedProjections = new ArrayList<>();
-		expectedProjections.add( "name" );
-		expectedProjections.add( "color" );
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
 
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Flower", nativeQuery, expectedProjections ) );
+	@Test
+	public void testProjectionWithSpacesAndWeirdCase() {
+		String nativeQuery = "                     SELect          name              ,          color      from            proto.Flower      where name = 'daisy'";
+		String expectedCacheName = "Flower";
+		String[] expectedProjections = { "name", "color" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
 	}
 
 	@Test
 	public void testProjectionAndAlias() {
 		String nativeQuery = "select f.id, f.color from proto.Fruit f where a.color = 'red'";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "f.id", "f.color" };
 
-		ArrayList<String> expectedProjections = new ArrayList<>();
-		expectedProjections.add( "id" );
-		expectedProjections.add( "color" );
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
 
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, expectedProjections ) );
+	@Test
+	public void testProjectionAndAliasWithSpacesAndWeirdCase() {
+		String nativeQuery = "          SELECT          f.id           ,      f.color         FROM proto.Fruit         f        "
+				+ "          where  a.color= 'red'                ";
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "f.id", "f.color" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
 	}
 
 	@Test
 	public void testUpperCase() {
 		String nativeQuery = "select a FROM org.hibernate.proto.Fruit a WHERE a.color = 'red'";
-		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
-		InfinispanRemoteQueryDescriptor result = testSubject.parse();
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
 	}
 
 	@Test
 	public void testProjectionAndAliasUsingFrom() {
 		String nativeQuery = "select f.ifrom , f.color from proto.Fruit f where a.color = 'red'";
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "f.ifrom", "f.color" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
+
+	@Test
+	public void testProjectionAndAliasUsingFromWithSpacesAndWeirdCase() {
+		String nativeQuery = "select                f.ifrom , f.color FROm                  proto.Fruit f WHEre   a.color = 'red'";
+		String expectedCacheName = "Fruit";
+		String[] expectedProjections = { "f.ifrom", "f.color" };
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName, expectedProjections );
+	}
+
+	@Test
+	public void testExceptionForQueriesWithMultipleCaches() {
+		String nativeQuery = "FROm             proto.Fruit f, proto.Flower ";
+		String expectedCacheName = "Fruit";
+
+		thrown.expect( HibernateException.class );
+		thrown.expectMessage( "OGM001721: Infinispan queries can only target a single entity type. Found [proto.Fruit f, proto.Flower] for query: " + nativeQuery );
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	@Test
+	public void testExceptionForQueriesWithoutFromClause() {
+		thrown.expect( HibernateException.class );
+		thrown.expectMessage( "OGM001720: Missing from clause in native query" );
+
+		String nativeQuery = "select proto.Fruit";
+		String expectedCacheName = "Fruit";
+
+		assertParsingIsCorrect( nativeQuery, expectedCacheName );
+	}
+
+	private void assertParsingIsCorrect(String nativeQuery, String cacheName) {
+		assertParsingIsCorrect( nativeQuery, cacheName, null );
+	}
+
+	private void assertParsingIsCorrect(String nativeQuery, String cacheName, String[] projections) {
 		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
 		InfinispanRemoteQueryDescriptor result = testSubject.parse();
 
-		ArrayList<String> expectedProjections = new ArrayList<>();
-		expectedProjections.add( "ifrom" );
-		expectedProjections.add( "color" );
-
-		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, expectedProjections ) );
+		assertThat( result.getCache() ).isEqualTo( cacheName );
+		assertThat( result.getQuery() ).isEqualTo( nativeQuery );
+		assertThat( result.getProjections() ).isEqualTo( projections );
 	}
 }

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteNativeQueryParserTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteNativeQueryParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteNativeQueryParser;
+
+import org.junit.Test;
+
+/**
+ * Unit test to verify the behaviour of the target class {@link InfinispanRemoteNativeQueryParser}
+ *
+ * @author Fabio Massimo Ercoli
+ */
+public class InfinispanRemoteNativeQueryParserTest {
+
+	@Test
+	public void testLoad() {
+		String nativeQuery = "from org.hibernate.proto.Fruit";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+	}
+
+	@Test
+	public void testWhere() {
+		String nativeQuery = "from proto.Flower where name = 'daisy'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Flower", nativeQuery, Collections.emptyList() ) );
+	}
+
+	@Test
+	public void testAlias() {
+		String nativeQuery = "select a from org.hibernate.proto.Fruit a where a.color = 'red'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+	}
+
+	@Test
+	public void testProjection() {
+		String nativeQuery = "select name, color from proto.Flower where name = 'daisy'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+
+		ArrayList<String> expectedProjections = new ArrayList<>();
+		expectedProjections.add( "name" );
+		expectedProjections.add( "color" );
+
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Flower", nativeQuery, expectedProjections ) );
+	}
+
+	@Test
+	public void testProjectionAndAlias() {
+		String nativeQuery = "select f.id, f.color from proto.Fruit f where a.color = 'red'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+
+		ArrayList<String> expectedProjections = new ArrayList<>();
+		expectedProjections.add( "id" );
+		expectedProjections.add( "color" );
+
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, expectedProjections ) );
+	}
+
+	@Test
+	public void testUpperCase() {
+		String nativeQuery = "select a FROM org.hibernate.proto.Fruit a WHERE a.color = 'red'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, Collections.emptyList() ) );
+	}
+
+	@Test
+	public void testProjectionAndAliasUsingFrom() {
+		String nativeQuery = "select f.ifrom , f.color from proto.Fruit f where a.color = 'red'";
+		InfinispanRemoteNativeQueryParser testSubject = new InfinispanRemoteNativeQueryParser( nativeQuery );
+		InfinispanRemoteQueryDescriptor result = testSubject.parse();
+
+		ArrayList<String> expectedProjections = new ArrayList<>();
+		expectedProjections.add( "ifrom" );
+		expectedProjections.add( "color" );
+
+		assertThat( result ).isEqualTo( new InfinispanRemoteQueryDescriptor( "Fruit", nativeQuery, expectedProjections ) );
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemotePaginationTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemotePaginationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.ogm.backendtck.queries.pagination.PaginationUseCases;
+import org.hibernate.ogm.backendtck.queries.pagination.Poem;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
+
+import org.junit.runner.RunWith;
+
+/**
+ * Test pagination on Infinispan Server native query
+ *
+ * @author Fabio Massimo Ercoli
+ */
+@RunWith(InfinispanRemoteServerRunner.class)
+public class InfinispanRemotePaginationTest extends PaginationUseCases {
+
+	public static final String NATIVE_QUERY = "from HibernateOGMGenerated.POEM where author = 'Oscar Wilde' order by name";
+
+	@Override
+	protected List<Poem> findPoemsSortedAlphabetically(Session session, int startPosition, int maxResult) {
+		List<Poem> result = session.createNativeQuery( NATIVE_QUERY )
+				.addEntity( Poem.TABLE_NAME, Poem.class )
+				.setFirstResult( startPosition )
+				.setMaxResults( maxResult )
+				.list();
+		return result;
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteProjectionTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteProjectionTest.java
@@ -10,10 +10,8 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.List;
 
-import org.hibernate.ogm.backendtck.queries.projection.Movie;
 import org.hibernate.ogm.backendtck.queries.projection.NativeQueryProjectionBaseTest;
 import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,9 +44,10 @@ public class InfinispanRemoteProjectionTest extends NativeQueryProjectionBaseTes
 	@Test
 	public void testResultListWithoutAddEntityWithProjection() {
 		inTransaction( session -> {
-			List<Movie> movies = session.createNativeQuery( getNativeQueryWithProjectionYearAuthor() )
+			List<?> movies = session.createNativeQuery( getNativeQueryWithProjectionYearAuthor() )
 					.getResultList();
 
+			assertThat( movies ).hasSize( 1 );
 			assertThat( movies.get( 0 ) ).isEqualTo( new Object[] { 1968, "Stanley Kubrick" } );
 		} );
 	}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteProjectionTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteProjectionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import org.hibernate.ogm.backendtck.queries.projection.Movie;
+import org.hibernate.ogm.backendtck.queries.projection.NativeQueryProjectionBaseTest;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Use of a projection in Infinispan Remote native query:
+ * if a projection is used on root Entity then the result must be an Object array instead of an Entity.
+ *
+ * addEntity native query parameter is not allowed then projection is used on root Entity.
+ *
+ * @author Fabio Massimo Ercoli
+ */
+@RunWith(InfinispanRemoteServerRunner.class)
+public class InfinispanRemoteProjectionTest extends NativeQueryProjectionBaseTest {
+
+	@Override
+	protected String getNativeQueryWithoutProjection() {
+		return "from HibernateOGMGenerated.Movie";
+	}
+
+	@Override
+	protected String getNativeQueryWithProjectionIdName() {
+		return "select id, name from HibernateOGMGenerated.Movie";
+	}
+
+	@Override
+	protected String getNativeQueryWithProjectionYearAuthor() {
+		return "select m.year, m.author from HibernateOGMGenerated.Movie m";
+	}
+
+	@Test
+	public void testResultListWithoutAddEntityWithProjection() {
+		inTransaction( session -> {
+			List<Movie> movies = session.createNativeQuery( getNativeQueryWithProjectionYearAuthor() )
+					.getResultList();
+
+			assertThat( movies.get( 0 ) ).isEqualTo( new Object[] { 1968, "Stanley Kubrick" } );
+		} );
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteSessionNativeQueryTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/InfinispanRemoteSessionNativeQueryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import static org.hibernate.ogm.utils.OgmAssertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.hibernate.query.NativeQuery;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the execution of native queries on Infinispan Server using the {@link Session}
+ *
+ * @author Fabio Massimo Ercoli &lt;fabio@hibernate.org&gt;
+ */
+@RunWith(InfinispanRemoteServerRunner.class)
+public class InfinispanRemoteSessionNativeQueryTest extends OgmTestCase {
+
+	public static final String MORETHAN_LVL_3_ORDERBY_START = "from HibernateOGMGenerated.Registry where level > 3 order by start";
+
+	private final Employee john = new Employee( 1l, "John Doe", getDate( 2017, Month.JUNE, 12 ), 4 );
+	private final Employee jane = new Employee( 2l, "Jane Gee", getDate( 2016, Month.MARCH, 7 ), 7 );
+	private final Employee jake = new Employee( 3l, "Jake Dee", getDate( 2011, Month.APRIL, 1 ), 2 );
+	private final Employee dave = new Employee( 4l, "Dave Lee", getDate( 2010, Month.JULY, 21 ), 9 );
+
+	@Before
+	public void before() {
+		inTransaction( session -> {
+			session.persist( john );
+			session.persist( jane );
+			session.persist( jake );
+			session.persist( dave );
+		} );
+	}
+
+	@After
+	public void after() {
+		inTransaction( session -> {
+			List<Employee> list = session.createQuery( "from " + Employee.class.getName(), Employee.class ).list();
+			assertThat( list ).hasSize( 4 );
+			for ( Employee employee : list ) {
+				session.delete( employee );
+			}
+		} );
+	}
+
+	@Test
+	public void testNativeQueryWithFirstResult() {
+		inTransaction( session -> {
+			List result = session.createNativeQuery( MORETHAN_LVL_3_ORDERBY_START )
+					.addEntity( Employee.class )
+					.setFirstResult( 1 )
+					.list();
+
+			assertThat( result ).containsExactly( jane, john );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryWithMaxRows() {
+		inTransaction( session -> {
+			List result = session.createNativeQuery( MORETHAN_LVL_3_ORDERBY_START )
+					.addEntity( Employee.class )
+					.setMaxResults( 2 )
+					.list();
+
+			assertThat( result ).containsExactly( dave, jane );
+		} );
+	}
+
+	@Test
+	public void testListMultipleResultQuery() {
+		inTransaction( session -> {
+			List result = session.createNativeQuery( MORETHAN_LVL_3_ORDERBY_START )
+					.addEntity( Employee.class )
+					.list();
+
+			assertThat( result ).containsExactly( dave, jane, john );
+		} );
+	}
+
+	@Test
+	public void testListMultipleResultQueryWithFirstResultAndMaxRows() {
+		inTransaction( session -> {
+			List result = session.createNativeQuery( MORETHAN_LVL_3_ORDERBY_START )
+					.addEntity( Employee.class )
+					.setFirstResult( 1 )
+					.setMaxResults( 1 )
+					.list();
+
+			assertThat( result ).containsExactly( jane );
+		} );
+	}
+
+	@Test
+	public void testUniqueResultNamedNativeQuery() {
+		inTransaction( session -> {
+			Employee result = (Employee) session.createNamedQuery( "JohnQuery" )
+					.getSingleResult();
+
+			assertThat( result ).isEqualTo( john );
+		} );
+	}
+
+	@Test
+	public void testEntitiesInsertedInCurrentSessionAreFoundByNativeQuery() {
+		Employee mike = new Employee( 5l, "Mike", getDate( 2020, Month.NOVEMBER, 21 ), 1 );
+
+		inTransaction( session -> {
+			String query = "from HibernateOGMGenerated.Registry where name = 'Mike'";
+
+			NativeQuery nativeQuery = session.createNativeQuery( query )
+					.addEntity( Employee.class );
+
+			List result = nativeQuery.list();
+			assertThat( result ).isEmpty();
+
+			session.persist( mike );
+
+			result = nativeQuery.list();
+			assertThat( result ).containsExactly( mike );
+		} );
+
+		inTransaction( session -> {
+			session.delete( mike );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Employee.class };
+	}
+
+	private Date getDate(int year, Month month, int day) {
+		return Date.from( LocalDate.of( year, month, day ).atStartOfDay( ZoneId.systemDefault() ).toInstant() );
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/Project.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/Project.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import java.util.Date;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.ColumnResult;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.SqlResultSetMapping;
+import javax.persistence.SqlResultSetMappings;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * @author Fabio Massimo Ercoli
+ */
+@Entity
+@Table(name = "Plan")
+@NamedNativeQueries(
+		@NamedNativeQuery(name = "sunQuery", query = "from HibernateOGMGenerated.Plan where title = 'Sun'", resultSetMapping = "titleMapping")
+)
+@SqlResultSetMappings({
+		@SqlResultSetMapping(name = "titleMapping", columns = @ColumnResult(name = "title")),
+		@SqlResultSetMapping(
+				name = "multiValueMapping",
+				columns = {
+						@ColumnResult(name = "title"),
+						@ColumnResult(name = "description"),
+						@ColumnResult(name = "key.fiscalYear")
+				}
+		)
+})
+public class Project {
+
+	public enum Status {
+		STARTED, COMPLETED, ABORTED
+	}
+
+	@Id
+	private ProjectKey key;
+
+	@Column(name = "title")
+	private String name;
+
+	private String description;
+
+	@Temporal(TemporalType.DATE)
+	private Date start;
+
+	@Temporal(TemporalType.DATE)
+	private Date end;
+
+	private Status status;
+
+	public Project() {
+	}
+
+	public Project(Integer fiscalYear, String businessUnit, Integer projectSerialNumber, String name, String description) {
+		this.key = new ProjectKey( fiscalYear, businessUnit, projectSerialNumber );
+		this.name = name;
+		this.description = description;
+		this.start = new Date();
+		this.status = Status.STARTED;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public Integer getFiscalYear() {
+		return key.getFiscalYear();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Project project = (Project) o;
+		return Objects.equals( key, project.key ) &&
+				Objects.equals( name, project.name ) &&
+				Objects.equals( description, project.description ) &&
+				Objects.equals( start, project.start ) &&
+				Objects.equals( end, project.end ) &&
+				status == project.status;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( key, name, description, start, end, status );
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder( "Project{" );
+		sb.append( "key=" ).append( key );
+		sb.append( ", name='" ).append( name ).append( '\'' );
+		sb.append( ", description='" ).append( description ).append( '\'' );
+		sb.append( ", start=" ).append( start );
+		sb.append( ", end=" ).append( end );
+		sb.append( ", status=" ).append( status );
+		sb.append( '}' );
+		return sb.toString();
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/ProjectKey.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/nativequery/ProjectKey.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.nativequery;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Embeddable;
+
+/**
+ * @author Fabio Massimo Ercoli
+ */
+@Embeddable
+public class ProjectKey implements Serializable {
+
+	private Integer fiscalYear;
+	private String businessUnit;
+	private Integer projectSerialNumber;
+
+	public ProjectKey() {
+	}
+
+	public ProjectKey(Integer fiscalYear, String businessUnit, Integer projectSerialNumber) {
+		this.fiscalYear = fiscalYear;
+		this.businessUnit = businessUnit;
+		this.projectSerialNumber = projectSerialNumber;
+	}
+
+	public Integer getFiscalYear() {
+		return fiscalYear;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		ProjectKey that = (ProjectKey) o;
+		return Objects.equals( fiscalYear, that.fiscalYear ) &&
+				Objects.equals( businessUnit, that.businessUnit ) &&
+				Objects.equals( projectSerialNumber, that.projectSerialNumber );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( fiscalYear, businessUnit, projectSerialNumber );
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder( "ProjectKey{" );
+		sb.append( "fiscalYear=" ).append( fiscalYear );
+		sb.append( ", businessUnit='" ).append( businessUnit ).append( '\'' );
+		sb.append( ", projectSerialNumber=" ).append( projectSerialNumber );
+		sb.append( '}' );
+		return sb.toString();
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/CommunityMemberST.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/CommunityMemberST.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.parsing;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("CMM")
+public class CommunityMemberST extends PersonST {
+
+	private String project;
+
+	public String getProject() {
+		return project;
+	}
+
+	public void setProject(String project) {
+		this.project = project;
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/EmployeeST.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/EmployeeST.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.parsing;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@DiscriminatorValue("EMP")
+public class EmployeeST extends CommunityMemberST {
+
+	private String employer;
+
+	public String getEmployer() {
+		return employer;
+	}
+
+	public void setEmployer(String employer) {
+		this.employer = employer;
+	}
+
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/IndexedEntity.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/IndexedEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.parsing;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
+ */
+@Entity
+public class IndexedEntity {
+
+	private String id;
+	private String name;
+	private long position;
+	private int size;
+	private String title;
+
+	@Id
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Column(name = "entityName")
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public long getPosition() {
+		return position;
+	}
+
+	public void setPosition(long position) {
+		this.position = position;
+	}
+
+	public int getSize() {
+		return size;
+	}
+
+	public void setSize(int size) {
+		this.size = size;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/InfinispanRemoteJPQLParsingTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/InfinispanRemoteJPQLParsingTest.java
@@ -15,7 +15,6 @@ import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.Infinispa
 import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
 import org.hibernate.ogm.query.spi.QueryParsingResult;
 import org.hibernate.ogm.utils.OgmTestCase;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -199,7 +198,7 @@ public class InfinispanRemoteJPQLParsingTest extends OgmTestCase {
 		);
 	}
 
-	private void verifyParsing(String jpql, String cache, String datastoreQuery, String... projection) {
+	private void verifyParsing(String jpql, String cache, String datastoreQuery, String... projections) {
 		// To *QueryParserService internal SPI the JPQL query arrives always
 		// with the Entity name expresses as **fully qualified** class name,
 		// even if in the original API invocation it had been expressed as a **simple name**.
@@ -207,9 +206,12 @@ public class InfinispanRemoteJPQLParsingTest extends OgmTestCase {
 		// %org.hibernate.ogm.datastore.infinispanremote.test.query.parsing.IndexedEntity%
 		// ans never like: %IndexedEntity%.
 		QueryParsingResult queryParsingResult = testTarget.parseQuery( getSessionFactory(), jpql );
-		Object queryDescriptor = queryParsingResult.getQueryObject();
+		InfinispanRemoteQueryDescriptor queryDescriptor = (InfinispanRemoteQueryDescriptor) queryParsingResult.getQueryObject();
 
-		assertThat( queryDescriptor ).isEqualTo( new InfinispanRemoteQueryDescriptor( cache, datastoreQuery, Arrays.asList( projection ) ) );
+		assertThat( queryParsingResult.getColumnNames() ).isEqualTo( Arrays.asList( projections ) );
+		assertThat( queryDescriptor.getCache() ).isEqualTo( cache );
+		assertThat( queryDescriptor.getQuery() ).isEqualTo( datastoreQuery );
+		assertThat( queryDescriptor.getProjections() ).isEqualTo( projections );
 	}
 
 	@Override

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/InfinispanRemoteJPQLParsingTest.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/InfinispanRemoteJPQLParsingTest.java
@@ -1,0 +1,221 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.parsing;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.hibernate.ogm.datastore.infinispanremote.query.impl.InfinispanRemoteQueryDescriptor;
+import org.hibernate.ogm.datastore.infinispanremote.query.parsing.impl.InfinispanRemoteBasedQueryParserService;
+import org.hibernate.ogm.datastore.infinispanremote.utils.InfinispanRemoteServerRunner;
+import org.hibernate.ogm.query.spi.QueryParsingResult;
+import org.hibernate.ogm.utils.OgmTestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration test scoped to the parsing process
+ * of a JPQL query into an Infinispan Server query
+ *
+ * @author Fabio Massimo Ercoli &lt;fabio@hibernate.org&gt;
+ */
+@RunWith(InfinispanRemoteServerRunner.class)
+public class InfinispanRemoteJPQLParsingTest extends OgmTestCase {
+
+	private InfinispanRemoteBasedQueryParserService testTarget = new InfinispanRemoteBasedQueryParserService();
+
+	@Test
+	public void shouldCreateUnrestrictedQuery() {
+		verifyParsing( "from " + IndexedEntity.class.getName(),
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValue() {
+		verifyParsing( "from " + EmployeeST.class.getName(),
+				"PersonST", "from HibernateOGMGenerated.PersonST where DTYPE = 'EMP'"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithSingleDiscriminatorValueWithFilter() {
+		verifyParsing( "from " + EmployeeST.class.getName() + " e where e.employer = 'Red Hat'",
+				"PersonST", "from HibernateOGMGenerated.PersonST where employer = 'Red Hat' and DTYPE = 'EMP'"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValues() {
+		verifyParsing( "from " + CommunityMemberST.class.getName(),
+				"PersonST", "from HibernateOGMGenerated.PersonST where DTYPE in ('EMP', 'CMM')"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithMultipleDiscriminatorValuesWithFilter() {
+		verifyParsing( "from " + CommunityMemberST.class.getName() + " c where c.project = 'Hibernate OGM'",
+				"PersonST", "from HibernateOGMGenerated.PersonST where project = 'Hibernate OGM' and DTYPE in ('EMP', 'CMM')"
+		);
+	}
+
+	@Test
+	public void shouldCreateRestrictedQueryUsingSelect() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title = 'same'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where title = 'same'"
+		);
+	}
+
+	@Test
+	public void shouldUseSpecialNameForIdPropertyInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.id = '1'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where id = '1'"
+		);
+	}
+
+	@Test
+	public void shouldUseColumnNameForPropertyInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.name = 'Bob'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where entityName = 'Bob'"
+		);
+	}
+
+	@Test
+	public void shouldCreateProjectionQuery() {
+		verifyParsing( "select e.id, e.name, e.position from " + IndexedEntity.class.getName() + " e",
+				"IndexedEntity", "select id, entityName, position from HibernateOGMGenerated.IndexedEntity",
+				"id", "entityName", "position"
+		);
+	}
+
+	@Test
+	public void shouldAddNumberPropertyAsNumber() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.position = 2",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where position = 2"
+		);
+	}
+
+	@Test
+	public void shouldCreateLessOrEqualQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.position <= 20",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where position <= 20"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithNegationInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.name <> 'Bob'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where entityName <> 'Bob'"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithNestedNegationInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where NOT e.name <> 'Bob'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where entityName = 'Bob'"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryUsingSelectWithConjunctionInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title = 'same' and e.position = 1",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where (title = 'same') and (position = 1)"
+		);
+	}
+
+	@Test
+	public void shouldCreateQueryWithNegationAndConjunctionInWhereClause() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where NOT ( e.name = 'Bob' AND e.position = 1 )",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where (entityName <> 'Bob') or (position <> 1)"
+		);
+	}
+
+	@Test
+	public void shouldCreateNegatedRangeQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.name = 'Bob' and not e.position between 1 and 3",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where (entityName = 'Bob') and (( position < 1 || position > 3 ))"
+		);
+	}
+
+	@Test
+	public void shouldCreateBooleanQueryUsingSelect() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.name = 'same' or ( e.id = 4 and e.name = 'booh')",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where (entityName = 'same') or ((id = '4') and (entityName = 'booh'))"
+		);
+	}
+
+	@Test
+	public void shouldCreateNumericBetweenQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.position between :lower and :upper",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where ( position >= :lower && position <= :upper )"
+		);
+	}
+
+	@Test
+	public void shouldCreateInQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title IN ( 'foo', 'bar', 'same')",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where title in ('foo', 'bar', 'same')"
+		);
+	}
+
+	@Test
+	public void shouldCreateNotInQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title NOT IN ( 'foo', 'bar', 'same')",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where not title in ('foo', 'bar', 'same')"
+		);
+	}
+
+	@Test
+	public void shouldCreateLikeQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title like 'Ali_e%'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where title LIKE 'Ali_e%'"
+		);
+	}
+
+	@Test
+	public void shouldCreateNotLikeQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title not like 'Ali_e%'",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where not title LIKE 'Ali_e%'"
+		);
+	}
+
+	@Test
+	public void shouldCreateIsNullQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title is null",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where title is null"
+		);
+	}
+
+	@Test
+	public void shouldCreateIsNotNullQuery() {
+		verifyParsing( "select e from " + IndexedEntity.class.getName() + " e where e.title is not null",
+				"IndexedEntity", "from HibernateOGMGenerated.IndexedEntity where title is not null"
+		);
+	}
+
+	private void verifyParsing(String jpql, String cache, String datastoreQuery, String... projection) {
+		// To *QueryParserService internal SPI the JPQL query arrives always
+		// with the Entity name expresses as **fully qualified** class name,
+		// even if in the original API invocation it had been expressed as a **simple name**.
+		// For this reason the queries used in this test are always like:
+		// %org.hibernate.ogm.datastore.infinispanremote.test.query.parsing.IndexedEntity%
+		// ans never like: %IndexedEntity%.
+		QueryParsingResult queryParsingResult = testTarget.parseQuery( getSessionFactory(), jpql );
+		Object queryDescriptor = queryParsingResult.getQueryObject();
+
+		assertThat( queryDescriptor ).isEqualTo( new InfinispanRemoteQueryDescriptor( cache, datastoreQuery, Arrays.asList( projection ) ) );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				IndexedEntity.class, PersonST.class, CommunityMemberST.class, EmployeeST.class
+		};
+	}
+}

--- a/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/PersonST.java
+++ b/infinispan-remote/src/test/java/org/hibernate/ogm/datastore/infinispanremote/test/query/parsing/PersonST.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.infinispanremote.test.query.parsing;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorValue("PRS")
+public class PersonST {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBProcessingChain.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/query/parsing/impl/MongoDBProcessingChain.java
@@ -16,6 +16,7 @@ import org.hibernate.hql.ast.spi.AstProcessor;
 import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.hibernate.hql.ast.spi.QueryRendererProcessor;
 import org.hibernate.hql.ast.spi.QueryResolverProcessor;
+import org.hibernate.ogm.query.parsing.impl.HibernateOGMQueryResolverDelegate;
 
 import org.bson.Document;
 
@@ -31,14 +32,15 @@ public class MongoDBProcessingChain implements AstProcessingChain<MongoDBQueryPa
 	private final MongoDBQueryRendererDelegate rendererDelegate;
 
 	public MongoDBProcessingChain(SessionFactoryImplementor sessionFactory, EntityNamesResolver entityNames, Map<String, Object> namedParameters) {
-		this.resolverProcessor = new QueryResolverProcessor( new MongoDBQueryResolverDelegate() );
+		this.resolverProcessor = new QueryResolverProcessor( new HibernateOGMQueryResolverDelegate() );
 
 		MongoDBPropertyHelper propertyHelper = new MongoDBPropertyHelper( sessionFactory, entityNames );
 		MongoDBQueryRendererDelegate rendererDelegate = new MongoDBQueryRendererDelegate(
 				sessionFactory,
 				entityNames,
 				propertyHelper,
-				namedParameters );
+				namedParameters
+		);
 		this.rendererProcessor = new QueryRendererProcessor( rendererDelegate );
 		this.rendererDelegate = rendererDelegate;
 	}


### PR DESCRIPTION
Follows https://github.com/hibernate/hibernate-ogm/pull/1012
 
https://hibernate.atlassian.net/browse/OGM-1426
https://hibernate.atlassian.net/browse/OGM-1463

This is a refactoring of the initial PR sent by @fax4ever:

* Reduce the amount of regular expressions needed for the parser
* Add new test cases to check queries with strange cases and use of spaces
* Give additional information when the query is invalid
* Test that expected exceptions are thrown

Using regular expressions for the parser scares me a bit, but it seems to work for now because we don't need to extract lot of info from the native query. We should consider switching to a proper parser in the future like Parboiled.

Please @fax4ever, have a look at this and if you find something that doesn't make sense let me know.
Otherwise, let's merge it and close this issue.

Thanks a lot