### PR TITLE
With upgrading the neo4j dependency version from 3.4.10 to 3.4.11, fo…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -73,7 +73,7 @@
 
         <!-- Neo4j -->
 
-        <version.org.neo4j>3.4.10</version.org.neo4j>
+        <version.org.neo4j>3.4.11</version.org.neo4j>
         <version.org.neo4j.driver>1.7.2</version.org.neo4j.driver>
         <version.neo4j.org.scala-lang>2.11.11</version.neo4j.org.scala-lang>
         <!-- See Parboiled dependency above -->

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/EmbeddedNeo4jDialect.java
@@ -69,7 +69,7 @@ import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
-import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 
 /**
  * Abstracts Hibernate OGM from Neo4j.
@@ -209,7 +209,7 @@ public class EmbeddedNeo4jDialect extends BaseNeo4jDialect<EmbeddedNeo4jEntityQu
 		catch (QueryExecutionException qee) {
 			if ( CONSTRAINT_VIOLATION_CODE.equals( qee.getStatusCode() ) ) {
 				Throwable cause = findRecognizableCause( qee );
-				if ( cause instanceof UniquePropertyValueValidationException ) {
+				if ( cause instanceof IndexEntryConflictException ) {
 					throw new TupleAlreadyExistsException( key, qee );
 				}
 			}


### PR DESCRIPTION
…ur unit-tests are failing.

To enable compatibility with neo4j 3.4.11 the class EmbeddedNeo4jDialects to be modified.

The exception has to get changed from "UniquePropertyValueValidation" to "IndexEntryConflict."

JIRA: https://hibernate.atlassian.net/browse/OGM-1573