### PR TITLE
Use specific Jenkins nodes for releases

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 
 pipeline {
 	agent {
-		label 'Worker&&Containers'
+		label 'Release'
 	}
 	tools {
 		maven 'Apache Maven 3.9'


### PR DESCRIPTION
This should be safer as these nodes are only used once.
