### PR TITLE
OGM-1589: Add hibernate-ogm metadata to MongoClient construction

### DIFF
--- a/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBDatastoreProvider.java
+++ b/mongodb/src/main/java/org/hibernate/ogm/datastore/mongodb/impl/MongoDBDatastoreProvider.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCursor;
@@ -20,6 +21,7 @@ import com.mongodb.client.MongoDatabase;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.engine.jndi.spi.JndiService;
+import org.hibernate.ogm.cfg.impl.Version;
 import org.hibernate.ogm.cfg.spi.Hosts;
 import org.hibernate.ogm.datastore.mongodb.MongoDBDialect;
 import org.hibernate.ogm.datastore.mongodb.binarystorage.GridFSStorageManager;
@@ -160,7 +162,11 @@ public class MongoDBDatastoreProvider extends BaseDatastoreProvider implements S
 			for ( Hosts.HostAndPort hostAndPort : config.getHosts() ) {
 				serverAddresses.add( new ServerAddress( hostAndPort.getHost(), hostAndPort.getPort() ) );
 			}
-			return new MongoClient( serverAddresses, credential, clientOptions );
+			return new MongoClient( serverAddresses, credential, clientOptions,
+					MongoDriverInformation.builder()
+							.driverName( "hibernate-ogm" )
+							.driverVersion( Version.getVersionString() )
+							.build() );
 		}
 		catch (RuntimeException e) {
 			throw log.unableToInitializeMongoDB( e );


### PR DESCRIPTION
This change allows users to track which connections are coming from hibernate-ogm by examining the MongoDB server logs, by looking for log statements like this:

```
{
  "t": {
    "$date": "2024-09-05T11:52:33.248-04:00"
  },
  "s": "D2",
  "c": "COMMAND",
  "id": 21965,
  "ctx": "conn304",
  "commandArgs": {
    "isMaster": 1,
    "helloOk": true,
    "client": {
      "driver": {
        "name": "mongo-java-driver|legacy|hibernate-ogm",
        "version": "4.11.3|5.4.2"
      },
      "os": {
        "type": "Darwin",
        "name": "Mac OS X",
        "architecture": "x86_64",
        "version": "14.6.1"
      },
      "platform": "Java/Amazon.com Inc./1.8.0_422-b05"
    },
    "$db": "admin"
  }
}
```

Note the driver name and version refer to both the underlying MongoDB Java driver and hibernate-ogm.

https://hibernate.atlassian.net/browse/OGM-1589
