### PR TITLE
OGM-1580 - Upgrade to a Checkstyle 8.29 compatible version of the plugin and fix remaining issues.

### DIFF
--- a/core/src/main/java/org/hibernate/ogm/util/configurationreader/impl/Validators.java
+++ b/core/src/main/java/org/hibernate/ogm/util/configurationreader/impl/Validators.java
@@ -38,5 +38,5 @@ public class Validators {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	private Validators() {
-	};
+	}
 }

--- a/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteValidators.java
+++ b/infinispan-remote/src/main/java/org/hibernate/ogm/datastore/infinispanremote/configuration/impl/InfinispanRemoteValidators.java
@@ -33,5 +33,5 @@ public class InfinispanRemoteValidators {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	private InfinispanRemoteValidators() {
-	};
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.0.0</version.buildhelper.plugin>
         <version.buildnumber.plugin>1.4</version.buildnumber.plugin>
-        <version.checkstyle.plugin>3.0.0</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
         <version.clean.plugin>3.0.0</version.clean.plugin>
         <version.clirr.plugin>2.7</version.clirr.plugin>
         <version.compiler.plugin>3.7.0</version.compiler.plugin>
@@ -130,7 +130,7 @@
             overridden by a CI job of the Checkstyle project so that they can
             check for regressions. Which is obviously good for us, too.
          -->
-        <puppycrawl.checkstyle.version>8.29</puppycrawl.checkstyle.version>
+        <puppycrawl.checkstyle.version>8.44</puppycrawl.checkstyle.version>
 
         <!-- Build settings -->
 


### PR DESCRIPTION
Hi. I wanted to check if the Neo4j Java driver could be upgrade with a decent amount of pain to a 4.x series and the whole project failed to build due to an incompatible mix of versions between Checkstyle itself and the Maven plugin. This PR fixes this and also removes 2 check style violations.