### PR TITLE
OGM-1499 Update integration tests to use WildFly 13.0.0.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -46,7 +46,7 @@
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
 
-        <version.wildfly>12.0.0.Final</version.wildfly>
+        <version.wildfly>13.0.0.Final</version.wildfly>
         <version.org.hibernate.commons.annotations>5.0.3.Final</version.org.hibernate.commons.annotations>
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>

--- a/documentation/examples/wildfly-quickstart/pom.xml
+++ b/documentation/examples/wildfly-quickstart/pom.xml
@@ -33,55 +33,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>fetch-jpa-patch</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.hibernate.javax.persistence</groupId>
-                                    <artifactId>hibernate-jpa-api-2.2-wildflymodules</artifactId>
-                                    <classifier>wildfly-${version.wildfly}-patch</classifier>
-                                    <version>${jpa22patch.version}</version>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <overWrite>true</overWrite>
-                                    <destFileName>${jpa22patch.filename}</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <executions>
-                    <!-- Install JPA 2.2 patch -->
-                    <execution>
-                        <id>apply-wildfly-node1-jpa22-patch-file</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>execute-commands</goal>
-                        </goals>
-                        <configuration>
-                            <offline>true</offline>
-                            <jbossHome>${project.build.directory}/wildfly-server</jbossHome>
-                            <commands>
-                                <command>patch apply --override-all ${project.build.directory}/${jpa22patch.filename}</command>
-                            </commands>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/documentation/manual/src/main/asciidoc/modules/configuration.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/configuration.asciidoc
@@ -574,36 +574,15 @@ link:$$https://repository.jboss.org/nexus/index.html#nexus-search;gav~org.hibern
 
 WildFly will by default attempt to guess which Persistence Provider you need by having a look at the `provider` section of the `persistence.xml`.
 
-==== Enable support for JEE 8
+==== Enable support for EE 8
 
-Hibernate OGM {hibernate-ogm-version} requires **CDI 2.0** and **JPA 2.2**, that belong to **JEE8** specification.
-WildFly 12 has limited support for Java EE8.
+Hibernate OGM {hibernate-ogm-version} requires **CDI 2.0** and **JPA 2.2**, that belong to **EE 8** specification.
+WildFly 13 has support for JavaEE 8.
 
-To enable required CDI version we need to start the server with __ee8.preview.mode__ Java system property set to **true** :
+But in order to enable required CDI and JPA versions we need to start the server with __ee8.preview.mode__ Java system property set to **true** :
 
 ----
 -Dee8.preview.mode=true
-----
-
-To enable required JPA version we need to apply __hibernate-jpa-api-2.2-wildflymodules__ patch to the server.
-Download the patch from here:
-
- * http://central.maven.org/maven2/org/hibernate/javax/persistence/hibernate-jpa-api-2.2-wildflymodules/1.0.0.Beta2/hibernate-jpa-api-2.2-wildflymodules-1.0.0.Beta2-wildfly-12.0.0.Final-patch.zip
-
-Or using these maven coordinates:
-[source, XML]
-[subs="verbatim,attributes"]
-----
-<groupId>org.hibernate.javax.persistence</groupId>
-<artifactId>hibernate-jpa-api-2.2-wildflymodules</artifactId>
-<classifier>wildfly-{wildfly-version}-patch</classifier>
-<version>1.0.0.Beta2</version>
-<type>zip</type>
-----
-
-To apply the patch execute the JBoss cli command:
-----
-patch apply --override-all hibernate-jpa-api-2.2-wildflymodules-1.0.0.Beta2-wildfly-12.0.0-patch.zip
 ----
 
 ==== Using the Hibernate OGM modules with Infinispan

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -116,53 +116,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>fetch-jpa-patch</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.hibernate.javax.persistence</groupId>
-                                    <artifactId>hibernate-jpa-api-2.2-wildflymodules</artifactId>
-                                    <classifier>wildfly-${version.wildfly}-patch</classifier>
-                                    <version>${jpa22patch.version}</version>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <overWrite>true</overWrite>
-                                    <destFileName>${jpa22patch.filename}</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <executions>
-                    <!-- Install JPA 2.2 patch -->
-                    <execution>
-                        <id>apply-wildfly-node1-jpa22-patch-file</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>execute-commands</goal>
-                        </goals>
-                        <configuration>
-                            <offline>true</offline>
-                            <jbossHome>${jboss.home}</jbossHome>
-                            <commands>
-                                <command>patch apply --override-all ${project.build.directory}/${jpa22patch.filename}</command>
-                            </commands>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,16 +70,15 @@
         <!-- Not using default port to reduce chances of shutting down an external MongoDB instance -->
         <mongodb.embedded.port>27018</mongodb.embedded.port>
 
-        <!-- JPA 2.2 patch -->
-
-        <jpa22patch.version>1.0.0.Beta2</jpa22patch.version>
-        <jpa22patch.filename>hibernate-jpa-api-2.2-wildflymodules-${jpa22patch.version}-wildfly-${version.wildfly}-patch.zip</jpa22patch.filename>
-
         <!-- Module slots -->
 
         <module-slot.org.hibernate.ogm.short-id>${parsed-version.majorVersion}.${parsed-version.minorVersion}</module-slot.org.hibernate.ogm.short-id>
         <module-slot.org.hibernate.ogm.jipijapa.full-id>${project.version}</module-slot.org.hibernate.ogm.jipijapa.full-id>
-        <module-slot.org.hibernate.search.short-id>${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}</module-slot.org.hibernate.search.short-id>
+
+        <!-- Temporary use of full version *5.10.0.Final* as module slot for Hibernate Search -->
+        <!-- Because *5.10* alias slot is reserved to *5.10.1.Final* in WildFly 13.0.0.Final -->
+        <module-slot.org.hibernate.search.short-id>${version.org.hibernate.search}</module-slot.org.hibernate.search.short-id>
+
         <module-slot.org.hibernate.short-id>${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}</module-slot.org.hibernate.short-id>
         <module-slot.org.hibernate.hql.full-id>${version.org.hibernate.hql}</module-slot.org.hibernate.hql.full-id>
         <module-slot.org.infinispan.short-id>ispn-${parsed-version.org.infinispan.majorVersion}.${parsed-version.org.infinispan.minorVersion}</module-slot.org.infinispan.short-id>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/OGM-1499

Unfortunately 5.2 Hibernate Search slot version is already taken in WildFly 13.0.0.Final, provisioned with Hibernate Search 5.10.1.Final, requiring Hibernate ORM 5.3.1.Final.
But the actual version of Hibernate OGM requires ORM 5.3.0.Final.
