### PR TITLE
Fix rendering of the migration guide

### DIFF
--- a/documentation/manual/src/main/asciidoc/index.asciidoc
+++ b/documentation/manual/src/main/asciidoc/index.asciidoc
@@ -18,6 +18,8 @@ include::modules/how-to-contribute.asciidoc[]
 
 include::modules/getting-started.asciidoc[]
 
+include::modules/migrating.asciidoc[]
+
 include::modules/architecture.asciidoc[]
 
 include::modules/configuration.asciidoc[]

--- a/documentation/manual/src/main/asciidoc/modules/migrating.asciidoc
+++ b/documentation/manual/src/main/asciidoc/modules/migrating.asciidoc
@@ -1,6 +1,6 @@
-[[ogm-migration]]
+[[ogm-migrating]]
 
-== 5.4.2.Final
+== Migrating from 5.4.1.Final
 
 === MongoDB
 
@@ -23,8 +23,7 @@ Recent versions of the MongoDB server have removed support for some features on 
 All other Hibernate OGM tests of MongoDB support are passing with MongoDB 3.6, up through the latest release of MongoDB
 (currently MongoDB 8.0).
 
-== Older versions
+=== Older versions
 
 The migration guide for the previous versions of Hibernate OGM is available on the
 https://developer.jboss.org/docs/DOC-52281[JBoss Community Archive] website.
-


### PR DESCRIPTION
Fix [OGM-1592](https://hibernate.atlassian.net/browse/OGM-1592)

It wasn't actually generated

Keeping it as part of the documentation because
the ascidoctor plugin seems to ignore it otherwise and
I don't want to spend more time on it.

Probably, we would need to upgrade the plugin.

[OGM-1592]: https://hibernate.atlassian.net/browse/OGM-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ