### PR TITLE
OGM-1581 Investigate work necessary to upgrade remote Neo4j to Bolt >= 4.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,7 +74,7 @@
         <!-- Neo4j -->
 
         <version.org.neo4j>3.4.11</version.org.neo4j>
-        <version.org.neo4j.driver>1.7.2</version.org.neo4j.driver>
+        <version.org.neo4j.driver>4.3.3</version.org.neo4j.driver>
         <version.neo4j.org.scala-lang>2.11.11</version.neo4j.org.scala-lang>
         <!-- See Parboiled dependency above -->
         <!-- See Lucene dependency above -->

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociatedNodesHelper.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociatedNodesHelper.java
@@ -13,8 +13,8 @@ import java.util.Map.Entry;
 import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
-import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.types.Node;
 
 /**
  * Function required to get the associated nodes when building the tuple snapshot.

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociationQueries.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jAssociationQueries.java
@@ -16,9 +16,9 @@ import org.hibernate.ogm.model.key.spi.EntityKey;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.RowKey;
 import org.hibernate.ogm.util.impl.ArrayHelper;
-import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.types.Relationship;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.types.Relationship;
 
 /**
  * @author Davide D'Alto
@@ -36,11 +36,11 @@ public class BoltNeo4jAssociationQueries extends BaseNeo4jAssociationQueries {
 	public Relationship findRelationship(Transaction tx, AssociationKey associationKey, RowKey rowKey) {
 		Object[] relationshipValues = relationshipValues( associationKey, rowKey );
 		Object[] queryValues = ArrayHelper.concat( associationKey.getEntityKey().getColumnValues(), relationshipValues );
-		StatementResult result = tx.run( findRelationshipQuery, params( queryValues ) );
+		Result result = tx.run( findRelationshipQuery, params( queryValues ) );
 		return relationship( result );
 	}
 
-	private Relationship relationship(StatementResult result) {
+	private Relationship relationship(Result result) {
 		if ( result.hasNext() ) {
 			return result.next().get( 0 ).asRelationship();
 		}
@@ -51,14 +51,14 @@ public class BoltNeo4jAssociationQueries extends BaseNeo4jAssociationQueries {
 			Object[] relationshipProperties) {
 		String query = initCreateEmbeddedAssociationQuery( associationKey, embeddedKey );
 		Object[] queryValues = createRelationshipForEmbeddedQueryValues( associationKey, embeddedKey, relationshipProperties );
-		StatementResult statementResult = tx.run( query, params( queryValues ) );
+		Result statementResult = tx.run( query, params( queryValues ) );
 		return relationship( statementResult );
 	}
 
 	public Relationship createRelationship(Transaction tx, Object[] ownerKeyValues, Object[] targetKeyValues, Object[] relationshipProperties) {
 		Object[] concat = ArrayHelper.concat( Arrays.asList( ownerKeyValues, targetKeyValues, relationshipProperties ) );
 		Map<String, Object> params = params( concat );
-		StatementResult statementResult = tx.run( createRelationshipQuery, params );
+		Result statementResult = tx.run( createRelationshipQuery, params );
 		return relationship( statementResult );
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jMapsTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jMapsTupleIterator.java
@@ -13,9 +13,9 @@ import java.util.Map;
 import org.hibernate.ogm.datastore.map.impl.MapTupleSnapshot;
 import org.hibernate.ogm.datastore.neo4j.remote.common.dialect.impl.RemoteNeo4jMapsTupleIterator;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
-import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Value;
 
 /**
  * Iterates over the results of a native query when each result is not mapped by an entity
@@ -24,7 +24,7 @@ import org.neo4j.driver.v1.Value;
  */
 public class BoltNeo4jMapsTupleIterator extends RemoteNeo4jMapsTupleIterator<Record> {
 
-	public BoltNeo4jMapsTupleIterator(StatementResult statementResult) {
+	public BoltNeo4jMapsTupleIterator(Result statementResult) {
 		super( statementResult, statementResult.keys() );
 	}
 

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jNodesTupleIterator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jNodesTupleIterator.java
@@ -13,8 +13,8 @@ import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.Tuple;
 import org.hibernate.ogm.model.spi.Tuple.SnapshotType;
-import org.neo4j.driver.v1.Transaction;
-import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.types.Node;
 
 /**
  * Iterates over the result of a native query when each result is a neo4j node. This is the case when the result of
@@ -81,7 +81,7 @@ public class BoltNeo4jNodesTupleIterator implements ClosableIterator<Tuple> {
 		try {
 			entities.close();
 			if ( closeTransaction ) {
-				tx.success();
+				tx.commit();
 			}
 		}
 		finally {

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jTupleSnapshot.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/BoltNeo4jTupleSnapshot.java
@@ -17,7 +17,7 @@ import org.hibernate.ogm.dialect.spi.TupleTypeContext;
 import org.hibernate.ogm.model.key.spi.AssociatedEntityKeyMetadata;
 import org.hibernate.ogm.model.key.spi.EntityKeyMetadata;
 import org.hibernate.ogm.model.spi.TupleSnapshot;
-import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.types.Node;
 
 /**
  * Represents the Tuple snapshot as loaded by the Neo4j datastore.

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/NodeWithEmbeddedNodes.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/dialect/impl/NodeWithEmbeddedNodes.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.types.Node;
 
 /**
  * An entity node and all the embedded values associated to it.

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jClient.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jClient.java
@@ -13,11 +13,11 @@ import org.hibernate.ogm.datastore.neo4j.logging.impl.LoggerFactory;
 import org.hibernate.ogm.datastore.neo4j.remote.common.impl.RemoteNeo4jConfiguration;
 import org.hibernate.ogm.datastore.neo4j.remote.common.impl.RemoteNeo4jDatabaseIdentifier;
 
-import org.neo4j.driver.v1.AuthToken;
-import org.neo4j.driver.v1.AuthTokens;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.driver.v1.exceptions.Neo4jException;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.exceptions.Neo4jException;
 
 /**
  * Provides access to Neo4j Bolt native {@link Driver}

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jDatastoreProvider.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/impl/BoltNeo4jDatastoreProvider.java
@@ -25,7 +25,7 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.Startable;
 import org.hibernate.service.spi.Stoppable;
 
-import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.Driver;
 
 /**
  * @author Davide D'Alto

--- a/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/transaction/impl/BoltNeo4jJtaTransactionCoordinator.java
+++ b/neo4j/src/main/java/org/hibernate/ogm/datastore/neo4j/remote/bolt/transaction/impl/BoltNeo4jJtaTransactionCoordinator.java
@@ -15,9 +15,9 @@ import org.hibernate.ogm.datastore.neo4j.transaction.impl.Neo4jSynchronization;
 import org.hibernate.ogm.datastore.neo4j.transaction.impl.RemoteTransactionDriver;
 import org.hibernate.ogm.transaction.impl.ForwardingTransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
 
 /**
  * A {@link TransactionCoordinator} for a remote Neo4j.
@@ -79,7 +79,7 @@ public class BoltNeo4jJtaTransactionCoordinator extends ForwardingTransactionCoo
 	public void success() {
 		if ( tx != null ) {
 			try {
-				tx.success();
+				tx.commit();
 				tx.close();
 			}
 			finally {
@@ -93,7 +93,7 @@ public class BoltNeo4jJtaTransactionCoordinator extends ForwardingTransactionCoo
 	public void failure() {
 		if ( tx != null ) {
 			try {
-				tx.failure();
+				tx.rollback();
 				tx.close();
 			}
 			finally {


### PR DESCRIPTION
This is a draft what is necessary of a more or less mechanical update.

Please see the prose here https://hibernate.atlassian.net/browse/OGM-1581

Open issues (at least)

* Parameter name syntax: `{name}` is no longer available in Neo4j 4.x, instead `$name` must be used
* The index tests fails: Syntax of what's being returned from the server as information about indexes changed quite a lot
* Probably session / result usages at some areas, such as in the test helper. The drivers session is now much more opinionated about accessing the result set after the session has been closed

This is not in hurry at all and I just like to leave this as a thing to discuss.